### PR TITLE
proto-build: set `publish = false` in Cargo.toml

### DIFF
--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -3,6 +3,7 @@ name = "proto-build"
 version = "0.1.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
+publish = false
 
 
 [dependencies]


### PR DESCRIPTION
Prevents accidental publication to crates.io