### PR TITLE
Release cosmos-sdk-proto v0.2.0 + cosmos-tx v0.2.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,9 @@
 #
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "async-stream"
@@ -164,13 +164,13 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069b46dab00267d018567b1154f38b706d6ed93c4915301a2fa73bc24a03a1e7"
+checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "cosmos-tx"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cosmos-sdk-proto",
  "ecdsa",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+checksum = "bb990906c94a51949a088cb5a4f9242164293c8fd21ec1d45147dd8301f4e6d6"
 dependencies = [
  "indenter",
  "once_cell",
@@ -356,9 +356,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -467,11 +467,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -521,9 +521,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
+checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
 
 [[package]]
 name = "indexmap"
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1213,9 +1213,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e0e9fd577458a4f61fb91fcb559ea2afecc54c934119421f9f5d3d5b1a1057"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 (2020-01-04)
+### Added
+- `grpc` crate feature ([#8])
+
+### Changed
+- Bump `cosmos-sdk` rev to v0.40.0-rc6 ([#32])
+- Bump `tendermint` + `tendermint-proto` crate dependencies to v0.17 ([#18])
+- Format `prost`/`tonic` output with `rustfmt` ([#17])
+
+[#8]: https://github.com/cosmos/cosmos-rust/pull/8
+[#17]: https://github.com/cosmos/cosmos-rust/pull/17
+[#18]: https://github.com/cosmos/cosmos-rust/pull/18
+[#32]: https://github.com/cosmos/cosmos-rust/pull/32
+
+## 0.1.2 (2020-11-30)
+
+## 0.1.1 (2020-11-30)
+- Initial release

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.1.2"
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Justin Kilpatrick <justin@althea.net>", "Greg Szabo <greg@informal.systems>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -6,29 +6,33 @@
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![MSRV][rustc-image]
 
-Rust crate for interacting with Cosmos SDK
-[Protobuf structs](https://github.com/cosmos/cosmos-sdk/tree/master/proto/).
+Rust crate for interacting with [Protobufs] defined by the [Cosmos SDK].
 
 The goal of this crate is to provide complete proto struct definitions for interacting
-with a CosmosSDK blockchain. Currently this crate only provides a minority of the many
-total structs exported by proto files. Pull requests to expand coverage are welcome.
+with a Cosmos SDK blockchain.
+
+Currently this crate only provides a minority of the many total structs exported by
+proto files.
+
+Pull requests to expand coverage are welcome.
 
 [Documentation][docs-link]
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust 1.48+
-- Cosmos SDK (downloaded automatically)
+Requires Rust **1.48** or newer.
 
 [//]: # "badges"
-[crate-image]: https://img.shields.io/crates/v/cosmos-rust.svg
-[crate-link]: https://crates.io/crates/cosmos-rust
-[docs-image]: https://docs.rs/cosmos-rust/badge.svg
-[docs-link]: https://docs.rs/cosmos-rust/
+[crate-image]: https://img.shields.io/crates/v/cosmos-sdk-proto.svg
+[crate-link]: https://crates.io/crates/cosmos-sdk-proto
+[docs-image]: https://docs.rs/cosmos-sdk-proto/badge.svg
+[docs-link]: https://docs.rs/cosmos-sdk-proto/
 [build-image]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg
 [build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow:cosmos-sdk-proto
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg
+
 [//]: # "general links"
-[cosmos sdk]: https://github.com/cosmos/cosmos-sdk
+[Protobufs]: (https://github.com/cosmos/cosmos-sdk/tree/master/proto/)
+[Cosmos SDK]: https://github.com/cosmos/cosmos-sdk

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -1,9 +1,11 @@
-//! cosmos-sdk-proto library gives the developer access to the Cosmos SDK proto-defined structs.
-//! These are then re-exported in a module structure as close as possible to the proto files. The
-//! version strings are intentionally excluded, that way users may specify cosmos-sdk versions as
-//! a feature argument to this crate and not have to change their imports. For as much as that is
+//! The `cosmos-sdk-proto` crate provides access to the Cosmos SDK proto-defined structs.
+//! These are then re-exported in a module structure as close as possible to the proto files.
+//!
+//! The version strings are intentionally excluded, that way users may specify `cosmos-sdk` versions
+//! as a feature argument to this crate and not have to change their imports. For as much as that is
 //! worth considering that modules seem to show up and go away with every RC.
-//! TODO actually implement features tag based compilation
+//!
+//! TODO: actually implement features tag based compilation
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
@@ -16,108 +18,150 @@
 /// The version (commit hash) of the Cosmos SDK used when generating this library.
 pub const COSMOS_SDK_VERSION: &str = include_str!("prost/COSMOS_SDK_COMMIT");
 
-/// Cosmos protobuf definitions
+/// Cosmos protobuf definitions.
 pub mod cosmos {
+    /// Authentication of accounts and transactions.
     pub mod auth {
         pub mod v1beta1 {
             include!("prost/cosmos.auth.v1beta1.rs");
         }
     }
+
+    /// Proof-of-Stake layer for public blockchains.
     pub mod staking {
         pub mod v1beta1 {
             include!("prost/cosmos.staking.v1beta1.rs");
         }
     }
+
+    /// Base functionality.
     pub mod base {
+        /// Application BlockChain Interface (ABCI).
+        ///
+        /// Interface that defines the boundary between the replication engine
+        /// (the blockchain), and the state machine (the application).
         pub mod abci {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.abci.v1beta1.rs");
             }
         }
+
+        /// Key-value pairs.
         pub mod kv {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.kv.v1beta1.rs");
             }
         }
+
+        /// Query support.
         pub mod query {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.query.v1beta1.rs");
             }
         }
+
+        /// Reflection support.
         pub mod reflection {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.reflection.v1beta1.rs");
             }
         }
+
+        /// Snapshots containing Tendermint state sync info.
         pub mod snapshots {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.snapshots.v1beta1.rs");
             }
         }
+
+        /// Data structure that holds the state of the application.
         pub mod store {
             pub mod v1beta1 {
                 include!("prost/cosmos.base.store.v1beta1.rs");
             }
         }
+
         pub mod v1beta1 {
             include!("prost/cosmos.base.v1beta1.rs");
         }
     }
+
+    /// Cryptographic primitives.
     pub mod crypto {
+        /// Multi-signature support.
         pub mod multisig {
             pub mod v1beta1 {
                 include!("prost/cosmos.crypto.multisig.v1beta1.rs");
             }
         }
     }
+
+    /// Transactions.
     pub mod tx {
+        /// Transaction signing support.
         pub mod signing {
             pub mod v1beta1 {
                 include!("prost/cosmos.tx.signing.v1beta1.rs");
             }
         }
+
         pub mod v1beta1 {
             include!("prost/cosmos.tx.v1beta1.rs");
         }
     }
 }
 
-/// IBC protobuf definitions
+/// IBC protobuf definitions.
 pub mod ibc {
+    /// IBC applications.
     pub mod applications {
+        /// Transfer support.
         pub mod transfer {
             pub mod v1 {
                 include!("prost/ibc.applications.transfer.v1.rs");
             }
         }
     }
+
+    /// IBC core.
     pub mod core {
+        /// IBC channels.
         pub mod channel {
             pub mod v1 {
                 include!("prost/ibc.core.channel.v1.rs");
             }
         }
+
+        /// IBC client.
         pub mod client {
             pub mod v1 {
                 include!("prost/ibc.core.client.v1.rs");
             }
         }
+
+        /// IBC commitments.
         pub mod commitment {
             pub mod v1 {
                 include!("prost/ibc.core.commitment.v1.rs");
             }
         }
+
+        /// IBC connections.
         pub mod connection {
             pub mod v1 {
                 include!("prost/ibc.core.connection.v1.rs");
             }
         }
+
+        /// IBC types.
         pub mod types {
             pub mod v1 {
                 include!("prost/ibc.core.types.v1.rs");
             }
         }
     }
+
+    /// IBC light clients.
     pub mod lightclients {
         pub mod localhost {
             pub mod v1 {
@@ -137,7 +181,7 @@ pub mod ibc {
     }
 }
 
-/// ICS23 protobuf definitions
+/// ICS23 protobuf definitions.
 pub mod ics23 {
     include!("prost/ics23.rs");
 }

--- a/cosmos-tx/CHANGELOG.md
+++ b/cosmos-tx/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0-pre (2021-01-04)
+### Added
+- Initial transaction builder and signer ([#6])
+
+[#6]: https://github.com/cosmos/cosmos-rust/pull/6
+
+## 0.1.0 (2020-12-07)
+- Initial release

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-tx"
-version = "0.1.0"
+version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.1", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.2", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }

--- a/cosmos-tx/README.md
+++ b/cosmos-tx/README.md
@@ -6,13 +6,13 @@
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![MSRV][rustc-image]
 
-Transaction builder and signer for Cosmos-based blockchains.
+Transaction builder and signer for [Cosmos]-based blockchains.
 
 [Documentation][docs-link]
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust 1.48+
+Requires Rust **1.48** or newer.
 
 [//]: # "badges"
 [crate-image]: https://img.shields.io/crates/v/cosmos-tx.svg
@@ -24,3 +24,6 @@ Transaction builder and signer for Cosmos-based blockchains.
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg
+
+[//]: # "general links"
+[Cosmos]: https://cosmos.network/

--- a/cosmos-tx/src/lib.rs
+++ b/cosmos-tx/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.1.2"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.2.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
## `cosmos-sdk-proto` v0.2.0
### Added
- `grpc` crate feature ([#8])

### Changed
- Bump `cosmos-sdk` rev to [v0.40.0-rc6](https://github.com/cosmos/cosmos-sdk/pull/8249) ([#32])
- Bump `tendermint` + `tendermint-proto` crate dependencies to v0.17 ([#18])
- Format `prost`/`tonic` output with `rustfmt` ([#17])

[#8]: https://github.com/cosmos/cosmos-rust/pull/8
[#17]: https://github.com/cosmos/cosmos-rust/pull/17
[#18]: https://github.com/cosmos/cosmos-rust/pull/18
[#32]: https://github.com/cosmos/cosmos-rust/pull/32

## `cosmos-tx` v0.2.0-pre
### Added
- Initial transaction builder and signer ([#6]) 

[#6]: https://github.com/cosmos/cosmos-rust/pull/6