### PR TITLE
Run `proto-build` automatically with GitHub Actions

### DIFF
--- a/.github/workflows/rebuild-protos.yml
+++ b/.github/workflows/rebuild-protos.yml
@@ -1,0 +1,31 @@
+name: Rebuild Protos
+
+on:
+  push:
+    branches: main
+
+jobs:
+  proto-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0 # MSRV
+          components: rustfmt
+          override: true
+          profile: minimal
+      - name: Run proto-build
+        id: build
+        working-directory: proto-build
+        run: |
+          message=$(cargo run --quiet -- --github)
+          echo "::set-output name=commit_message::${message}"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3.5.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ${{ steps.assign.outputs.commit_message }}
+          title: ${{ steps.assign.outputs.commit_message }}
+          branch: rebuild-protos


### PR DESCRIPTION
Adds a `rebuild-protos` GitHub Actions workflow to automatically run `proto-build` every time a commit is merged/pushed to the `main` branch.

After running `rebuild-protos`, if there are any changed files, it uses the [peter-evans/create-pull-request](https://github.com/marketplace/actions/create-pull-request) GitHub Action to open a PR with those changes automatically, thus ensuring `cosmos-sdk-proto` is reproducible and automating the work of regenerating the protos so it can be kept out-of-band with other PRs.

If no files are changed, the workflow otherwise completes successfully.

Note that this is using a 3rd party GitHub Action, and exposing the repo's `GITHUB_TOKEN` to it. However, the action is pinned to the latest release (`peter-evans/create-pull-request@v3.5.2`) effectively making it trust-on-first-use (i.e. if future updates to the action introduce malware, we will not be affected unless we choose to bump versions. If however the malware is already there, we're vulnerable).

If we're really worried, we can do a quick audit of the code and/or fork the action, either of which might be wise.