### PR TITLE
cosmos-tx crate

### DIFF
--- a/.github/workflows/cosmos-sdk-proto.yml
+++ b/.github/workflows/cosmos-sdk-proto.yml
@@ -1,0 +1,25 @@
+name: cosmos-sdk-proto
+
+on:
+  push:
+    branches: main
+  pull_request:
+    paths:
+      - "cosmos-sdk-proto/**"
+      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: cosmos-sdk-proto
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/.github/workflows/cosmos-tx.yml
+++ b/.github/workflows/cosmos-tx.yml
@@ -1,0 +1,36 @@
+name: cosmos-tx
+
+on:
+  push:
+    branches: main
+  pull_request:
+    paths:
+      - "cosmos-sdk-proto/**"
+      - "cosmos-tx/**"
+      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: cosmos-tx
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.48.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo build --release
+      - run: cargo test --release

--- a/.github/workflows/proto-build.yml
+++ b/.github/workflows/proto-build.yml
@@ -1,0 +1,25 @@
+name: proto-build
+
+on:
+  push:
+    branches: main
+  pull_request:
+    paths:
+      - "proto-build/**"
+      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: proto-build
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Workspace
 
 on:
   push:
@@ -14,13 +14,6 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: cargo build --all --verbose
-      - run: cargo test --all --verbose
-
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f31e8ecbfc556990ae313b64aedaa11d901616af2a886e8caf57883caa43f0"
+
+[[package]]
 name = "cosmos-sdk-proto"
 version = "0.1.2"
 dependencies = [
@@ -151,10 +183,159 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmos-tx"
+version = "0.1.0"
+dependencies = [
+ "cosmos-sdk-proto",
+ "ecdsa 0.8.5",
+ "eyre",
+ "k256",
+ "prost",
+ "prost-types",
+ "rust_decimal",
+ "tendermint",
+ "thiserror",
+]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
+dependencies = [
+ "elliptic-curve 0.6.6",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f488ad19df443921d9fa5b9ce13a282b552709c511d2d90b1fd635e0204d74d5"
+dependencies = [
+ "elliptic-curve 0.7.1",
+ "hmac",
+ "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+dependencies = [
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
+dependencies = [
+ "digest",
+ "generic-array",
+ "rand_core 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d02ac72d4e61713e291a2ae644c1bd82be82c21b9a0de2271e0aa6886b7e0b4"
+dependencies = [
+ "bitvec",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core 0.5.1",
+ "subtle",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -201,12 +382,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+
+[[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -214,6 +417,35 @@ name = "futures-core"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -226,6 +458,9 @@ name = "futures-task"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
@@ -233,10 +468,28 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project 1.0.2",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -272,6 +525,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core 0.5.1",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -375,6 +649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +695,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "k256"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aebc14f2c1f2c5fd414f878084102b9ccb100fd90706e35979cd70a32f5d938"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa 0.9.0",
+ "elliptic-curve 0.7.1",
+ "sha2",
 ]
 
 [[package]]
@@ -595,6 +887,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6529960a627342f19f68d43a07b268c98fd347e68668df3743a3cb9211c0975f"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +1011,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -780,6 +1105,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
 name = "rand"
@@ -885,10 +1216,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -929,6 +1276,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+dependencies = [
+ "digest",
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+
+[[package]]
 name = "subtle-encoding"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1361,18 @@ checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -988,6 +1398,37 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.17.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469c73d90e4f6ae15f68e2475db9e7cd3ebcf71321d30910acefa92b83c70804"
+dependencies = [
+ "anomaly",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "ed25519",
+ "ed25519-dalek",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "thiserror",
+ "toml",
+ "zeroize",
 ]
 
 [[package]]
@@ -1084,6 +1525,15 @@ dependencies = [
  "log",
  "pin-project-lite 0.1.11",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1356,6 +1806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1858,12 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "walkdir"
@@ -1499,7 +1961,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
 name = "zeroize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "proto-build",
     "cosmos-sdk-proto",
+    "cosmos-tx"
 ]

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -4,7 +4,7 @@
 [![Docs][docs-image]][docs-link]
 [![Build Status][build-image]][build-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
-![Rust 1.39+][rustc-image]
+![MSRV][rustc-image]
 
 Rust crate for interacting with Cosmos SDK
 [Protobuf structs](https://github.com/cosmos/cosmos-sdk/tree/master/proto/).
@@ -17,7 +17,7 @@ total structs exported by proto files. Pull requests to expand coverage are welc
 
 ## Requirements
 
-- Rust 1.39+
+- Rust 1.48+
 - Cosmos SDK (downloaded automatically)
 
 [//]: # "badges"
@@ -29,6 +29,6 @@ total structs exported by proto files. Pull requests to expand coverage are welc
 [build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow%3ARust
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg
 [//]: # "general links"
 [cosmos sdk]: https://github.com/cosmos/cosmos-sdk

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cosmos-tx"
+version = "0.1.0"
+authors = ["Tony Arcieri <tony@iqlusion.io>"]
+edition = "2018"
+license = "Apache-2.0"
+repository = "https://github.com/cosmos/cosmos-rust/tree/master/cosmos-tx"
+description = "Transaction builder and signer for Cosmos-based blockchains"
+readme     = "README.md"
+categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
+keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
+
+[dependencies]
+cosmos-sdk-proto = { version = "0.1", path = "../cosmos-sdk-proto" }
+ecdsa = { version = "0.8", features = ["std"] }
+eyre = "0.6"
+k256 = { version = "0.6", features = ["ecdsa", "sha256"] }
+prost = "0.6"
+prost-types = "0.6"
+rust_decimal = "1.7"
+tendermint = "=0.17.0-rc3"
+thiserror = "1"

--- a/cosmos-tx/README.md
+++ b/cosmos-tx/README.md
@@ -1,0 +1,26 @@
+# cosmos-tx
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+[![Apache 2.0 Licensed][license-image]][license-link]
+![MSRV][rustc-image]
+
+Transaction builder and signer for Cosmos-based blockchains.
+
+[Documentation][docs-link]
+
+## Requirements
+
+- Rust 1.48+
+
+[//]: # "badges"
+[crate-image]: https://img.shields.io/crates/v/cosmos-tx.svg
+[crate-link]: https://crates.io/crates/cosmos-tx
+[docs-image]: https://docs.rs/cosmos-tx/badge.svg
+[docs-link]: https://docs.rs/cosmos-tx/
+[build-image]: https://github.com/cosmos/cosmos-rust/workflows/Rust/badge.svg
+[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow%3ARust
+[license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
+[license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg

--- a/cosmos-tx/src/builder.rs
+++ b/cosmos-tx/src/builder.rs
@@ -1,0 +1,128 @@
+//! Protocol Buffer-encoded transaction builder
+
+// Includes code originally from ibc-rs:
+// <https://github.com/informalsystems/ibc-rs>
+// Copyright © 2020 Informal Systems Inc.
+// Licensed under the Apache 2.0 license
+
+use super::msg::Msg;
+use crate::{Signature, VerifyingKey};
+use cosmos_sdk_proto::cosmos::tx::v1beta1::{
+    mode_info, AuthInfo, Fee, ModeInfo, SignDoc, SignerInfo, TxBody, TxRaw,
+};
+use ecdsa::signature::Signer;
+use eyre::Result;
+use tendermint::{block, chain};
+
+/// Protocol Buffer-encoded transaction builder
+pub struct Builder {
+    /// Chain ID
+    chain_id: chain::Id,
+
+    /// Account number to include in transactions
+    account_number: u64,
+}
+
+impl Builder {
+    /// Create a new transaction builder
+    pub fn new(chain_id: impl Into<chain::Id>, account_number: u64) -> Self {
+        Self {
+            chain_id: chain_id.into(),
+            account_number,
+        }
+    }
+
+    /// Borrow this transaction builder's chain ID
+    pub fn chain_id(&self) -> &chain::Id {
+        &self.chain_id
+    }
+
+    /// Get this transaction builder's account number
+    pub fn account_number(&self) -> u64 {
+        self.account_number
+    }
+
+    /// Build and sign a transaction containing the given messages
+    pub fn sign_tx<S>(
+        &self,
+        signer: &S,
+        sequence: u64,
+        messages: &[Msg],
+        fee: Fee,
+        memo: impl Into<String>,
+        timeout_height: block::Height,
+    ) -> Result<Vec<u8>>
+    where
+        S: Signer<Signature>,
+        VerifyingKey: for<'a> From<&'a S>,
+    {
+        // Create TxBody
+        let body = TxBody {
+            messages: messages.iter().map(|msg| msg.0.clone()).collect(),
+            memo: memo.into(),
+            timeout_height: timeout_height.into(),
+            extension_options: Default::default(),
+            non_critical_extension_options: Default::default(),
+        };
+
+        // A protobuf serialization of a TxBody
+        let mut body_buf = Vec::new();
+        prost::Message::encode(&body, &mut body_buf).unwrap();
+
+        let pk = VerifyingKey::from(signer);
+        let mut pk_buf = Vec::new();
+        prost::Message::encode(&pk.to_bytes().to_vec(), &mut pk_buf).unwrap();
+
+        // TODO(tarcieri): extract proper key type
+        let pk_any = prost_types::Any {
+            type_url: "/cosmos.crypto.secp256k1.PubKey".to_string(),
+            value: Vec::from(&pk.to_bytes()[..]),
+        };
+
+        let single = mode_info::Single { mode: 1 };
+
+        let mode = Some(ModeInfo {
+            sum: Some(mode_info::Sum::Single(single)),
+        });
+
+        let signer_info = SignerInfo {
+            public_key: Some(pk_any),
+            mode_info: mode,
+            sequence,
+        };
+
+        let auth_info = AuthInfo {
+            signer_infos: vec![signer_info],
+            fee: Some(fee),
+        };
+
+        // Protobuf serialization of `AuthInfo`
+        let mut auth_buf = Vec::new();
+        prost::Message::encode(&auth_info, &mut auth_buf)?;
+
+        let sign_doc = SignDoc {
+            body_bytes: body_buf.clone(),
+            auth_info_bytes: auth_buf.clone(),
+            chain_id: self.chain_id.to_string(),
+            account_number: self.account_number,
+        };
+
+        // Protobuf serialization of `SignDoc`
+        let mut signdoc_buf = Vec::new();
+        prost::Message::encode(&sign_doc, &mut signdoc_buf)?;
+
+        // Sign the signdoc
+        let signed = signer.sign(&signdoc_buf);
+
+        let tx_raw = TxRaw {
+            body_bytes: body_buf,
+            auth_info_bytes: auth_buf,
+            signatures: vec![signed.as_ref().to_vec()],
+        };
+
+        let mut txraw_buf = Vec::new();
+        prost::Message::encode(&tx_raw, &mut txraw_buf)?;
+
+        Ok(txraw_buf)
+    }
+}

--- a/cosmos-tx/src/decimal.rs
+++ b/cosmos-tx/src/decimal.rs
@@ -1,5 +1,4 @@
-//! Decimal type providing equivalent semantics to the [cosmos-sdk `Dec`][1]
-//! type.
+//! Decimal type with equivalent semantics to the [Cosmos `sdk.Dec`][1] type.
 //!
 //! [1]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types#Dec
 
@@ -11,14 +10,14 @@ use std::{
     str::FromStr,
 };
 
-/// Number of decimal places required
+/// Number of decimal places required by an `sdk.Dec`
 /// See: <https://github.com/cosmos/cosmos-sdk/blob/018915b/types/decimal.go#L23>
 pub const PRECISION: u32 = 18;
 
 /// Maximum value of the decimal part of an `sdk.Dec`
 pub const FRACTIONAL_DIGITS_MAX: u64 = 9_999_999_999_999_999_999;
 
-/// Decimal type which follows Cosmos [cosmos-sdk `Dec`][1] conventions.
+/// Decimal type which follows Cosmos [Cosmos `sdk.Dec`][1] conventions.
 ///
 /// [1]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types#Dec
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]

--- a/cosmos-tx/src/decimal.rs
+++ b/cosmos-tx/src/decimal.rs
@@ -1,0 +1,119 @@
+//! Decimal type providing equivalent semantics to the [cosmos-sdk `Dec`][1]
+//! type.
+//!
+//! [1]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types#Dec
+
+use crate::Error;
+use eyre::{Result, WrapErr};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
+
+/// Number of decimal places required
+/// See: <https://github.com/cosmos/cosmos-sdk/blob/018915b/types/decimal.go#L23>
+pub const PRECISION: u32 = 18;
+
+/// Maximum value of the decimal part of an `sdk.Dec`
+pub const FRACTIONAL_DIGITS_MAX: u64 = 9_999_999_999_999_999_999;
+
+/// Decimal type which follows Cosmos [cosmos-sdk `Dec`][1] conventions.
+///
+/// [1]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types#Dec
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Decimal(rust_decimal::Decimal);
+
+impl Decimal {
+    /// Create a new [`Decimal`] with the given whole number and decimal
+    /// parts. The decimal part assumes 18 digits of precision e.g. a
+    /// decimal with `(1, 1)` is `1.000000000000000001`.
+    ///
+    /// 18 digits required by the Cosmos SDK. See:
+    /// See: <https://github.com/cosmos/cosmos-sdk/blob/26d6e49/types/decimal.go#L23>
+    pub fn new(integral_digits: i64, fractional_digits: u64) -> Result<Self> {
+        if fractional_digits > FRACTIONAL_DIGITS_MAX {
+            return Err(Error::Decimal).wrap_err_with(|| {
+                format!(
+                    "fractional digits exceed available precision: {}",
+                    fractional_digits
+                )
+            });
+        }
+
+        let integral_digits: rust_decimal::Decimal = integral_digits.into();
+        let fractional_digits: rust_decimal::Decimal = fractional_digits.into();
+        let precision_exp: rust_decimal::Decimal = 10u64.pow(PRECISION).into();
+
+        let mut combined_decimal = (integral_digits * precision_exp) + fractional_digits;
+        combined_decimal.set_scale(PRECISION)?;
+        Ok(Decimal(combined_decimal))
+    }
+}
+
+impl Debug for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl Display for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Decimal {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        s.parse::<rust_decimal::Decimal>()?.try_into()
+    }
+}
+
+impl TryFrom<rust_decimal::Decimal> for Decimal {
+    type Error = eyre::Report;
+
+    fn try_from(mut decimal_value: rust_decimal::Decimal) -> Result<Self> {
+        match decimal_value.scale() {
+            0 => {
+                let exp: rust_decimal::Decimal = 10u64.pow(PRECISION).into();
+                decimal_value *= exp;
+                decimal_value.set_scale(PRECISION)?;
+            }
+            PRECISION => (),
+            other => {
+                return Err(Error::Decimal).wrap_err_with(|| {
+                    format!("invalid decimal precision: {} (must be 0 or 18)", other)
+                })
+            }
+        }
+
+        Ok(Decimal(decimal_value))
+    }
+}
+
+macro_rules! impl_from_primitive_int_for_decimal {
+    ($($int:ty),+) => {
+        $(impl From<$int> for Decimal {
+            fn from(num: $int) -> Decimal {
+                #[allow(trivial_numeric_casts)]
+                Decimal::new(num as i64, 0).unwrap()
+            }
+        })+
+    };
+}
+
+impl_from_primitive_int_for_decimal!(i8, i16, i32, i64, isize);
+impl_from_primitive_int_for_decimal!(u8, u16, u32, u64, usize);
+
+#[cfg(test)]
+mod tests {
+    use super::Decimal;
+
+    #[test]
+    fn string_serialization_test() {
+        let num = Decimal::from(-1i8);
+        assert_eq!(num.to_string(), "-1.000000000000000000")
+    }
+}

--- a/cosmos-tx/src/error.rs
+++ b/cosmos-tx/src/error.rs
@@ -1,0 +1,13 @@
+//! Error types
+
+pub use eyre::{Report, Result};
+
+use thiserror::Error;
+
+/// Kinds of errors
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
+pub enum Error {
+    /// Invalid decimal value
+    #[error("invalid decimal value")]
+    Decimal,
+}

--- a/cosmos-tx/src/lib.rs
+++ b/cosmos-tx/src/lib.rs
@@ -1,0 +1,15 @@
+//! Transaction builder and signer for Cosmos-based blockchains
+
+#![forbid(unsafe_code)]
+#![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+
+pub mod builder;
+pub mod decimal;
+pub mod error;
+pub mod msg;
+
+pub use crate::{builder::Builder, decimal::Decimal, error::Error};
+pub use k256::ecdsa::{Signature, VerifyingKey};
+
+/// Transaction signer for ECDSA/secp256k1 signatures
+pub type Signer = dyn ecdsa::signature::Signer<Signature>;

--- a/cosmos-tx/src/msg.rs
+++ b/cosmos-tx/src/msg.rs
@@ -1,0 +1,28 @@
+//! Transaction messages
+
+use prost_types::Any;
+
+/// Transaction messages
+pub struct Msg(pub(crate) Any);
+
+impl Msg {
+    /// Create a new message type
+    pub fn new(type_url: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
+        Msg(Any {
+            type_url: type_url.into(),
+            value: value.into(),
+        })
+    }
+}
+
+impl From<Any> for Msg {
+    fn from(any: Any) -> Msg {
+        Msg(any)
+    }
+}
+
+impl From<Msg> for Any {
+    fn from(msg: Msg) -> Any {
+        msg.0
+    }
+}


### PR DESCRIPTION
Adds a `cosmos-tx` crate which provides a transaction builder and signer for Cosmos-based blockchains.

This commit ports over the WIP protobuf support from:

https://github.com/iqlusioninc/crates/tree/develop/stdtx