### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Automatically opens PRs to update out-of-date dependencies:

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/configuring-dependabot-security-updates