### PR TITLE
proto-build: improve protoc errors

### DIFF
--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -128,7 +128,11 @@ fn compile_protos(out_dir: &Path) {
     let mut config = prost_build::Config::default();
     config.out_dir(out_dir);
     config.extern_path(".tendermint", "::tendermint_proto");
-    config.compile_protos(&protos, &includes).unwrap();
+
+    if let Err(e) = config.compile_protos(&protos, &includes) {
+        eprintln!("[error] couldn't compile protos: {}", e);
+        panic!("protoc failed!");
+    }
 }
 
 fn compile_proto_services(out_dir: impl AsRef<Path>) {
@@ -201,7 +205,7 @@ fn copy_generated_files(from_dir: &Path, to_dir: &Path) {
 
     if !errors.is_empty() {
         for e in errors {
-            println!("[error] Error while copying compiled file: {}", e);
+            eprintln!("[error] Error while copying compiled file: {}", e);
         }
 
         panic!("[error] Aborted.");


### PR DESCRIPTION
Prints a string-formatted error message to STDERR when protoc fails, instead of printing raw `Debug` output indirectly via `unwrap()` triggering Rust's built-in panic handler.

## Before

```
[info] Compiling .proto files to Rust into '/tmp/tmp-protobuf/'...
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "protoc failed: /Users/bascule/src/cosmos-rust/proto-build/../proto: warning: directory does not exist.\nibc/core/client/v1/tx.proto:8:1: warning: Import ibc/core/client/v1/client.proto is unused.\ncosmos/tx/v1beta1/service.proto:7:1: warning: Import gogoproto/gogo.proto is unused.\ncosmos/base/tendermint/v1beta1/query.proto:87:3: \"tendermint.types.BlockID\" is resolved to \"cosmos.base.tendermint.types.BlockID\", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading \'.\'(i.e., \".tendermint.types.BlockID\") to start from the outermost scope.\ncosmos/base/tendermint/v1beta1/query.proto:88:3: \"tendermint.types.Block\" is resolved to \"cosmos.base.tendermint.types.Block\", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading \'.\'(i.e., \".tendermint.types.Block\") to start from the outermost scope.\ncosmos/base/tendermint/v1beta1/query.proto:96:3: \"tendermint.types.BlockID\" is resolved to \"cosmos.base.tendermint.types.BlockID\", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading \'.\'(i.e., \".tendermint.types.BlockID\") to start from the outermost scope.\ncosmos/base/tendermint/v1beta1/query.proto:97:3: \"tendermint.types.Block\" is resolved to \"cosmos.base.tendermint.types.Block\", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading \'.\'(i.e., \".tendermint.types.Block\") to start from the outermost scope.\ncosmos/base/tendermint/v1beta1/query.proto:113:3: \"tendermint.p2p.DefaultNodeInfo\" is resolved to \"cosmos.base.tendermint.p2p.DefaultNodeInfo\", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading \'.\'(i.e., \".tendermint.p2p.DefaultNodeInfo\") to start from the outermost scope.\ncosmos/base/tendermint/v1beta1/query.proto:6:1: warning: Import google/api/annotations.proto is unused.\ncosmos/base/tendermint/v1beta1/query.proto:4:1: warning: Import gogoproto/gogo.proto is unused.\ncosmos/base/tendermint/v1beta1/query.proto:9:1: warning: Import tendermint/types/types.proto is unused.\ncosmos/base/tendermint/v1beta1/query.proto:8:1: warning: Import tendermint/types/block.proto is unused.\ncosmos/base/tendermint/v1beta1/query.proto:7:1: warning: Import tendermint/p2p/types.proto is unused.\n" }', proto-build/src/main.rs:139:47
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## After

```
[info] Compiling .proto files to Rust into '/tmp/tmp-protobuf/'...
[error] couldn't compile protos: protoc failed: /Users/bascule/src/cosmos-rust/proto-build/../proto: warning: directory does not exist.
ibc/core/client/v1/tx.proto:8:1: warning: Import ibc/core/client/v1/client.proto is unused.
cosmos/tx/v1beta1/service.proto:7:1: warning: Import gogoproto/gogo.proto is unused.
cosmos/base/tendermint/v1beta1/query.proto:87:3: "tendermint.types.BlockID" is resolved to "cosmos.base.tendermint.types.BlockID", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.BlockID") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:88:3: "tendermint.types.Block" is resolved to "cosmos.base.tendermint.types.Block", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.Block") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:96:3: "tendermint.types.BlockID" is resolved to "cosmos.base.tendermint.types.BlockID", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.BlockID") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:97:3: "tendermint.types.Block" is resolved to "cosmos.base.tendermint.types.Block", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.Block") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:113:3: "tendermint.p2p.DefaultNodeInfo" is resolved to "cosmos.base.tendermint.p2p.DefaultNodeInfo", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.p2p.DefaultNodeInfo") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:4:1: warning: Import gogoproto/gogo.proto is unused.
cosmos/base/tendermint/v1beta1/query.proto:9:1: warning: Import tendermint/types/types.proto is unused.
cosmos/base/tendermint/v1beta1/query.proto:6:1: warning: Import google/api/annotations.proto is unused.
cosmos/base/tendermint/v1beta1/query.proto:8:1: warning: Import tendermint/types/block.proto is unused.
cosmos/base/tendermint/v1beta1/query.proto:7:1: warning: Import tendermint/p2p/types.proto is unused.

thread 'main' panicked at 'protoc failed!', proto-build/src/main.rs:142:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```