### PR TITLE
Fix GitHub Actions badges

### DIFF
--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -25,8 +25,8 @@ total structs exported by proto files. Pull requests to expand coverage are welc
 [crate-link]: https://crates.io/crates/cosmos-rust
 [docs-image]: https://docs.rs/cosmos-rust/badge.svg
 [docs-link]: https://docs.rs/cosmos-rust/
-[build-image]: https://github.com/cosmos/cosmos-rust/workflows/Rust/badge.svg
-[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow%3ARust
+[build-image]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg
+[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow:cosmos-sdk-proto
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg

--- a/cosmos-tx/README.md
+++ b/cosmos-tx/README.md
@@ -19,8 +19,8 @@ Transaction builder and signer for Cosmos-based blockchains.
 [crate-link]: https://crates.io/crates/cosmos-tx
 [docs-image]: https://docs.rs/cosmos-tx/badge.svg
 [docs-link]: https://docs.rs/cosmos-tx/
-[build-image]: https://github.com/cosmos/cosmos-rust/workflows/Rust/badge.svg
-[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow%3ARust
+[build-image]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-tx/badge.svg
+[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow:cosmos-tx
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg


### PR DESCRIPTION
The "Rust" workflow was split into separate workflows-per-crate in #6.

However, the badges in the README.md files were not updated. This commit updates them to point to the new workflows.