### PR TITLE
Bump tendermint-rs + tendermint-proto to v0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f31e8ecbfc556990ae313b64aedaa11d901616af2a886e8caf57883caa43f0"
+checksum = "069b46dab00267d018567b1154f38b706d6ed93c4915301a2fa73bc24a03a1e7"
 
 [[package]]
 name = "cosmos-sdk-proto"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f488ad19df443921d9fa5b9ce13a282b552709c511d2d90b1fd635e0204d74d5"
+checksum = "d39be153f0e278ffba17d1c05e8999641fcf3df7584a7251b5e660742fcab1ef"
 dependencies = [
  "elliptic-curve",
  "hmac",
@@ -275,9 +275,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d02ac72d4e61713e291a2ae644c1bd82be82c21b9a0de2271e0aa6886b7e0b4"
+checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
 dependencies = [
  "bitvec",
  "digest",
@@ -628,9 +628,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aebc14f2c1f2c5fd414f878084102b9ccb100fd90706e35979cd70a32f5d938"
+checksum = "e443f962f64bcd3753b09e9d6c3733986a81e49b2a36c3c2faaedbe2c3a8e7dd"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
@@ -857,9 +857,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.1.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6529960a627342f19f68d43a07b268c98fd347e68668df3743a3cb9211c0975f"
+checksum = "9911ed9965aeee333588f226ad2baeabda478bf5ec151550735ed1760df759ba"
 dependencies = [
  "const-oid",
 ]
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469c73d90e4f6ae15f68e2475db9e7cd3ebcf71321d30910acefa92b83c70804"
+checksum = "b700d694c42ed7ed61f4d66f742820fc0b903877893d0b095ee1c80eeb5474e8"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e38abad428d9414b61b20a252441a04dff48daf68e9562352f10201df5a3cb6"
+checksum = "4a8d65c9235cbb53d87c4b4d9d1c139fbc0b0f585d92643cd625c71c9975ccd1"
 dependencies = [
  "anomaly",
  "bytes",

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -18,7 +18,7 @@ prost-types = "0.6"
 tonic = { version = "0.3.1", optional = true }
 
 [dependencies.tendermint-proto]
-version = "=0.17.0-rc3"
+version = "0.17"
 
 [features]
 default = ["grpc"]

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -12,11 +12,11 @@ keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
 cosmos-sdk-proto = { version = "0.1", default-features = false, path = "../cosmos-sdk-proto" }
-ecdsa = { version = "0.9", features = ["std"] }
+ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
-k256 = { version = "0.6", features = ["ecdsa", "sha256"] }
+k256 = { version = "0.7", features = ["ecdsa", "sha256"] }
 prost = "0.6"
 prost-types = "0.6"
 rust_decimal = "1.7"
-tendermint = "=0.17.0-rc3"
+tendermint = "0.17"
 thiserror = "1"


### PR DESCRIPTION
Updates prerelease versions of these crates to the final releases.

## Changelog

https://github.com/informalsystems/tendermint-rs/blob/master/CHANGELOG.md#v0170