### PR TITLE
Rename `cosmos-sdk` to `cosmos-sdk-go`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cosmos-sdk"]
-	path = cosmos-sdk
+	path = cosmos-sdk-go
 	url = https://github.com/cosmos/cosmos-sdk.git

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -22,7 +22,7 @@ const COSMOS_REV: &str = "v0.40.0-rc3";
 /// The directory generated proto files go into in this repo
 const COSMOS_SDK_PROTO_DIR: &str = "../cosmos-sdk-proto/src/prost/";
 /// Directory where the submodule is located
-const COSMOS_SDK_DIR: &str = "../cosmos-sdk";
+const COSMOS_SDK_DIR: &str = "../cosmos-sdk-go";
 /// A temporary directory for proto building
 const TMP_BUILD_DIR: &str = "/tmp/tmp-protobuf/";
 


### PR DESCRIPTION
After looking at the `cosmos-sdk/` submodule in my editor, I realized it's not exactly clear that this directory is the Go library rather than a `cosmos-sdk` crate (which would aspirationally be a cool thing to have)

This renames it so it's clear the directory contains the upstream Go SDK.