### PR TITLE
Add Confio to the cosmos-rust governing team

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a place for commonly shared rust resources related to the Cosmos ecosyst
 
 The goal of this repository is to create a place for upstream consensus in the Cosmos Rust community. Different applications will have different requirements from libraries, this repo should strive to contain only code that is useful and actively used by more than one organization.
 
-Current maintainers of this repo include [InformalSystems](https://github.com/informalsystems), [Iqlusion](https://github.com/iqlusioninc), and [Althea](https://github.com/althea-net)
+Current maintainers of this repo include [InformalSystems](https://github.com/informalsystems), [Iqlusion](https://github.com/iqlusioninc), [Confio](https://github.com/confio), and [Althea](https://github.com/althea-net)
 
 A pull request should be approved by representatives from at least two of those organizations
 before being merged. In order to update membership or update these rules a pull request changing


### PR DESCRIPTION
This is our first governance vote for expanding the maintaining team. I would like to invite Confio to the governance process of this repo.

This includes having one member on the Crates.io maintainer list of cosmos-sdk-proto (and future crates published from this repo) as well
as being added to this list of teams capable of seconding a change before merge (as outlined in the readme) and given push access to make
branches.