### PR TITLE
Bump `tendermint` crate dependency to v0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,15 +36,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -52,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -80,12 +86,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -94,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -126,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -137,10 +143,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "bytes"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"
@@ -159,7 +165,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -172,9 +178,9 @@ checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
 name = "cosmos-sdk-proto"
 version = "0.2.0"
 dependencies = [
- "prost",
- "prost-types",
- "tendermint-proto",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tendermint-proto 0.18.0",
  "tonic",
 ]
 
@@ -186,8 +192,8 @@ dependencies = [
  "ecdsa",
  "eyre",
  "k256",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
  "rust_decimal",
  "tendermint",
  "thiserror",
@@ -211,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
@@ -339,22 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,9 +352,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -377,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -387,15 +377,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -404,15 +394,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -422,24 +412,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -448,7 +438,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -471,9 +461,20 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -495,11 +496,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -540,22 +541,22 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
 ]
 
@@ -573,11 +574,11 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -587,7 +588,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -612,19 +613,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -637,24 +638,14 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e443f962f64bcd3753b09e9d6c3733986a81e49b2a36c3c2faaedbe2c3a8e7dd"
+checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "sha2",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -665,17 +656,17 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -696,33 +687,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -732,14 +715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
-name = "net2"
-version = "0.2.37"
+name = "ntapi"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -774,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
@@ -817,11 +798,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -837,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -848,15 +829,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -887,9 +862,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -906,24 +881,34 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes",
- "prost-derive",
+ "bytes 0.5.6",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.7.0",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "heck",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
  "tempfile",
  "which",
 ]
@@ -935,7 +920,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -947,15 +945,25 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes",
- "prost",
+ "bytes 0.5.6",
+ "prost 0.6.1",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.7.0",
 ]
 
 [[package]]
 name = "proto-build"
 version = "0.1.0"
 dependencies = [
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "regex",
  "tempdir",
@@ -989,7 +997,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -998,12 +1006,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1014,6 +1033,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1037,7 +1066,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1050,12 +1088,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1069,9 +1107,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -1097,15 +1138,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c739ba050709eae138f053356d27ff818d71fe54ce5a8d9f4c7a660bfb6684"
+checksum = "04d1fde955d206c00af1eb529d8ebfca3b505921820a0436566dbcc6c4d4ffb3"
 dependencies = [
+ "arrayvec",
  "num-traits",
  "serde",
 ]
@@ -1133,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
@@ -1151,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1184,12 +1226,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpuid-bool",
  "digest",
  "opaque-debug",
@@ -1217,9 +1259,9 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1239,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1272,35 +1314,35 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
- "rand 0.7.3",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tendermint"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700d694c42ed7ed61f4d66f742820fc0b903877893d0b095ee1c80eeb5474e8"
+checksum = "dece4b481502a8dc31696b7656b97dd73fba374112c22a9a9dae2dcae47231ac"
 dependencies = [
  "anomaly",
  "async-trait",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "ed25519",
  "ed25519-dalek",
  "futures",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1309,7 +1351,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.17.1",
  "thiserror",
  "toml",
  "zeroize",
@@ -1317,17 +1359,36 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d65c9235cbb53d87c4b4d9d1c139fbc0b0f585d92643cd625c71c9975ccd1"
+checksum = "1dc89e2c7de21f1abb9ae5bc7eb5570b10a3ec11ca0a7a009ec594b1d3b8c917"
 dependencies = [
  "anomaly",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "num-derive",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d54af90058f8df5bf6b9469f6988f49a80c169c3e450d702c1101432df60a6"
+dependencies = [
+ "anomaly",
+ "bytes 1.0.1",
+ "chrono",
+ "num-derive",
+ "num-traits",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -1356,52 +1417,71 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
  "memchr",
  "mio",
- "pin-project-lite 0.1.11",
- "slab",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1416,29 +1496,28 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
+checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
 dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
  "percent-encoding",
- "pin-project 0.4.27",
- "prost",
- "prost-derive",
+ "pin-project 1.0.4",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -1446,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
+checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -1458,181 +1537,34 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "5fd7b451959622e21de79261673d658a0944b835012c58c51878ea55957fb51a"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
- "rand 0.7.3",
+ "pin-project 1.0.4",
+ "rand 0.8.3",
  "slab",
  "tokio",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
+ "tokio-stream",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
-
-[[package]]
-name = "tower-limit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log",
- "pin-project 0.4.27",
- "tokio",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log",
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-service",
-]
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-
-[[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.27",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.27",
- "tower-service",
-]
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -1640,9 +1572,9 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -1714,7 +1646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -1736,24 +1668,19 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
  "libc",
+ "thiserror",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -1764,12 +1691,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1783,7 +1704,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1791,16 +1712,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "wyz"

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -11,14 +11,14 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords   = ["blockchain", "cosmos", "tendermint", "proto"]
 
 [dependencies]
-prost = "0.6"
-prost-types = "0.6"
+prost = "0.7"
+prost-types = "0.7"
 
 # Optional dependencies
-tonic = { version = "0.3.1", optional = true }
+tonic = { version = "0.4", optional = true }
 
 [dependencies.tendermint-proto]
-version = "0.17"
+version = "0.18"
 
 [features]
 default = ["grpc"]

--- a/cosmos-sdk-proto/src/prost/cosmos.auth.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.auth.v1beta1.rs
@@ -4,9 +4,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BaseAccount {
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub pub_key: ::std::option::Option<::prost_types::Any>,
+    pub pub_key: ::core::option::Option<::prost_types::Any>,
     #[prost(uint64, tag = "3")]
     pub account_number: u64,
     #[prost(uint64, tag = "4")]
@@ -16,11 +16,11 @@ pub struct BaseAccount {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleAccount {
     #[prost(message, optional, tag = "1")]
-    pub base_account: ::std::option::Option<BaseAccount>,
+    pub base_account: ::core::option::Option<BaseAccount>,
     #[prost(string, tag = "2")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     #[prost(string, repeated, tag = "3")]
-    pub permissions: ::std::vec::Vec<std::string::String>,
+    pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Params defines the parameters for the auth module.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -41,14 +41,14 @@ pub struct Params {
 pub struct QueryAccountRequest {
     /// address defines the address to query for.
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
 }
 /// QueryAccountResponse is the response type for the Query/Account RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryAccountResponse {
     /// account defines the account of the corresponding address.
     #[prost(message, optional, tag = "1")]
-    pub account: ::std::option::Option<::prost_types::Any>,
+    pub account: ::core::option::Option<::prost_types::Any>,
 }
 /// QueryParamsRequest is the request type for the Query/Params RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -58,7 +58,7 @@ pub struct QueryParamsRequest {}
 pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]

--- a/cosmos-sdk-proto/src/prost/cosmos.bank.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.bank.v1beta1.rs
@@ -2,7 +2,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
     #[prost(message, repeated, tag = "1")]
-    pub send_enabled: ::std::vec::Vec<SendEnabled>,
+    pub send_enabled: ::prost::alloc::vec::Vec<SendEnabled>,
     #[prost(bool, tag = "2")]
     pub default_send_enabled: bool,
 }
@@ -11,7 +11,7 @@ pub struct Params {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendEnabled {
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
     #[prost(bool, tag = "2")]
     pub enabled: bool,
 }
@@ -19,24 +19,24 @@ pub struct SendEnabled {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Input {
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub coins: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub coins: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
 /// Output models transaction outputs.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Output {
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub coins: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub coins: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
 /// Supply represents a struct that passively keeps track of the total supply
 /// amounts in the network.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Supply {
     #[prost(message, repeated, tag = "1")]
-    pub total: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub total: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
 /// DenomUnit represents a struct that describes a given
 /// denomination unit of the basic token.
@@ -44,7 +44,7 @@ pub struct Supply {
 pub struct DenomUnit {
     /// denom represents the string name of the given denom unit (e.g uatom).
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
     /// exponent represents power of 10 exponent that one must
     /// raise the base_denom to in order to equal the given DenomUnit's denom
     /// 1 denom = 1^exponent base_denom
@@ -54,51 +54,51 @@ pub struct DenomUnit {
     pub exponent: u32,
     /// aliases is a list of string aliases for the given denom
     #[prost(string, repeated, tag = "3")]
-    pub aliases: ::std::vec::Vec<std::string::String>,
+    pub aliases: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Metadata represents a struct that describes
 /// a basic token.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metadata {
     #[prost(string, tag = "1")]
-    pub description: std::string::String,
+    pub description: ::prost::alloc::string::String,
     /// denom_units represents the list of DenomUnit's for a given coin
     #[prost(message, repeated, tag = "2")]
-    pub denom_units: ::std::vec::Vec<DenomUnit>,
+    pub denom_units: ::prost::alloc::vec::Vec<DenomUnit>,
     /// base represents the base denom (should be the DenomUnit with exponent = 0).
     #[prost(string, tag = "3")]
-    pub base: std::string::String,
+    pub base: ::prost::alloc::string::String,
     /// display indicates the suggested denom that should be
     /// displayed in clients.
     #[prost(string, tag = "4")]
-    pub display: std::string::String,
+    pub display: ::prost::alloc::string::String,
 }
 /// QueryBalanceRequest is the request type for the Query/Balance RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBalanceRequest {
     /// address is the address to query balances for.
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     /// denom is the coin denom to query balances for.
     #[prost(string, tag = "2")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
 }
 /// QueryBalanceResponse is the response type for the Query/Balance RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBalanceResponse {
     /// balance is the balance of the coin.
     #[prost(message, optional, tag = "1")]
-    pub balance: ::std::option::Option<super::super::base::v1beta1::Coin>,
+    pub balance: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
 /// QueryBalanceRequest is the request type for the Query/AllBalances RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryAllBalancesRequest {
     /// address is the address to query balances for.
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryAllBalancesResponse is the response type for the Query/AllBalances RPC
 /// method.
@@ -106,10 +106,10 @@ pub struct QueryAllBalancesRequest {
 pub struct QueryAllBalancesResponse {
     /// balances is the balances of all the coins.
     #[prost(message, repeated, tag = "1")]
-    pub balances: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub balances: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
 /// method.
@@ -121,21 +121,21 @@ pub struct QueryTotalSupplyRequest {}
 pub struct QueryTotalSupplyResponse {
     /// supply is the supply of the coins
     #[prost(message, repeated, tag = "1")]
-    pub supply: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub supply: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
 /// QuerySupplyOfRequest is the request type for the Query/SupplyOf RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuerySupplyOfRequest {
     /// denom is the coin denom to query balances for.
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
 }
 /// QuerySupplyOfResponse is the response type for the Query/SupplyOf RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuerySupplyOfResponse {
     /// amount is the supply of the coin.
     #[prost(message, optional, tag = "1")]
-    pub amount: ::std::option::Option<super::super::base::v1beta1::Coin>,
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
 /// QueryParamsRequest defines the request type for querying x/bank parameters.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -144,7 +144,7 @@ pub struct QueryParamsRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsResponse {
     #[prost(message, optional, tag = "1")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]

--- a/cosmos-sdk-proto/src/prost/cosmos.base.abci.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.abci.v1beta1.rs
@@ -7,26 +7,26 @@ pub struct TxResponse {
     pub height: i64,
     /// The transaction hash.
     #[prost(string, tag = "2")]
-    pub txhash: std::string::String,
+    pub txhash: ::prost::alloc::string::String,
     /// Namespace for the Code
     #[prost(string, tag = "3")]
-    pub codespace: std::string::String,
+    pub codespace: ::prost::alloc::string::String,
     /// Response code.
     #[prost(uint32, tag = "4")]
     pub code: u32,
     /// Result bytes, if any.
     #[prost(string, tag = "5")]
-    pub data: std::string::String,
+    pub data: ::prost::alloc::string::String,
     /// The output of the application's logger (raw string). May be
     /// non-deterministic.
     #[prost(string, tag = "6")]
-    pub raw_log: std::string::String,
+    pub raw_log: ::prost::alloc::string::String,
     /// The output of the application's logger (typed). May be non-deterministic.
     #[prost(message, repeated, tag = "7")]
-    pub logs: ::std::vec::Vec<AbciMessageLog>,
+    pub logs: ::prost::alloc::vec::Vec<AbciMessageLog>,
     /// Additional information. May be non-deterministic.
     #[prost(string, tag = "8")]
-    pub info: std::string::String,
+    pub info: ::prost::alloc::string::String,
     /// Amount of gas requested for transaction.
     #[prost(int64, tag = "9")]
     pub gas_wanted: i64,
@@ -35,12 +35,12 @@ pub struct TxResponse {
     pub gas_used: i64,
     /// The request transaction bytes.
     #[prost(message, optional, tag = "11")]
-    pub tx: ::std::option::Option<::prost_types::Any>,
+    pub tx: ::core::option::Option<::prost_types::Any>,
     /// Time of the previous block. For heights > 1, it's the weighted median of
     /// the timestamps of the valid votes in the block.LastCommit. For height == 1,
     /// it's genesis time.
     #[prost(string, tag = "12")]
-    pub timestamp: std::string::String,
+    pub timestamp: ::prost::alloc::string::String,
 }
 /// ABCIMessageLog defines a structure containing an indexed tx ABCI message log.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -48,29 +48,29 @@ pub struct AbciMessageLog {
     #[prost(uint32, tag = "1")]
     pub msg_index: u32,
     #[prost(string, tag = "2")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     /// Events contains a slice of Event objects that were emitted during some
     /// execution.
     #[prost(message, repeated, tag = "3")]
-    pub events: ::std::vec::Vec<StringEvent>,
+    pub events: ::prost::alloc::vec::Vec<StringEvent>,
 }
 /// StringEvent defines en Event object wrapper where all the attributes
 /// contain key/value pairs that are strings instead of raw bytes.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringEvent {
     #[prost(string, tag = "1")]
-    pub r#type: std::string::String,
+    pub r#type: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub attributes: ::std::vec::Vec<Attribute>,
+    pub attributes: ::prost::alloc::vec::Vec<Attribute>,
 }
 /// Attribute defines an attribute wrapper where the key and value are
 /// strings instead of raw bytes.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Attribute {
     #[prost(string, tag = "1")]
-    pub key: std::string::String,
+    pub key: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub value: std::string::String,
+    pub value: ::prost::alloc::string::String,
 }
 /// GasInfo defines tx execution gas context.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -87,40 +87,40 @@ pub struct GasInfo {
 pub struct Result {
     /// Data is any data returned from message or handler execution. It MUST be
     /// length prefixed in order to separate data from multiple message executions.
-    #[prost(bytes, tag = "1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     /// Log contains the log information from message or handler execution.
     #[prost(string, tag = "2")]
-    pub log: std::string::String,
+    pub log: ::prost::alloc::string::String,
     /// Events contains a slice of Event objects that were emitted during message
     /// or handler execution.
     #[prost(message, repeated, tag = "3")]
-    pub events: ::std::vec::Vec<tendermint_proto::abci::Event>,
+    pub events: ::prost::alloc::vec::Vec<tendermint_proto::abci::Event>,
 }
 /// SimulationResponse defines the response generated when a transaction is
 /// successfully simulated.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimulationResponse {
     #[prost(message, optional, tag = "1")]
-    pub gas_info: ::std::option::Option<GasInfo>,
+    pub gas_info: ::core::option::Option<GasInfo>,
     #[prost(message, optional, tag = "2")]
-    pub result: ::std::option::Option<Result>,
+    pub result: ::core::option::Option<Result>,
 }
 /// MsgData defines the data returned in a Result object during message
 /// execution.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgData {
     #[prost(string, tag = "1")]
-    pub msg_type: std::string::String,
-    #[prost(bytes, tag = "2")]
-    pub data: std::vec::Vec<u8>,
+    pub msg_type: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// TxMsgData defines a list of MsgData. A transaction will have a MsgData object
 /// for each message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxMsgData {
     #[prost(message, repeated, tag = "1")]
-    pub data: ::std::vec::Vec<MsgData>,
+    pub data: ::prost::alloc::vec::Vec<MsgData>,
 }
 /// SearchTxsResult defines a structure for querying txs pageable
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -142,5 +142,5 @@ pub struct SearchTxsResult {
     pub limit: u64,
     /// List of txs in current page
     #[prost(message, repeated, tag = "6")]
-    pub txs: ::std::vec::Vec<TxResponse>,
+    pub txs: ::prost::alloc::vec::Vec<TxResponse>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.base.kv.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.kv.v1beta1.rs
@@ -2,13 +2,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Pairs {
     #[prost(message, repeated, tag = "1")]
-    pub pairs: ::std::vec::Vec<Pair>,
+    pub pairs: ::prost::alloc::vec::Vec<Pair>,
 }
 /// Pair defines a key/value bytes tuple.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Pair {
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.base.query.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.query.v1beta1.rs
@@ -10,8 +10,8 @@ pub struct PageRequest {
     /// key is a value returned in PageResponse.next_key to begin
     /// querying the next page most efficiently. Only one of offset or key
     /// should be set.
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     /// offset is a numeric offset that can be used when key is unavailable.
     /// It is less efficient than using key. Only one of offset or key should
     /// be set.
@@ -39,8 +39,8 @@ pub struct PageRequest {
 pub struct PageResponse {
     /// next_key is the key to be passed to PageRequest.key to
     /// query the next page most efficiently
-    #[prost(bytes, tag = "1")]
-    pub next_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub next_key: ::prost::alloc::vec::Vec<u8>,
     /// total is total number of results available if PageRequest.count_total
     /// was set, its value is undefined otherwise
     #[prost(uint64, tag = "2")]

--- a/cosmos-sdk-proto/src/prost/cosmos.base.reflection.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.reflection.v1beta1.rs
@@ -6,7 +6,7 @@ pub struct ListAllInterfacesRequest {}
 pub struct ListAllInterfacesResponse {
     /// interface_names is an array of all the registered interfaces.
     #[prost(string, repeated, tag = "1")]
-    pub interface_names: ::std::vec::Vec<std::string::String>,
+    pub interface_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// ListImplementationsRequest is the request type of the ListImplementations
 /// RPC.
@@ -14,12 +14,12 @@ pub struct ListAllInterfacesResponse {
 pub struct ListImplementationsRequest {
     /// interface_name defines the interface to query the implementations for.
     #[prost(string, tag = "1")]
-    pub interface_name: std::string::String,
+    pub interface_name: ::prost::alloc::string::String,
 }
 /// ListImplementationsResponse is the response type of the ListImplementations
 /// RPC.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListImplementationsResponse {
     #[prost(string, repeated, tag = "1")]
-    pub implementation_message_names: ::std::vec::Vec<std::string::String>,
+    pub implementation_message_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.base.snapshots.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.snapshots.v1beta1.rs
@@ -7,15 +7,15 @@ pub struct Snapshot {
     pub format: u32,
     #[prost(uint32, tag = "3")]
     pub chunks: u32,
-    #[prost(bytes, tag = "4")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "5")]
-    pub metadata: ::std::option::Option<Metadata>,
+    pub metadata: ::core::option::Option<Metadata>,
 }
 /// Metadata contains SDK-specific snapshot metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metadata {
     /// SHA-256 chunk hashes
-    #[prost(bytes, repeated, tag = "1")]
-    pub chunk_hashes: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub chunk_hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.base.store.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.store.v1beta1.rs
@@ -5,16 +5,16 @@ pub struct CommitInfo {
     #[prost(int64, tag = "1")]
     pub version: i64,
     #[prost(message, repeated, tag = "2")]
-    pub store_infos: ::std::vec::Vec<StoreInfo>,
+    pub store_infos: ::prost::alloc::vec::Vec<StoreInfo>,
 }
 /// StoreInfo defines store-specific commit information. It contains a reference
 /// between a store name and the commit ID.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StoreInfo {
     #[prost(string, tag = "1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub commit_id: ::std::option::Option<CommitId>,
+    pub commit_id: ::core::option::Option<CommitId>,
 }
 /// CommitID defines the committment information when a specific store is
 /// committed.
@@ -22,16 +22,17 @@ pub struct StoreInfo {
 pub struct CommitId {
     #[prost(int64, tag = "1")]
     pub version: i64,
-    #[prost(bytes, tag = "2")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// SnapshotItem is an item contained in a rootmulti.Store snapshot.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotItem {
     /// item is the specific type of snapshot item.
     #[prost(oneof = "snapshot_item::Item", tags = "1, 2")]
-    pub item: ::std::option::Option<snapshot_item::Item>,
+    pub item: ::core::option::Option<snapshot_item::Item>,
 }
+/// Nested message and enum types in `SnapshotItem`.
 pub mod snapshot_item {
     /// item is the specific type of snapshot item.
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -46,15 +47,15 @@ pub mod snapshot_item {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotStoreItem {
     #[prost(string, tag = "1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
 }
 /// SnapshotIAVLItem is an exported IAVL node.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotIavlItem {
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(int64, tag = "3")]
     pub version: i64,
     #[prost(int32, tag = "4")]

--- a/cosmos-sdk-proto/src/prost/cosmos.base.tendermint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.tendermint.v1beta1.rs
@@ -5,7 +5,7 @@ pub struct GetValidatorSetByHeightRequest {
     pub height: i64,
     /// pagination defines an pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::query::v1beta1::PageRequest>,
 }
 /// GetValidatorSetByHeightResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -13,17 +13,17 @@ pub struct GetValidatorSetByHeightResponse {
     #[prost(int64, tag = "1")]
     pub block_height: i64,
     #[prost(message, repeated, tag = "2")]
-    pub validators: ::std::vec::Vec<Validator>,
+    pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines an pagination for the response.
     #[prost(message, optional, tag = "3")]
-    pub pagination: ::std::option::Option<super::super::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::query::v1beta1::PageResponse>,
 }
 /// GetLatestValidatorSetRequest is the request type for the Query/GetValidatorSetByHeight RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestValidatorSetRequest {
     /// pagination defines an pagination for the request.
     #[prost(message, optional, tag = "1")]
-    pub pagination: ::std::option::Option<super::super::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::query::v1beta1::PageRequest>,
 }
 /// GetLatestValidatorSetResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -31,18 +31,18 @@ pub struct GetLatestValidatorSetResponse {
     #[prost(int64, tag = "1")]
     pub block_height: i64,
     #[prost(message, repeated, tag = "2")]
-    pub validators: ::std::vec::Vec<Validator>,
+    pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines an pagination for the response.
     #[prost(message, optional, tag = "3")]
-    pub pagination: ::std::option::Option<super::super::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::query::v1beta1::PageResponse>,
 }
 /// Validator is the type for the validator-set.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Validator {
     #[prost(string, tag = "1")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub pub_key: ::std::option::Option<::prost_types::Any>,
+    pub pub_key: ::core::option::Option<::prost_types::Any>,
     #[prost(int64, tag = "3")]
     pub voting_power: i64,
     #[prost(int64, tag = "4")]
@@ -58,9 +58,9 @@ pub struct GetBlockByHeightRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockByHeightResponse {
     #[prost(message, optional, tag = "1")]
-    pub block_id: ::std::option::Option<::tendermint_proto::types::BlockId>,
+    pub block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
     #[prost(message, optional, tag = "2")]
-    pub block: ::std::option::Option<::tendermint_proto::types::Block>,
+    pub block: ::core::option::Option<::tendermint_proto::types::Block>,
 }
 /// GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -69,9 +69,9 @@ pub struct GetLatestBlockRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestBlockResponse {
     #[prost(message, optional, tag = "1")]
-    pub block_id: ::std::option::Option<::tendermint_proto::types::BlockId>,
+    pub block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
     #[prost(message, optional, tag = "2")]
-    pub block: ::std::option::Option<::tendermint_proto::types::Block>,
+    pub block: ::core::option::Option<::tendermint_proto::types::Block>,
 }
 /// GetSyncingRequest is the request type for the Query/GetSyncing RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,38 +89,38 @@ pub struct GetNodeInfoRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoResponse {
     #[prost(message, optional, tag = "1")]
-    pub default_node_info: ::std::option::Option<::tendermint_proto::p2p::DefaultNodeInfo>,
+    pub default_node_info: ::core::option::Option<::tendermint_proto::p2p::DefaultNodeInfo>,
     #[prost(message, optional, tag = "2")]
-    pub application_version: ::std::option::Option<VersionInfo>,
+    pub application_version: ::core::option::Option<VersionInfo>,
 }
 /// VersionInfo is the type for the GetNodeInfoResponse message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VersionInfo {
     #[prost(string, tag = "1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub app_name: std::string::String,
+    pub app_name: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub git_commit: std::string::String,
+    pub git_commit: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
-    pub build_tags: std::string::String,
+    pub build_tags: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub go_version: std::string::String,
+    pub go_version: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "7")]
-    pub build_deps: ::std::vec::Vec<Module>,
+    pub build_deps: ::prost::alloc::vec::Vec<Module>,
 }
 /// Module is the type for VersionInfo
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Module {
     /// module path
     #[prost(string, tag = "1")]
-    pub path: std::string::String,
+    pub path: ::prost::alloc::string::String,
     /// module version
     #[prost(string, tag = "2")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     /// checksum
     #[prost(string, tag = "3")]
-    pub sum: std::string::String,
+    pub sum: ::prost::alloc::string::String,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.base.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.base.v1beta1.rs
@@ -5,9 +5,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Coin {
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub amount: std::string::String,
+    pub amount: ::prost::alloc::string::String,
 }
 /// DecCoin defines a token with a denomination and a decimal amount.
 ///
@@ -16,19 +16,19 @@ pub struct Coin {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DecCoin {
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub amount: std::string::String,
+    pub amount: ::prost::alloc::string::String,
 }
 /// IntProto defines a Protobuf wrapper around an Int object.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IntProto {
     #[prost(string, tag = "1")]
-    pub int: std::string::String,
+    pub int: ::prost::alloc::string::String,
 }
 /// DecProto defines a Protobuf wrapper around a Dec object.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DecProto {
     #[prost(string, tag = "1")]
-    pub dec: std::string::String,
+    pub dec: ::prost::alloc::string::String,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.crypto.multisig.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.crypto.multisig.v1beta1.rs
@@ -3,8 +3,8 @@
 /// signed and with which modes.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MultiSignature {
-    #[prost(bytes, repeated, tag = "1")]
-    pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub signatures: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// CompactBitArray is an implementation of a space efficient bit array.
 /// This is used to ensure that the encoded data takes up a minimal amount of
@@ -14,6 +14,6 @@ pub struct MultiSignature {
 pub struct CompactBitArray {
     #[prost(uint32, tag = "1")]
     pub extra_bits_stored: u32,
-    #[prost(bytes, tag = "2")]
-    pub elems: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub elems: ::prost::alloc::vec::Vec<u8>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.staking.v1beta1.rs
@@ -5,42 +5,42 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistoricalInfo {
     #[prost(message, optional, tag = "1")]
-    pub header: ::std::option::Option<tendermint_proto::types::Header>,
+    pub header: ::core::option::Option<tendermint_proto::types::Header>,
     #[prost(message, repeated, tag = "2")]
-    pub valset: ::std::vec::Vec<Validator>,
+    pub valset: ::prost::alloc::vec::Vec<Validator>,
 }
 /// CommissionRates defines the initial commission rates to be used for creating
 /// a validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRates {
     #[prost(string, tag = "1")]
-    pub rate: std::string::String,
+    pub rate: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub max_rate: std::string::String,
+    pub max_rate: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub max_change_rate: std::string::String,
+    pub max_change_rate: ::prost::alloc::string::String,
 }
 /// Commission defines commission parameters for a given validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commission {
     #[prost(message, optional, tag = "1")]
-    pub commission_rates: ::std::option::Option<CommissionRates>,
+    pub commission_rates: ::core::option::Option<CommissionRates>,
     #[prost(message, optional, tag = "2")]
-    pub update_time: ::std::option::Option<::prost_types::Timestamp>,
+    pub update_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// Description defines a validator description.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Description {
     #[prost(string, tag = "1")]
-    pub moniker: std::string::String,
+    pub moniker: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub identity: std::string::String,
+    pub identity: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub website: std::string::String,
+    pub website: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub security_contact: std::string::String,
+    pub security_contact: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
-    pub details: std::string::String,
+    pub details: ::prost::alloc::string::String,
 }
 /// Validator defines a validator, together with the total amount of the
 /// Validator's bond shares and their exchange rate to coins. Slashing results in
@@ -53,33 +53,33 @@ pub struct Description {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Validator {
     #[prost(string, tag = "1")]
-    pub operator_address: std::string::String,
+    pub operator_address: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub consensus_pubkey: ::std::option::Option<::prost_types::Any>,
+    pub consensus_pubkey: ::core::option::Option<::prost_types::Any>,
     #[prost(bool, tag = "3")]
     pub jailed: bool,
     #[prost(enumeration = "BondStatus", tag = "4")]
     pub status: i32,
     #[prost(string, tag = "5")]
-    pub tokens: std::string::String,
+    pub tokens: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub delegator_shares: std::string::String,
+    pub delegator_shares: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "7")]
-    pub description: ::std::option::Option<Description>,
+    pub description: ::core::option::Option<Description>,
     #[prost(int64, tag = "8")]
     pub unbonding_height: i64,
     #[prost(message, optional, tag = "9")]
-    pub unbonding_time: ::std::option::Option<::prost_types::Timestamp>,
+    pub unbonding_time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "10")]
-    pub commission: ::std::option::Option<Commission>,
+    pub commission: ::core::option::Option<Commission>,
     #[prost(string, tag = "11")]
-    pub min_self_delegation: std::string::String,
+    pub min_self_delegation: ::prost::alloc::string::String,
 }
 /// ValAddresses defines a repeated set of validator addresses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValAddresses {
     #[prost(string, repeated, tag = "1")]
-    pub addresses: ::std::vec::Vec<std::string::String>,
+    pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// DVPair is struct that just has a delegator-validator pair with no other data.
 /// It is intended to be used as a marshalable pointer. For example, a DVPair can
@@ -87,15 +87,15 @@ pub struct ValAddresses {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvPair {
     #[prost(string, tag = "1")]
-    pub delegator_address: std::string::String,
+    pub delegator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub validator_address: std::string::String,
+    pub validator_address: ::prost::alloc::string::String,
 }
 /// DVPairs defines an array of DVPair objects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvPairs {
     #[prost(message, repeated, tag = "1")]
-    pub pairs: ::std::vec::Vec<DvPair>,
+    pub pairs: ::prost::alloc::vec::Vec<DvPair>,
 }
 /// DVVTriplet is struct that just has a delegator-validator-validator triplet
 /// with no other data. It is intended to be used as a marshalable pointer. For
@@ -104,17 +104,17 @@ pub struct DvPairs {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvvTriplet {
     #[prost(string, tag = "1")]
-    pub delegator_address: std::string::String,
+    pub delegator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub validator_src_address: std::string::String,
+    pub validator_src_address: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub validator_dst_address: std::string::String,
+    pub validator_dst_address: ::prost::alloc::string::String,
 }
 /// DVVTriplets defines an array of DVVTriplet objects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvvTriplets {
     #[prost(message, repeated, tag = "1")]
-    pub triplets: ::std::vec::Vec<DvvTriplet>,
+    pub triplets: ::prost::alloc::vec::Vec<DvvTriplet>,
 }
 /// Delegation represents the bond with tokens held by an account. It is
 /// owned by one delegator, and is associated with the voting power of one
@@ -122,23 +122,23 @@ pub struct DvvTriplets {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Delegation {
     #[prost(string, tag = "1")]
-    pub delegator_address: std::string::String,
+    pub delegator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub validator_address: std::string::String,
+    pub validator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub shares: std::string::String,
+    pub shares: ::prost::alloc::string::String,
 }
 /// UnbondingDelegation stores all of a single delegator's unbonding bonds
 /// for a single validator in an time-ordered list.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnbondingDelegation {
     #[prost(string, tag = "1")]
-    pub delegator_address: std::string::String,
+    pub delegator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub validator_address: std::string::String,
+    pub validator_address: ::prost::alloc::string::String,
     /// unbonding delegation entries
     #[prost(message, repeated, tag = "3")]
-    pub entries: ::std::vec::Vec<UnbondingDelegationEntry>,
+    pub entries: ::prost::alloc::vec::Vec<UnbondingDelegationEntry>,
 }
 /// UnbondingDelegationEntry defines an unbonding object with relevant metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -146,11 +146,11 @@ pub struct UnbondingDelegationEntry {
     #[prost(int64, tag = "1")]
     pub creation_height: i64,
     #[prost(message, optional, tag = "2")]
-    pub completion_time: ::std::option::Option<::prost_types::Timestamp>,
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(string, tag = "3")]
-    pub initial_balance: std::string::String,
+    pub initial_balance: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub balance: std::string::String,
+    pub balance: ::prost::alloc::string::String,
 }
 /// RedelegationEntry defines a redelegation object with relevant metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -158,31 +158,31 @@ pub struct RedelegationEntry {
     #[prost(int64, tag = "1")]
     pub creation_height: i64,
     #[prost(message, optional, tag = "2")]
-    pub completion_time: ::std::option::Option<::prost_types::Timestamp>,
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(string, tag = "3")]
-    pub initial_balance: std::string::String,
+    pub initial_balance: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub shares_dst: std::string::String,
+    pub shares_dst: ::prost::alloc::string::String,
 }
 /// Redelegation contains the list of a particular delegator's redelegating bonds
 /// from a particular source validator to a particular destination validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Redelegation {
     #[prost(string, tag = "1")]
-    pub delegator_address: std::string::String,
+    pub delegator_address: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub validator_src_address: std::string::String,
+    pub validator_src_address: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub validator_dst_address: std::string::String,
+    pub validator_dst_address: ::prost::alloc::string::String,
     /// redelegation entries
     #[prost(message, repeated, tag = "4")]
-    pub entries: ::std::vec::Vec<RedelegationEntry>,
+    pub entries: ::prost::alloc::vec::Vec<RedelegationEntry>,
 }
 /// Params defines the parameters for the staking module.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
     #[prost(message, optional, tag = "1")]
-    pub unbonding_time: ::std::option::Option<::prost_types::Duration>,
+    pub unbonding_time: ::core::option::Option<::prost_types::Duration>,
     #[prost(uint32, tag = "2")]
     pub max_validators: u32,
     #[prost(uint32, tag = "3")]
@@ -190,16 +190,16 @@ pub struct Params {
     #[prost(uint32, tag = "4")]
     pub historical_entries: u32,
     #[prost(string, tag = "5")]
-    pub bond_denom: std::string::String,
+    pub bond_denom: ::prost::alloc::string::String,
 }
 /// DelegationResponse is equivalent to Delegation except that it contains a
 /// balance in addition to shares which is more suitable for client responses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationResponse {
     #[prost(message, optional, tag = "1")]
-    pub delegation: ::std::option::Option<Delegation>,
+    pub delegation: ::core::option::Option<Delegation>,
     #[prost(message, optional, tag = "2")]
-    pub balance: ::std::option::Option<super::super::base::v1beta1::Coin>,
+    pub balance: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
 /// RedelegationEntryResponse is equivalent to a RedelegationEntry except that it
 /// contains a balance in addition to shares which is more suitable for client
@@ -207,9 +207,9 @@ pub struct DelegationResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RedelegationEntryResponse {
     #[prost(message, optional, tag = "1")]
-    pub redelegation_entry: ::std::option::Option<RedelegationEntry>,
+    pub redelegation_entry: ::core::option::Option<RedelegationEntry>,
     #[prost(string, tag = "4")]
-    pub balance: std::string::String,
+    pub balance: ::prost::alloc::string::String,
 }
 /// RedelegationResponse is equivalent to a Redelegation except that its entries
 /// contain a balance in addition to shares which is more suitable for client
@@ -217,18 +217,18 @@ pub struct RedelegationEntryResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RedelegationResponse {
     #[prost(message, optional, tag = "1")]
-    pub redelegation: ::std::option::Option<Redelegation>,
+    pub redelegation: ::core::option::Option<Redelegation>,
     #[prost(message, repeated, tag = "2")]
-    pub entries: ::std::vec::Vec<RedelegationEntryResponse>,
+    pub entries: ::prost::alloc::vec::Vec<RedelegationEntryResponse>,
 }
 /// Pool is used for tracking bonded and not-bonded token supply of the bond
 /// denomination.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Pool {
     #[prost(string, tag = "1")]
-    pub not_bonded_tokens: std::string::String,
+    pub not_bonded_tokens: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub bonded_tokens: std::string::String,
+    pub bonded_tokens: ::prost::alloc::string::String,
 }
 /// BondStatus is the status of a validator.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -248,34 +248,34 @@ pub enum BondStatus {
 pub struct QueryValidatorsRequest {
     /// status enables to query for validators matching a given status.
     #[prost(string, tag = "1")]
-    pub status: std::string::String,
+    pub status: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorsResponse is response type for the Query/Validators RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorsResponse {
     /// validators contains all the queried validators.
     #[prost(message, repeated, tag = "1")]
-    pub validators: ::std::vec::Vec<Validator>,
+    pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryValidatorRequest is response type for the Query/Validator RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorRequest {
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "1")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryValidatorResponse is response type for the Query/Validator RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorResponse {
     /// validator defines the the validator info.
     #[prost(message, optional, tag = "1")]
-    pub validator: ::std::option::Option<Validator>,
+    pub validator: ::core::option::Option<Validator>,
 }
 /// QueryValidatorDelegationsRequest is request type for the
 /// Query/ValidatorDelegations RPC method
@@ -283,20 +283,20 @@ pub struct QueryValidatorResponse {
 pub struct QueryValidatorDelegationsRequest {
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "1")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorDelegationsResponse is response type for the
 /// Query/ValidatorDelegations RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorDelegationsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub delegation_responses: ::std::vec::Vec<DelegationResponse>,
+    pub delegation_responses: ::prost::alloc::vec::Vec<DelegationResponse>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryValidatorUnbondingDelegationsRequest is required type for the
 /// Query/ValidatorUnbondingDelegations RPC method
@@ -304,37 +304,37 @@ pub struct QueryValidatorDelegationsResponse {
 pub struct QueryValidatorUnbondingDelegationsRequest {
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "1")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorUnbondingDelegationsResponse is response type for the
 /// Query/ValidatorUnbondingDelegations RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorUnbondingDelegationsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub unbonding_responses: ::std::vec::Vec<UnbondingDelegation>,
+    pub unbonding_responses: ::prost::alloc::vec::Vec<UnbondingDelegation>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegationRequest is request type for the Query/Delegation RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegationRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "2")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegationResponse is response type for the Query/Delegation RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegationResponse {
     /// delegation_responses defines the delegation info of a delegation.
     #[prost(message, optional, tag = "1")]
-    pub delegation_response: ::std::option::Option<DelegationResponse>,
+    pub delegation_response: ::core::option::Option<DelegationResponse>,
 }
 /// QueryUnbondingDelegationRequest is request type for the
 /// Query/UnbondingDelegation RPC method.
@@ -342,10 +342,10 @@ pub struct QueryDelegationResponse {
 pub struct QueryUnbondingDelegationRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "2")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegationResponse is response type for the Query/UnbondingDelegation
 /// RPC method.
@@ -353,7 +353,7 @@ pub struct QueryUnbondingDelegationRequest {
 pub struct QueryUnbondingDelegationResponse {
     /// unbond defines the unbonding information of a delegation.
     #[prost(message, optional, tag = "1")]
-    pub unbond: ::std::option::Option<UnbondingDelegation>,
+    pub unbond: ::core::option::Option<UnbondingDelegation>,
 }
 /// QueryDelegatorDelegationsRequest is request type for the
 /// Query/DelegatorDelegations RPC method.
@@ -361,10 +361,10 @@ pub struct QueryUnbondingDelegationResponse {
 pub struct QueryDelegatorDelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryDelegatorDelegationsResponse is response type for the
 /// Query/DelegatorDelegations RPC method.
@@ -372,10 +372,10 @@ pub struct QueryDelegatorDelegationsRequest {
 pub struct QueryDelegatorDelegationsResponse {
     /// delegation_responses defines all the delegations' info of a delegator.
     #[prost(message, repeated, tag = "1")]
-    pub delegation_responses: ::std::vec::Vec<DelegationResponse>,
+    pub delegation_responses: ::prost::alloc::vec::Vec<DelegationResponse>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorUnbondingDelegationsRequest is request type for the
 /// Query/DelegatorUnbondingDelegations RPC method.
@@ -383,20 +383,20 @@ pub struct QueryDelegatorDelegationsResponse {
 pub struct QueryDelegatorUnbondingDelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryUnbondingDelegatorDelegationsResponse is response type for the
 /// Query/UnbondingDelegatorDelegations RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorUnbondingDelegationsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub unbonding_responses: ::std::vec::Vec<UnbondingDelegation>,
+    pub unbonding_responses: ::prost::alloc::vec::Vec<UnbondingDelegation>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryRedelegationsRequest is request type for the Query/Redelegations RPC
 /// method.
@@ -404,26 +404,26 @@ pub struct QueryDelegatorUnbondingDelegationsResponse {
 pub struct QueryRedelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// src_validator_addr defines the validator address to redelegate from.
     #[prost(string, tag = "2")]
-    pub src_validator_addr: std::string::String,
+    pub src_validator_addr: ::prost::alloc::string::String,
     /// dst_validator_addr defines the validator address to redelegate to.
     #[prost(string, tag = "3")]
-    pub dst_validator_addr: std::string::String,
+    pub dst_validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "4")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryRedelegationsResponse is response type for the Query/Redelegations RPC
 /// method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryRedelegationsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub redelegation_responses: ::std::vec::Vec<RedelegationResponse>,
+    pub redelegation_responses: ::prost::alloc::vec::Vec<RedelegationResponse>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorValidatorsRequest is request type for the
 /// Query/DelegatorValidators RPC method.
@@ -431,10 +431,10 @@ pub struct QueryRedelegationsResponse {
 pub struct QueryDelegatorValidatorsRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryDelegatorValidatorsResponse is response type for the
 /// Query/DelegatorValidators RPC method.
@@ -442,10 +442,10 @@ pub struct QueryDelegatorValidatorsRequest {
 pub struct QueryDelegatorValidatorsResponse {
     /// validators defines the the validators' info of a delegator.
     #[prost(message, repeated, tag = "1")]
-    pub validators: ::std::vec::Vec<Validator>,
+    pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorValidatorRequest is request type for the
 /// Query/DelegatorValidator RPC method.
@@ -453,10 +453,10 @@ pub struct QueryDelegatorValidatorsResponse {
 pub struct QueryDelegatorValidatorRequest {
     /// delegator_addr defines the delegator address to query for.
     #[prost(string, tag = "1")]
-    pub delegator_addr: std::string::String,
+    pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
     #[prost(string, tag = "2")]
-    pub validator_addr: std::string::String,
+    pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegatorValidatorResponse response type for the
 /// Query/DelegatorValidator RPC method.
@@ -464,7 +464,7 @@ pub struct QueryDelegatorValidatorRequest {
 pub struct QueryDelegatorValidatorResponse {
     /// validator defines the the validator info.
     #[prost(message, optional, tag = "1")]
-    pub validator: ::std::option::Option<Validator>,
+    pub validator: ::core::option::Option<Validator>,
 }
 /// QueryHistoricalInfoRequest is request type for the Query/HistoricalInfo RPC
 /// method.
@@ -480,7 +480,7 @@ pub struct QueryHistoricalInfoRequest {
 pub struct QueryHistoricalInfoResponse {
     /// hist defines the historical info at the given height.
     #[prost(message, optional, tag = "1")]
-    pub hist: ::std::option::Option<HistoricalInfo>,
+    pub hist: ::core::option::Option<HistoricalInfo>,
 }
 /// QueryPoolRequest is request type for the Query/Pool RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -490,7 +490,7 @@ pub struct QueryPoolRequest {}
 pub struct QueryPoolResponse {
     /// pool defines the pool info.
     #[prost(message, optional, tag = "1")]
-    pub pool: ::std::option::Option<Pool>,
+    pub pool: ::core::option::Option<Pool>,
 }
 /// QueryParamsRequest is request type for the Query/Params RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -500,7 +500,7 @@ pub struct QueryParamsRequest {}
 pub struct QueryParamsResponse {
     /// params holds all the parameters of this module.
     #[prost(message, optional, tag = "1")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]

--- a/cosmos-sdk-proto/src/prost/cosmos.tx.signing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.tx.signing.v1beta1.rs
@@ -3,7 +3,7 @@
 pub struct SignatureDescriptors {
     /// signatures are the signature descriptors
     #[prost(message, repeated, tag = "1")]
-    pub signatures: ::std::vec::Vec<SignatureDescriptor>,
+    pub signatures: ::prost::alloc::vec::Vec<SignatureDescriptor>,
 }
 /// SignatureDescriptor is a convenience type which represents the full data for
 /// a signature including the public key of the signer, signing modes and the
@@ -13,23 +13,25 @@ pub struct SignatureDescriptors {
 pub struct SignatureDescriptor {
     /// public_key is the public key of the signer
     #[prost(message, optional, tag = "1")]
-    pub public_key: ::std::option::Option<::prost_types::Any>,
+    pub public_key: ::core::option::Option<::prost_types::Any>,
     #[prost(message, optional, tag = "2")]
-    pub data: ::std::option::Option<signature_descriptor::Data>,
+    pub data: ::core::option::Option<signature_descriptor::Data>,
     /// sequence is the sequence of the account, which describes the
     /// number of committed transactions signed by a given address. It is used to prevent
     /// replay attacks.
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
 }
+/// Nested message and enum types in `SignatureDescriptor`.
 pub mod signature_descriptor {
     /// Data represents signature data
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Data {
         /// sum is the oneof that specifies whether this represents single or multi-signature data
         #[prost(oneof = "data::Sum", tags = "1, 2")]
-        pub sum: ::std::option::Option<data::Sum>,
+        pub sum: ::core::option::Option<data::Sum>,
     }
+    /// Nested message and enum types in `Data`.
     pub mod data {
         /// Single is the signature data for a single signer
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -38,20 +40,20 @@ pub mod signature_descriptor {
             #[prost(enumeration = "super::super::SignMode", tag = "1")]
             pub mode: i32,
             /// signature is the raw signature bytes
-            #[prost(bytes, tag = "2")]
-            pub signature: std::vec::Vec<u8>,
+            #[prost(bytes = "vec", tag = "2")]
+            pub signature: ::prost::alloc::vec::Vec<u8>,
         }
         /// Multi is the signature data for a multisig public key
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Multi {
             /// bitarray specifies which keys within the multisig are signing
             #[prost(message, optional, tag = "1")]
-            pub bitarray: ::std::option::Option<
+            pub bitarray: ::core::option::Option<
                 super::super::super::super::super::crypto::multisig::v1beta1::CompactBitArray,
             >,
             /// signatures is the signatures of the multi-signature
             #[prost(message, repeated, tag = "2")]
-            pub signatures: ::std::vec::Vec<super::Data>,
+            pub signatures: ::prost::alloc::vec::Vec<super::Data>,
         }
         /// sum is the oneof that specifies whether this represents single or multi-signature data
         #[derive(Clone, PartialEq, ::prost::Oneof)]

--- a/cosmos-sdk-proto/src/prost/cosmos.tx.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.tx.v1beta1.rs
@@ -3,16 +3,16 @@
 pub struct Tx {
     /// body is the processable content of the transaction
     #[prost(message, optional, tag = "1")]
-    pub body: ::std::option::Option<TxBody>,
+    pub body: ::core::option::Option<TxBody>,
     /// auth_info is the authorization related content of the transaction,
     /// specifically signers, signer modes and fee
     #[prost(message, optional, tag = "2")]
-    pub auth_info: ::std::option::Option<AuthInfo>,
+    pub auth_info: ::core::option::Option<AuthInfo>,
     /// signatures is a list of signatures that matches the length and order of
     /// AuthInfo's signer_infos to allow connecting signature meta information like
     /// public key and signing mode by position.
-    #[prost(bytes, repeated, tag = "3")]
-    pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    pub signatures: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// TxRaw is a variant of Tx that pins the signer's exact binary representation
 /// of body and auth_info. This is used for signing, broadcasting and
@@ -23,34 +23,34 @@ pub struct Tx {
 pub struct TxRaw {
     /// body_bytes is a protobuf serialization of a TxBody that matches the
     /// representation in SignDoc.
-    #[prost(bytes, tag = "1")]
-    pub body_bytes: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub body_bytes: ::prost::alloc::vec::Vec<u8>,
     /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the
     /// representation in SignDoc.
-    #[prost(bytes, tag = "2")]
-    pub auth_info_bytes: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub auth_info_bytes: ::prost::alloc::vec::Vec<u8>,
     /// signatures is a list of signatures that matches the length and order of
     /// AuthInfo's signer_infos to allow connecting signature meta information like
     /// public key and signing mode by position.
-    #[prost(bytes, repeated, tag = "3")]
-    pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    pub signatures: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// SignDoc is the type used for generating sign bytes for SIGN_MODE_DIRECT.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignDoc {
     /// body_bytes is protobuf serialization of a TxBody that matches the
     /// representation in TxRaw.
-    #[prost(bytes, tag = "1")]
-    pub body_bytes: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub body_bytes: ::prost::alloc::vec::Vec<u8>,
     /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the
     /// representation in TxRaw.
-    #[prost(bytes, tag = "2")]
-    pub auth_info_bytes: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub auth_info_bytes: ::prost::alloc::vec::Vec<u8>,
     /// chain_id is the unique identifier of the chain this transaction targets.
     /// It prevents signed transactions from being used on another chain by an
     /// attacker
     #[prost(string, tag = "3")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     /// account_number is the account number of the account in state
     #[prost(uint64, tag = "4")]
     pub account_number: u64,
@@ -66,10 +66,10 @@ pub struct TxBody {
     /// is referred to as the primary signer and pays the fee for the whole
     /// transaction.
     #[prost(message, repeated, tag = "1")]
-    pub messages: ::std::vec::Vec<::prost_types::Any>,
+    pub messages: ::prost::alloc::vec::Vec<::prost_types::Any>,
     /// memo is any arbitrary memo to be added to the transaction
     #[prost(string, tag = "2")]
-    pub memo: std::string::String,
+    pub memo: ::prost::alloc::string::String,
     /// timeout is the block height after which this transaction will not
     /// be processed by the chain
     #[prost(uint64, tag = "3")]
@@ -78,12 +78,12 @@ pub struct TxBody {
     /// when the default options are not sufficient. If any of these are present
     /// and can't be handled, the transaction will be rejected
     #[prost(message, repeated, tag = "1023")]
-    pub extension_options: ::std::vec::Vec<::prost_types::Any>,
+    pub extension_options: ::prost::alloc::vec::Vec<::prost_types::Any>,
     /// extension_options are arbitrary options that can be added by chains
     /// when the default options are not sufficient. If any of these are present
     /// and can't be handled, they will be ignored
     #[prost(message, repeated, tag = "2047")]
-    pub non_critical_extension_options: ::std::vec::Vec<::prost_types::Any>,
+    pub non_critical_extension_options: ::prost::alloc::vec::Vec<::prost_types::Any>,
 }
 /// AuthInfo describes the fee and signer modes that are used to sign a
 /// transaction.
@@ -94,13 +94,13 @@ pub struct AuthInfo {
     /// messages. The first element is the primary signer and the one which pays
     /// the fee.
     #[prost(message, repeated, tag = "1")]
-    pub signer_infos: ::std::vec::Vec<SignerInfo>,
+    pub signer_infos: ::prost::alloc::vec::Vec<SignerInfo>,
     /// Fee is the fee and gas limit for the transaction. The first signer is the
     /// primary signer and the one which pays the fee. The fee can be calculated
     /// based on the cost of evaluating the body and doing signature verification
     /// of the signers. This can be estimated via simulation.
     #[prost(message, optional, tag = "2")]
-    pub fee: ::std::option::Option<Fee>,
+    pub fee: ::core::option::Option<Fee>,
 }
 /// SignerInfo describes the public key and signing mode of a single top-level
 /// signer.
@@ -110,11 +110,11 @@ pub struct SignerInfo {
     /// that already exist in state. If unset, the verifier can use the required \
     /// signer address for this position and lookup the public key.
     #[prost(message, optional, tag = "1")]
-    pub public_key: ::std::option::Option<::prost_types::Any>,
+    pub public_key: ::core::option::Option<::prost_types::Any>,
     /// mode_info describes the signing mode of the signer and is a nested
     /// structure to support nested multisig pubkey's
     #[prost(message, optional, tag = "2")]
-    pub mode_info: ::std::option::Option<ModeInfo>,
+    pub mode_info: ::core::option::Option<ModeInfo>,
     /// sequence is the sequence of the account, which describes the
     /// number of committed transactions signed by a given address. It is used to
     /// prevent replay attacks.
@@ -127,8 +127,9 @@ pub struct ModeInfo {
     /// sum is the oneof that specifies whether this represents a single or nested
     /// multisig signer
     #[prost(oneof = "mode_info::Sum", tags = "1, 2")]
-    pub sum: ::std::option::Option<mode_info::Sum>,
+    pub sum: ::core::option::Option<mode_info::Sum>,
 }
+/// Nested message and enum types in `ModeInfo`.
 pub mod mode_info {
     /// Single is the mode info for a single signer. It is structured as a message
     /// to allow for additional fields such as locale for SIGN_MODE_TEXTUAL in the
@@ -145,11 +146,11 @@ pub mod mode_info {
         /// bitarray specifies which keys within the multisig are signing
         #[prost(message, optional, tag = "1")]
         pub bitarray:
-            ::std::option::Option<super::super::super::crypto::multisig::v1beta1::CompactBitArray>,
+            ::core::option::Option<super::super::super::crypto::multisig::v1beta1::CompactBitArray>,
         /// mode_infos is the corresponding modes of the signers of the multisig
         /// which could include nested multisig public keys
         #[prost(message, repeated, tag = "2")]
-        pub mode_infos: ::std::vec::Vec<super::ModeInfo>,
+        pub mode_infos: ::prost::alloc::vec::Vec<super::ModeInfo>,
     }
     /// sum is the oneof that specifies whether this represents a single or nested
     /// multisig signer
@@ -170,7 +171,7 @@ pub mod mode_info {
 pub struct Fee {
     /// amount is the amount of coins to be paid as a fee
     #[prost(message, repeated, tag = "1")]
-    pub amount: ::std::vec::Vec<super::super::base::v1beta1::Coin>,
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
     /// gas_limit is the maximum gas that can be used in transaction processing
     /// before an out of gas error occurs
     #[prost(uint64, tag = "2")]
@@ -179,12 +180,12 @@ pub struct Fee {
     /// the payer must be a tx signer (and thus have signed this field in AuthInfo).
     /// setting this field does *not* change the ordering of required signers for the transaction.
     #[prost(string, tag = "3")]
-    pub payer: std::string::String,
+    pub payer: ::prost::alloc::string::String,
     /// if set, the fee payer (either the first signer or the value of the payer field) requests that a fee grant be used
     /// to pay fees instead of the fee payer's own balance. If an appropriate fee grant does not exist or the chain does
     /// not support fee grants, this will fail
     #[prost(string, tag = "4")]
-    pub granter: std::string::String,
+    pub granter: ::prost::alloc::string::String,
 }
 /// GetTxsEventRequest is the request type for the Service.TxsByEvents
 /// RPC method.
@@ -192,10 +193,10 @@ pub struct Fee {
 pub struct GetTxsEventRequest {
     /// events is the list of transaction event type.
     #[prost(string, repeated, tag = "1")]
-    pub events: ::std::vec::Vec<std::string::String>,
+    pub events: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// pagination defines an pagination for the request.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// GetTxsEventResponse is the response type for the Service.TxsByEvents
 /// RPC method.
@@ -203,21 +204,21 @@ pub struct GetTxsEventRequest {
 pub struct GetTxsEventResponse {
     /// txs is the list of queried transactions.
     #[prost(message, repeated, tag = "1")]
-    pub txs: ::std::vec::Vec<Tx>,
+    pub txs: ::prost::alloc::vec::Vec<Tx>,
     /// tx_responses is the list of queried TxResponses.
     #[prost(message, repeated, tag = "2")]
-    pub tx_responses: ::std::vec::Vec<super::super::base::abci::v1beta1::TxResponse>,
+    pub tx_responses: ::prost::alloc::vec::Vec<super::super::base::abci::v1beta1::TxResponse>,
     /// pagination defines an pagination for the response.
     #[prost(message, optional, tag = "3")]
-    pub pagination: ::std::option::Option<super::super::base::query::v1beta1::PageResponse>,
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// BroadcastTxRequest is the request type for the Service.BroadcastTxRequest
 /// RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BroadcastTxRequest {
     /// tx_bytes is the raw transaction.
-    #[prost(bytes, tag = "1")]
-    pub tx_bytes: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub tx_bytes: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration = "BroadcastMode", tag = "2")]
     pub mode: i32,
 }
@@ -227,7 +228,7 @@ pub struct BroadcastTxRequest {
 pub struct BroadcastTxResponse {
     /// tx_response is the queried TxResponses.
     #[prost(message, optional, tag = "1")]
-    pub tx_response: ::std::option::Option<super::super::base::abci::v1beta1::TxResponse>,
+    pub tx_response: ::core::option::Option<super::super::base::abci::v1beta1::TxResponse>,
 }
 /// SimulateRequest is the request type for the Service.Simulate
 /// RPC method.
@@ -235,7 +236,7 @@ pub struct BroadcastTxResponse {
 pub struct SimulateRequest {
     /// tx is the transaction to simulate.
     #[prost(message, optional, tag = "1")]
-    pub tx: ::std::option::Option<Tx>,
+    pub tx: ::core::option::Option<Tx>,
 }
 /// SimulateResponse is the response type for the
 /// Service.SimulateRPC method.
@@ -243,10 +244,10 @@ pub struct SimulateRequest {
 pub struct SimulateResponse {
     /// gas_info is the information about gas used in the simulation.
     #[prost(message, optional, tag = "1")]
-    pub gas_info: ::std::option::Option<super::super::base::abci::v1beta1::GasInfo>,
+    pub gas_info: ::core::option::Option<super::super::base::abci::v1beta1::GasInfo>,
     /// result is the result of the simulation.
     #[prost(message, optional, tag = "2")]
-    pub result: ::std::option::Option<super::super::base::abci::v1beta1::Result>,
+    pub result: ::core::option::Option<super::super::base::abci::v1beta1::Result>,
 }
 /// GetTxRequest is the request type for the Service.GetTx
 /// RPC method.
@@ -254,17 +255,17 @@ pub struct SimulateResponse {
 pub struct GetTxRequest {
     /// hash is the tx hash to query, encoded as a hex string.
     #[prost(string, tag = "1")]
-    pub hash: std::string::String,
+    pub hash: ::prost::alloc::string::String,
 }
 /// GetTxResponse is the response type for the Service.GetTx method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTxResponse {
     /// tx is the queried transaction.
     #[prost(message, optional, tag = "1")]
-    pub tx: ::std::option::Option<Tx>,
+    pub tx: ::core::option::Option<Tx>,
     /// tx_response is the queried TxResponses.
     #[prost(message, optional, tag = "2")]
-    pub tx_response: ::std::option::Option<super::super::base::abci::v1beta1::TxResponse>,
+    pub tx_response: ::core::option::Option<super::super::base::abci::v1beta1::TxResponse>,
 }
 /// BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/cosmos-sdk-proto/src/prost/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.applications.transfer.v1.rs
@@ -5,23 +5,23 @@
 pub struct MsgTransfer {
     /// the port on which the packet will be sent
     #[prost(string, tag = "1")]
-    pub source_port: std::string::String,
+    pub source_port: ::prost::alloc::string::String,
     /// the channel by which the packet will be sent
     #[prost(string, tag = "2")]
-    pub source_channel: std::string::String,
+    pub source_channel: ::prost::alloc::string::String,
     /// the tokens to be transferred
     #[prost(message, optional, tag = "3")]
-    pub token: ::std::option::Option<super::super::super::super::cosmos::base::v1beta1::Coin>,
+    pub token: ::core::option::Option<super::super::super::super::cosmos::base::v1beta1::Coin>,
     /// the sender address
     #[prost(string, tag = "4")]
-    pub sender: std::string::String,
+    pub sender: ::prost::alloc::string::String,
     /// the recipient address on the destination chain
     #[prost(string, tag = "5")]
-    pub receiver: std::string::String,
+    pub receiver: ::prost::alloc::string::String,
     /// Timeout height relative to the current block height.
     /// The timeout is disabled when set to 0.
     #[prost(message, optional, tag = "6")]
-    pub timeout_height: ::std::option::Option<super::super::super::core::client::v1::Height>,
+    pub timeout_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
     /// Timeout timestamp (in nanoseconds) relative to the current block timestamp.
     /// The timeout is disabled when set to 0.
     #[prost(uint64, tag = "7")]
@@ -37,16 +37,16 @@ pub struct MsgTransferResponse {}
 pub struct FungibleTokenPacketData {
     /// the token denomination to be transferred
     #[prost(string, tag = "1")]
-    pub denom: std::string::String,
+    pub denom: ::prost::alloc::string::String,
     /// the token amount to be transferred
     #[prost(uint64, tag = "2")]
     pub amount: u64,
     /// the sender address
     #[prost(string, tag = "3")]
-    pub sender: std::string::String,
+    pub sender: ::prost::alloc::string::String,
     /// the recipient address on the destination chain
     #[prost(string, tag = "4")]
-    pub receiver: std::string::String,
+    pub receiver: ::prost::alloc::string::String,
 }
 /// DenomTrace contains the base denomination for ICS20 fungible tokens and the
 /// source tracing information path.
@@ -55,10 +55,10 @@ pub struct DenomTrace {
     /// path defines the chain of port/channel identifiers used for tracing the
     /// source of the fungible token.
     #[prost(string, tag = "1")]
-    pub path: std::string::String,
+    pub path: ::prost::alloc::string::String,
     /// base denomination of the relayed fungible token.
     #[prost(string, tag = "2")]
-    pub base_denom: std::string::String,
+    pub base_denom: ::prost::alloc::string::String,
 }
 /// Params defines the set of IBC transfer parameters.
 /// NOTE: To prevent a single token from being transferred, set the
@@ -81,7 +81,7 @@ pub struct Params {
 pub struct QueryDenomTraceRequest {
     /// hash (in hex format) of the denomination trace information.
     #[prost(string, tag = "1")]
-    pub hash: std::string::String,
+    pub hash: ::prost::alloc::string::String,
 }
 /// QueryDenomTraceResponse is the response type for the Query/DenomTrace RPC
 /// method.
@@ -89,7 +89,7 @@ pub struct QueryDenomTraceRequest {
 pub struct QueryDenomTraceResponse {
     /// denom_trace returns the requested denomination trace information.
     #[prost(message, optional, tag = "1")]
-    pub denom_trace: ::std::option::Option<DenomTrace>,
+    pub denom_trace: ::core::option::Option<DenomTrace>,
 }
 /// QueryConnectionsRequest is the request type for the Query/DenomTraces RPC
 /// method
@@ -97,7 +97,7 @@ pub struct QueryDenomTraceResponse {
 pub struct QueryDenomTracesRequest {
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "1")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -107,10 +107,10 @@ pub struct QueryDenomTracesRequest {
 pub struct QueryDenomTracesResponse {
     /// denom_traces returns all denominations trace information.
     #[prost(message, repeated, tag = "1")]
-    pub denom_traces: ::std::vec::Vec<DenomTrace>,
+    pub denom_traces: ::prost::alloc::vec::Vec<DenomTrace>,
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
 }
@@ -122,15 +122,15 @@ pub struct QueryParamsRequest {}
 pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }
 /// GenesisState defines the ibc-transfer genesis state
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub denom_traces: ::std::vec::Vec<DenomTrace>,
+    pub denom_traces: ::prost::alloc::vec::Vec<DenomTrace>,
     #[prost(message, optional, tag = "3")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.core.channel.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.channel.v1.rs
@@ -11,14 +11,14 @@ pub struct Channel {
     pub ordering: i32,
     /// counterparty channel end
     #[prost(message, optional, tag = "3")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     /// list of connection identifiers, in order, along which packets sent on
     /// this channel will travel
     #[prost(string, repeated, tag = "4")]
-    pub connection_hops: ::std::vec::Vec<std::string::String>,
+    pub connection_hops: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// opaque channel version, which is agreed upon during the handshake
     #[prost(string, tag = "5")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
 }
 /// IdentifiedChannel defines a channel with additional port and channel
 /// identifier fields.
@@ -32,30 +32,30 @@ pub struct IdentifiedChannel {
     pub ordering: i32,
     /// counterparty channel end
     #[prost(message, optional, tag = "3")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     /// list of connection identifiers, in order, along which packets sent on
     /// this channel will travel
     #[prost(string, repeated, tag = "4")]
-    pub connection_hops: ::std::vec::Vec<std::string::String>,
+    pub connection_hops: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// opaque channel version, which is agreed upon during the handshake
     #[prost(string, tag = "5")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     /// port identifier
     #[prost(string, tag = "6")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel identifier
     #[prost(string, tag = "7")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
 }
 /// Counterparty defines a channel end counterparty
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Counterparty {
     /// port on the counterparty chain which owns the other end of the channel.
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel end on the counterparty chain
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
 }
 /// Packet defines a type that carries data across different chains through IBC
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -67,22 +67,22 @@ pub struct Packet {
     pub sequence: u64,
     /// identifies the port on the sending chain.
     #[prost(string, tag = "2")]
-    pub source_port: std::string::String,
+    pub source_port: ::prost::alloc::string::String,
     /// identifies the channel end on the sending chain.
     #[prost(string, tag = "3")]
-    pub source_channel: std::string::String,
+    pub source_channel: ::prost::alloc::string::String,
     /// identifies the port on the receiving chain.
     #[prost(string, tag = "4")]
-    pub destination_port: std::string::String,
+    pub destination_port: ::prost::alloc::string::String,
     /// identifies the channel end on the receiving chain.
     #[prost(string, tag = "5")]
-    pub destination_channel: std::string::String,
+    pub destination_channel: ::prost::alloc::string::String,
     /// actual opaque bytes transferred directly to the application module
-    #[prost(bytes, tag = "6")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     /// block height after which the packet times out
     #[prost(message, optional, tag = "7")]
-    pub timeout_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub timeout_height: ::core::option::Option<super::super::client::v1::Height>,
     /// block timestamp (in nanoseconds) after which the packet times out
     #[prost(uint64, tag = "8")]
     pub timeout_timestamp: u64,
@@ -95,16 +95,16 @@ pub struct Packet {
 pub struct PacketState {
     /// channel port identifier.
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier.
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// packet sequence.
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
     /// embedded data that represents packet state.
-    #[prost(bytes, tag = "4")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// Acknowledgement is the recommended acknowledgement format to be used by
 /// app-specific protocols.
@@ -117,16 +117,17 @@ pub struct PacketState {
 pub struct Acknowledgement {
     /// response contains either a result or an error and must be non-empty
     #[prost(oneof = "acknowledgement::Response", tags = "21, 22")]
-    pub response: ::std::option::Option<acknowledgement::Response>,
+    pub response: ::core::option::Option<acknowledgement::Response>,
 }
+/// Nested message and enum types in `Acknowledgement`.
 pub mod acknowledgement {
     /// response contains either a result or an error and must be non-empty
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Response {
         #[prost(bytes, tag = "21")]
-        Result(std::vec::Vec<u8>),
+        Result(::prost::alloc::vec::Vec<u8>),
         #[prost(string, tag = "22")]
-        Error(std::string::String),
+        Error(::prost::alloc::string::String),
     }
 }
 /// State defines if a channel is in one of the following states:
@@ -163,19 +164,19 @@ pub enum Order {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
     #[prost(message, repeated, tag = "1")]
-    pub channels: ::std::vec::Vec<IdentifiedChannel>,
+    pub channels: ::prost::alloc::vec::Vec<IdentifiedChannel>,
     #[prost(message, repeated, tag = "2")]
-    pub acknowledgements: ::std::vec::Vec<PacketState>,
+    pub acknowledgements: ::prost::alloc::vec::Vec<PacketState>,
     #[prost(message, repeated, tag = "3")]
-    pub commitments: ::std::vec::Vec<PacketState>,
+    pub commitments: ::prost::alloc::vec::Vec<PacketState>,
     #[prost(message, repeated, tag = "4")]
-    pub receipts: ::std::vec::Vec<PacketState>,
+    pub receipts: ::prost::alloc::vec::Vec<PacketState>,
     #[prost(message, repeated, tag = "5")]
-    pub send_sequences: ::std::vec::Vec<PacketSequence>,
+    pub send_sequences: ::prost::alloc::vec::Vec<PacketSequence>,
     #[prost(message, repeated, tag = "6")]
-    pub recv_sequences: ::std::vec::Vec<PacketSequence>,
+    pub recv_sequences: ::prost::alloc::vec::Vec<PacketSequence>,
     #[prost(message, repeated, tag = "7")]
-    pub ack_sequences: ::std::vec::Vec<PacketSequence>,
+    pub ack_sequences: ::prost::alloc::vec::Vec<PacketSequence>,
     /// the sequence for the next generated channel identifier
     #[prost(uint64, tag = "8")]
     pub next_channel_sequence: u64,
@@ -185,9 +186,9 @@ pub struct GenesisState {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketSequence {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
 }
@@ -196,11 +197,11 @@ pub struct PacketSequence {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenInit {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub channel: ::std::option::Option<Channel>,
+    pub channel: ::core::option::Option<Channel>,
     #[prost(string, tag = "3")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelOpenInitResponse defines the Msg/ChannelOpenInit response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -210,21 +211,21 @@ pub struct MsgChannelOpenInitResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenTry {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// in the case of crossing hello's, when both chains call OpenInit, we need the channel identifier
     /// of the previous channel in state INIT
     #[prost(string, tag = "2")]
-    pub previous_channel_id: std::string::String,
+    pub previous_channel_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "3")]
-    pub channel: ::std::option::Option<Channel>,
+    pub channel: ::core::option::Option<Channel>,
     #[prost(string, tag = "4")]
-    pub counterparty_version: std::string::String,
-    #[prost(bytes, tag = "5")]
-    pub proof_init: std::vec::Vec<u8>,
+    pub counterparty_version: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "5")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "6")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "7")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelOpenTryResponse defines the Msg/ChannelOpenTry response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -234,19 +235,19 @@ pub struct MsgChannelOpenTryResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenAck {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub counterparty_channel_id: std::string::String,
+    pub counterparty_channel_id: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub counterparty_version: std::string::String,
-    #[prost(bytes, tag = "5")]
-    pub proof_try: std::vec::Vec<u8>,
+    pub counterparty_version: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "5")]
+    pub proof_try: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "6")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "7")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelOpenAckResponse defines the Msg/ChannelOpenAck response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -256,15 +257,15 @@ pub struct MsgChannelOpenAckResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenConfirm {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
-    #[prost(bytes, tag = "3")]
-    pub proof_ack: std::vec::Vec<u8>,
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "5")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -274,11 +275,11 @@ pub struct MsgChannelOpenConfirmResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelCloseInit {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelCloseInitResponse defines the Msg/ChannelCloseInit response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -288,15 +289,15 @@ pub struct MsgChannelCloseInitResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelCloseConfirm {
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
-    #[prost(bytes, tag = "3")]
-    pub proof_init: std::vec::Vec<u8>,
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "5")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -305,13 +306,13 @@ pub struct MsgChannelCloseConfirmResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgRecvPacket {
     #[prost(message, optional, tag = "1")]
-    pub packet: ::std::option::Option<Packet>,
-    #[prost(bytes, tag = "2")]
-    pub proof_commitment: std::vec::Vec<u8>,
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof_commitment: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "4")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgRecvPacketResponse defines the Msg/RecvPacket response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -320,15 +321,15 @@ pub struct MsgRecvPacketResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgTimeout {
     #[prost(message, optional, tag = "1")]
-    pub packet: ::std::option::Option<Packet>,
-    #[prost(bytes, tag = "2")]
-    pub proof_unreceived: std::vec::Vec<u8>,
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(uint64, tag = "4")]
     pub next_sequence_recv: u64,
     #[prost(string, tag = "5")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgTimeoutResponse defines the Msg/Timeout response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -337,17 +338,17 @@ pub struct MsgTimeoutResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgTimeoutOnClose {
     #[prost(message, optional, tag = "1")]
-    pub packet: ::std::option::Option<Packet>,
-    #[prost(bytes, tag = "2")]
-    pub proof_unreceived: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub proof_close: std::vec::Vec<u8>,
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof_close: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(uint64, tag = "5")]
     pub next_sequence_recv: u64,
     #[prost(string, tag = "6")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgTimeoutOnCloseResponse defines the Msg/TimeoutOnClose response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -356,15 +357,15 @@ pub struct MsgTimeoutOnCloseResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgAcknowledgement {
     #[prost(message, optional, tag = "1")]
-    pub packet: ::std::option::Option<Packet>,
-    #[prost(bytes, tag = "2")]
-    pub acknowledgement: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub proof_acked: std::vec::Vec<u8>,
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof_acked: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "5")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgAcknowledgementResponse defines the Msg/Acknowledgement response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -374,10 +375,10 @@ pub struct MsgAcknowledgementResponse {}
 pub struct QueryChannelRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
 }
 /// QueryChannelResponse is the response type for the Query/Channel RPC method.
 /// Besides the Channel end, it includes a proof and the height from which the
@@ -386,20 +387,20 @@ pub struct QueryChannelRequest {
 pub struct QueryChannelResponse {
     /// channel associated with the request identifiers
     #[prost(message, optional, tag = "1")]
-    pub channel: ::std::option::Option<Channel>,
+    pub channel: ::core::option::Option<Channel>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryChannelsRequest is the request type for the Query/Channels RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryChannelsRequest {
     /// pagination request
     #[prost(message, optional, tag = "1")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -408,15 +409,15 @@ pub struct QueryChannelsRequest {
 pub struct QueryChannelsResponse {
     /// list of stored channels of the chain.
     #[prost(message, repeated, tag = "1")]
-    pub channels: ::std::vec::Vec<IdentifiedChannel>,
+    pub channels: ::prost::alloc::vec::Vec<IdentifiedChannel>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
     /// query block height
     #[prost(message, optional, tag = "3")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryConnectionChannelsRequest is the request type for the
 /// Query/QueryConnectionChannels RPC method
@@ -424,10 +425,10 @@ pub struct QueryChannelsResponse {
 pub struct QueryConnectionChannelsRequest {
     /// connection unique identifier
     #[prost(string, tag = "1")]
-    pub connection: std::string::String,
+    pub connection: ::prost::alloc::string::String,
     /// pagination request
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -437,15 +438,15 @@ pub struct QueryConnectionChannelsRequest {
 pub struct QueryConnectionChannelsResponse {
     /// list of channels associated with a connection.
     #[prost(message, repeated, tag = "1")]
-    pub channels: ::std::vec::Vec<IdentifiedChannel>,
+    pub channels: ::prost::alloc::vec::Vec<IdentifiedChannel>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
     /// query block height
     #[prost(message, optional, tag = "3")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryChannelClientStateRequest is the request type for the Query/ClientState
 /// RPC method
@@ -453,10 +454,10 @@ pub struct QueryConnectionChannelsResponse {
 pub struct QueryChannelClientStateRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
 }
 /// QueryChannelClientStateResponse is the Response type for the
 /// Query/QueryChannelClientState RPC method
@@ -465,13 +466,13 @@ pub struct QueryChannelClientStateResponse {
     /// client state associated with the channel
     #[prost(message, optional, tag = "1")]
     pub identified_client_state:
-        ::std::option::Option<super::super::client::v1::IdentifiedClientState>,
+        ::core::option::Option<super::super::client::v1::IdentifiedClientState>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryChannelConsensusStateRequest is the request type for the
 /// Query/ConsensusState RPC method
@@ -479,10 +480,10 @@ pub struct QueryChannelClientStateResponse {
 pub struct QueryChannelConsensusStateRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// revision number of the consensus state
     #[prost(uint64, tag = "3")]
     pub revision_number: u64,
@@ -496,16 +497,16 @@ pub struct QueryChannelConsensusStateRequest {
 pub struct QueryChannelConsensusStateResponse {
     /// consensus state associated with the channel
     #[prost(message, optional, tag = "1")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
     /// client ID associated with the consensus state
     #[prost(string, tag = "2")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// merkle proof of existence
-    #[prost(bytes, tag = "3")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryPacketCommitmentRequest is the request type for the
 /// Query/PacketCommitment RPC method
@@ -513,10 +514,10 @@ pub struct QueryChannelConsensusStateResponse {
 pub struct QueryPacketCommitmentRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
@@ -527,14 +528,14 @@ pub struct QueryPacketCommitmentRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPacketCommitmentResponse {
     /// packet associated with the request fields
-    #[prost(bytes, tag = "1")]
-    pub commitment: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub commitment: ::prost::alloc::vec::Vec<u8>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryPacketCommitmentsRequest is the request type for the
 /// Query/QueryPacketCommitments RPC method
@@ -542,13 +543,13 @@ pub struct QueryPacketCommitmentResponse {
 pub struct QueryPacketCommitmentsRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// pagination request
     #[prost(message, optional, tag = "3")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -557,15 +558,15 @@ pub struct QueryPacketCommitmentsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPacketCommitmentsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub commitments: ::std::vec::Vec<PacketState>,
+    pub commitments: ::prost::alloc::vec::Vec<PacketState>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
     /// query block height
     #[prost(message, optional, tag = "3")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryPacketReceiptRequest is the request type for the
 /// Query/PacketReceipt RPC method
@@ -573,10 +574,10 @@ pub struct QueryPacketCommitmentsResponse {
 pub struct QueryPacketReceiptRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
@@ -590,11 +591,11 @@ pub struct QueryPacketReceiptResponse {
     #[prost(bool, tag = "2")]
     pub received: bool,
     /// merkle proof of existence
-    #[prost(bytes, tag = "3")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryPacketAcknowledgementRequest is the request type for the
 /// Query/PacketAcknowledgement RPC method
@@ -602,10 +603,10 @@ pub struct QueryPacketReceiptResponse {
 pub struct QueryPacketAcknowledgementRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
@@ -616,14 +617,14 @@ pub struct QueryPacketAcknowledgementRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPacketAcknowledgementResponse {
     /// packet associated with the request fields
-    #[prost(bytes, tag = "1")]
-    pub acknowledgement: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryPacketAcknowledgementsRequest is the request type for the
 /// Query/QueryPacketCommitments RPC method
@@ -631,13 +632,13 @@ pub struct QueryPacketAcknowledgementResponse {
 pub struct QueryPacketAcknowledgementsRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// pagination request
     #[prost(message, optional, tag = "3")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -646,15 +647,15 @@ pub struct QueryPacketAcknowledgementsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPacketAcknowledgementsResponse {
     #[prost(message, repeated, tag = "1")]
-    pub acknowledgements: ::std::vec::Vec<PacketState>,
+    pub acknowledgements: ::prost::alloc::vec::Vec<PacketState>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
     /// query block height
     #[prost(message, optional, tag = "3")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryUnreceivedPacketsRequest is the request type for the
 /// Query/UnreceivedPackets RPC method
@@ -662,13 +663,13 @@ pub struct QueryPacketAcknowledgementsResponse {
 pub struct QueryUnreceivedPacketsRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// list of packet sequences
     #[prost(uint64, repeated, tag = "3")]
-    pub packet_commitment_sequences: ::std::vec::Vec<u64>,
+    pub packet_commitment_sequences: ::prost::alloc::vec::Vec<u64>,
 }
 /// QueryUnreceivedPacketsResponse is the response type for the
 /// Query/UnreceivedPacketCommitments RPC method
@@ -676,10 +677,10 @@ pub struct QueryUnreceivedPacketsRequest {
 pub struct QueryUnreceivedPacketsResponse {
     /// list of unreceived packet sequences
     #[prost(uint64, repeated, tag = "1")]
-    pub sequences: ::std::vec::Vec<u64>,
+    pub sequences: ::prost::alloc::vec::Vec<u64>,
     /// query block height
     #[prost(message, optional, tag = "2")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryUnreceivedAcks is the request type for the
 /// Query/UnreceivedAcks RPC method
@@ -687,13 +688,13 @@ pub struct QueryUnreceivedPacketsResponse {
 pub struct QueryUnreceivedAcksRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
     /// list of acknowledgement sequences
     #[prost(uint64, repeated, tag = "3")]
-    pub packet_ack_sequences: ::std::vec::Vec<u64>,
+    pub packet_ack_sequences: ::prost::alloc::vec::Vec<u64>,
 }
 /// QueryUnreceivedAcksResponse is the response type for the
 /// Query/UnreceivedAcks RPC method
@@ -701,10 +702,10 @@ pub struct QueryUnreceivedAcksRequest {
 pub struct QueryUnreceivedAcksResponse {
     /// list of unreceived acknowledgement sequences
     #[prost(uint64, repeated, tag = "1")]
-    pub sequences: ::std::vec::Vec<u64>,
+    pub sequences: ::prost::alloc::vec::Vec<u64>,
     /// query block height
     #[prost(message, optional, tag = "2")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryNextSequenceReceiveRequest is the request type for the
 /// Query/QueryNextSequenceReceiveRequest RPC method
@@ -712,10 +713,10 @@ pub struct QueryUnreceivedAcksResponse {
 pub struct QueryNextSequenceReceiveRequest {
     /// port unique identifier
     #[prost(string, tag = "1")]
-    pub port_id: std::string::String,
+    pub port_id: ::prost::alloc::string::String,
     /// channel unique identifier
     #[prost(string, tag = "2")]
-    pub channel_id: std::string::String,
+    pub channel_id: ::prost::alloc::string::String,
 }
 /// QuerySequenceResponse is the request type for the
 /// Query/QueryNextSequenceReceiveResponse RPC method
@@ -725,9 +726,9 @@ pub struct QueryNextSequenceReceiveResponse {
     #[prost(uint64, tag = "1")]
     pub next_sequence_receive: u64,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.core.client.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.client.v1.rs
@@ -4,20 +4,20 @@
 pub struct IdentifiedClientState {
     /// client identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// client state
     #[prost(message, optional, tag = "2")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
 }
 /// ConsensusStateWithHeight defines a consensus state with an additional height field.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusStateWithHeight {
     /// consensus state height
     #[prost(message, optional, tag = "1")]
-    pub height: ::std::option::Option<Height>,
+    pub height: ::core::option::Option<Height>,
     /// consensus state
     #[prost(message, optional, tag = "2")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
 }
 /// ClientConsensusStates defines all the stored consensus states for a given
 /// client.
@@ -25,10 +25,10 @@ pub struct ConsensusStateWithHeight {
 pub struct ClientConsensusStates {
     /// client identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// consensus states and their heights associated with the client
     #[prost(message, repeated, tag = "2")]
-    pub consensus_states: ::std::vec::Vec<ConsensusStateWithHeight>,
+    pub consensus_states: ::prost::alloc::vec::Vec<ConsensusStateWithHeight>,
 }
 /// ClientUpdateProposal is a governance proposal. If it passes, the client is
 /// updated with the provided header. The update may fail if the header is not
@@ -37,16 +37,16 @@ pub struct ClientConsensusStates {
 pub struct ClientUpdateProposal {
     /// the title of the update proposal
     #[prost(string, tag = "1")]
-    pub title: std::string::String,
+    pub title: ::prost::alloc::string::String,
     /// the description of the proposal
     #[prost(string, tag = "2")]
-    pub description: std::string::String,
+    pub description: ::prost::alloc::string::String,
     /// the client identifier for the client to be updated if the proposal passes
     #[prost(string, tag = "3")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// the header used to update the client if the proposal passes
     #[prost(message, optional, tag = "4")]
-    pub header: ::std::option::Option<::prost_types::Any>,
+    pub header: ::core::option::Option<::prost_types::Any>,
 }
 /// Height is a monotonically increasing data type
 /// that can be compared against another Height for the purposes of updating and
@@ -71,22 +71,22 @@ pub struct Height {
 pub struct Params {
     /// allowed_clients defines the list of allowed client state types.
     #[prost(string, repeated, tag = "1")]
-    pub allowed_clients: ::std::vec::Vec<std::string::String>,
+    pub allowed_clients: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// GenesisState defines the ibc client submodule's genesis state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
     /// client states with their corresponding identifiers
     #[prost(message, repeated, tag = "1")]
-    pub clients: ::std::vec::Vec<IdentifiedClientState>,
+    pub clients: ::prost::alloc::vec::Vec<IdentifiedClientState>,
     /// consensus states from each client
     #[prost(message, repeated, tag = "2")]
-    pub clients_consensus: ::std::vec::Vec<ClientConsensusStates>,
+    pub clients_consensus: ::prost::alloc::vec::Vec<ClientConsensusStates>,
     /// metadata from each client
     #[prost(message, repeated, tag = "3")]
-    pub clients_metadata: ::std::vec::Vec<IdentifiedGenesisMetadata>,
+    pub clients_metadata: ::prost::alloc::vec::Vec<IdentifiedGenesisMetadata>,
     #[prost(message, optional, tag = "4")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
     /// create localhost on initialization
     #[prost(bool, tag = "5")]
     pub create_localhost: bool,
@@ -99,33 +99,33 @@ pub struct GenesisState {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisMetadata {
     /// store key of metadata without clientID-prefix
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     /// metadata value
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// IdentifiedGenesisMetadata has the client metadata with the corresponding client id.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentifiedGenesisMetadata {
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub client_metadata: ::std::vec::Vec<GenesisMetadata>,
+    pub client_metadata: ::prost::alloc::vec::Vec<GenesisMetadata>,
 }
 /// MsgCreateClient defines a message to create an IBC client
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCreateClient {
     /// light client state
     #[prost(message, optional, tag = "1")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
     /// consensus state associated with the client that corresponds to a given
     /// height.
     #[prost(message, optional, tag = "2")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
     /// signer address
     #[prost(string, tag = "3")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgCreateClientResponse defines the Msg/CreateClient response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -136,13 +136,13 @@ pub struct MsgCreateClientResponse {}
 pub struct MsgUpdateClient {
     /// client unique identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// header to update the light client
     #[prost(message, optional, tag = "2")]
-    pub header: ::std::option::Option<::prost_types::Any>,
+    pub header: ::core::option::Option<::prost_types::Any>,
     /// signer address
     #[prost(string, tag = "3")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgUpdateClientResponse defines the Msg/UpdateClient response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -152,22 +152,22 @@ pub struct MsgUpdateClientResponse {}
 pub struct MsgUpgradeClient {
     /// client unique identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// upgraded client state
     #[prost(message, optional, tag = "2")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
     /// upgraded consensus state, only contains enough information to serve as a basis of trust in update logic
     #[prost(message, optional, tag = "3")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
     /// proof that old chain committed to new client
-    #[prost(bytes, tag = "4")]
-    pub proof_upgrade_client: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub proof_upgrade_client: ::prost::alloc::vec::Vec<u8>,
     /// proof that old chain committed to new consensus state
-    #[prost(bytes, tag = "5")]
-    pub proof_upgrade_consensus_state: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub proof_upgrade_consensus_state: ::prost::alloc::vec::Vec<u8>,
     /// signer address
     #[prost(string, tag = "6")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgUpgradeClientResponse defines the Msg/UpgradeClient response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -178,13 +178,13 @@ pub struct MsgUpgradeClientResponse {}
 pub struct MsgSubmitMisbehaviour {
     /// client unique identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// misbehaviour used for freezing the light client
     #[prost(message, optional, tag = "2")]
-    pub misbehaviour: ::std::option::Option<::prost_types::Any>,
+    pub misbehaviour: ::core::option::Option<::prost_types::Any>,
     /// signer address
     #[prost(string, tag = "3")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -195,7 +195,7 @@ pub struct MsgSubmitMisbehaviourResponse {}
 pub struct QueryClientStateRequest {
     /// client state unique identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
 }
 /// QueryClientStateResponse is the response type for the Query/ClientState RPC
 /// method. Besides the client state, it includes a proof and the height from
@@ -204,13 +204,13 @@ pub struct QueryClientStateRequest {
 pub struct QueryClientStateResponse {
     /// client state associated with the request identifier
     #[prost(message, optional, tag = "1")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<Height>,
+    pub proof_height: ::core::option::Option<Height>,
 }
 /// QueryClientStatesRequest is the request type for the Query/ClientStates RPC
 /// method
@@ -218,7 +218,7 @@ pub struct QueryClientStateResponse {
 pub struct QueryClientStatesRequest {
     /// pagination request
     #[prost(message, optional, tag = "1")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -228,10 +228,10 @@ pub struct QueryClientStatesRequest {
 pub struct QueryClientStatesResponse {
     /// list of stored ClientStates of the chain.
     #[prost(message, repeated, tag = "1")]
-    pub client_states: ::std::vec::Vec<IdentifiedClientState>,
+    pub client_states: ::prost::alloc::vec::Vec<IdentifiedClientState>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
 }
@@ -242,7 +242,7 @@ pub struct QueryClientStatesResponse {
 pub struct QueryConsensusStateRequest {
     /// client identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// consensus state revision number
     #[prost(uint64, tag = "2")]
     pub revision_number: u64,
@@ -260,13 +260,13 @@ pub struct QueryConsensusStateRequest {
 pub struct QueryConsensusStateResponse {
     /// consensus state associated with the client identifier at the given height
     #[prost(message, optional, tag = "1")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<Height>,
+    pub proof_height: ::core::option::Option<Height>,
 }
 /// QueryConsensusStatesRequest is the request type for the Query/ConsensusStates
 /// RPC method.
@@ -274,10 +274,10 @@ pub struct QueryConsensusStateResponse {
 pub struct QueryConsensusStatesRequest {
     /// client identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// pagination request
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -287,10 +287,10 @@ pub struct QueryConsensusStatesRequest {
 pub struct QueryConsensusStatesResponse {
     /// consensus states associated with the identifier
     #[prost(message, repeated, tag = "1")]
-    pub consensus_states: ::std::vec::Vec<ConsensusStateWithHeight>,
+    pub consensus_states: ::prost::alloc::vec::Vec<ConsensusStateWithHeight>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
 }
@@ -302,5 +302,5 @@ pub struct QueryClientParamsRequest {}
 pub struct QueryClientParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
-    pub params: ::std::option::Option<Params>,
+    pub params: ::core::option::Option<Params>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.core.commitment.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.commitment.v1.rs
@@ -2,16 +2,16 @@
 /// In the Cosmos SDK, the AppHash of a block header becomes the root.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerkleRoot {
-    #[prost(bytes, tag = "1")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// MerklePrefix is merkle path prefixed to the key.
 /// The constructed key from the Path and the key will be append(Path.KeyPath,
 /// append(Path.KeyPrefix, key...))
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerklePrefix {
-    #[prost(bytes, tag = "1")]
-    pub key_prefix: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key_prefix: ::prost::alloc::vec::Vec<u8>,
 }
 /// MerklePath is the path used to verify commitment proofs, which can be an
 /// arbitrary structured object (defined by a commitment type).
@@ -19,7 +19,7 @@ pub struct MerklePrefix {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerklePath {
     #[prost(string, repeated, tag = "1")]
-    pub key_path: ::std::vec::Vec<std::string::String>,
+    pub key_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// MerkleProof is a wrapper type over a chain of CommitmentProofs.
 /// It demonstrates membership or non-membership for an element or set of
@@ -29,5 +29,5 @@ pub struct MerklePath {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerkleProof {
     #[prost(message, repeated, tag = "1")]
-    pub proofs: ::std::vec::Vec<super::super::super::super::ics23::CommitmentProof>,
+    pub proofs: ::prost::alloc::vec::Vec<super::super::super::super::ics23::CommitmentProof>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.core.connection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.connection.v1.rs
@@ -9,17 +9,17 @@
 pub struct ConnectionEnd {
     /// client associated with this connection.
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// IBC version which can be utilised to determine encodings or protocols for
     /// channels or packets utilising this connection.
     #[prost(message, repeated, tag = "2")]
-    pub versions: ::std::vec::Vec<Version>,
+    pub versions: ::prost::alloc::vec::Vec<Version>,
     /// current state of the connection end.
     #[prost(enumeration = "State", tag = "3")]
     pub state: i32,
     /// counterparty chain associated with this connection.
     #[prost(message, optional, tag = "4")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     /// delay period that must pass before a consensus state can be used for packet-verification
     /// NOTE: delay period logic is only implemented by some clients.
     #[prost(uint64, tag = "5")]
@@ -31,20 +31,20 @@ pub struct ConnectionEnd {
 pub struct IdentifiedConnection {
     /// connection identifier.
     #[prost(string, tag = "1")]
-    pub id: std::string::String,
+    pub id: ::prost::alloc::string::String,
     /// client associated with this connection.
     #[prost(string, tag = "2")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// IBC version which can be utilised to determine encodings or protocols for
     /// channels or packets utilising this connection
     #[prost(message, repeated, tag = "3")]
-    pub versions: ::std::vec::Vec<Version>,
+    pub versions: ::prost::alloc::vec::Vec<Version>,
     /// current state of the connection end.
     #[prost(enumeration = "State", tag = "4")]
     pub state: i32,
     /// counterparty chain associated with this connection.
     #[prost(message, optional, tag = "5")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     /// delay period associated with this connection.
     #[prost(uint64, tag = "6")]
     pub delay_period: u64,
@@ -55,31 +55,31 @@ pub struct Counterparty {
     /// identifies the client on the counterparty chain associated with a given
     /// connection.
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// identifies the connection end on the counterparty chain associated with a
     /// given connection.
     #[prost(string, tag = "2")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
     /// commitment merkle prefix of the counterparty chain.
     #[prost(message, optional, tag = "3")]
-    pub prefix: ::std::option::Option<super::super::commitment::v1::MerklePrefix>,
+    pub prefix: ::core::option::Option<super::super::commitment::v1::MerklePrefix>,
 }
 /// ClientPaths define all the connection paths for a client state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientPaths {
     /// list of connection paths
     #[prost(string, repeated, tag = "1")]
-    pub paths: ::std::vec::Vec<std::string::String>,
+    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// ConnectionPaths define all the connection paths for a given client state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionPaths {
     /// client state unique identifier
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// list of connection paths
     #[prost(string, repeated, tag = "2")]
-    pub paths: ::std::vec::Vec<std::string::String>,
+    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Version defines the versioning scheme used to negotiate the IBC verison in
 /// the connection handshake.
@@ -87,10 +87,10 @@ pub struct ConnectionPaths {
 pub struct Version {
     /// unique version identifier
     #[prost(string, tag = "1")]
-    pub identifier: std::string::String,
+    pub identifier: ::prost::alloc::string::String,
     /// list of features compatible with the specified identifier
     #[prost(string, repeated, tag = "2")]
-    pub features: ::std::vec::Vec<std::string::String>,
+    pub features: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// State defines if a connection is in one of the following states:
 /// INIT, TRYOPEN, OPEN or UNINITIALIZED.
@@ -111,9 +111,9 @@ pub enum State {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
     #[prost(message, repeated, tag = "1")]
-    pub connections: ::std::vec::Vec<IdentifiedConnection>,
+    pub connections: ::prost::alloc::vec::Vec<IdentifiedConnection>,
     #[prost(message, repeated, tag = "2")]
-    pub client_connection_paths: ::std::vec::Vec<ConnectionPaths>,
+    pub client_connection_paths: ::prost::alloc::vec::Vec<ConnectionPaths>,
     /// the sequence for the next generated connection identifier
     #[prost(uint64, tag = "3")]
     pub next_connection_sequence: u64,
@@ -123,15 +123,15 @@ pub struct GenesisState {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenInit {
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     #[prost(message, optional, tag = "3")]
-    pub version: ::std::option::Option<Version>,
+    pub version: ::core::option::Option<Version>,
     #[prost(uint64, tag = "4")]
     pub delay_period: u64,
     #[prost(string, tag = "5")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -141,35 +141,35 @@ pub struct MsgConnectionOpenInitResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenTry {
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// in the case of crossing hello's, when both chains call OpenInit, we need the connection identifier
     /// of the previous connection in state INIT
     #[prost(string, tag = "2")]
-    pub previous_connection_id: std::string::String,
+    pub previous_connection_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "3")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
     #[prost(message, optional, tag = "4")]
-    pub counterparty: ::std::option::Option<Counterparty>,
+    pub counterparty: ::core::option::Option<Counterparty>,
     #[prost(uint64, tag = "5")]
     pub delay_period: u64,
     #[prost(message, repeated, tag = "6")]
-    pub counterparty_versions: ::std::vec::Vec<Version>,
+    pub counterparty_versions: ::prost::alloc::vec::Vec<Version>,
     #[prost(message, optional, tag = "7")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     /// proof of the initialization the connection on Chain A: `UNITIALIZED ->
     /// INIT`
-    #[prost(bytes, tag = "8")]
-    pub proof_init: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "8")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
     /// proof of client state included in message
-    #[prost(bytes, tag = "9")]
-    pub proof_client: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "9")]
+    pub proof_client: ::prost::alloc::vec::Vec<u8>,
     /// proof of client consensus state
-    #[prost(bytes, tag = "10")]
-    pub proof_consensus: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "10")]
+    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "11")]
-    pub consensus_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "12")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgConnectionOpenTryResponse defines the Msg/ConnectionOpenTry response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -179,29 +179,29 @@ pub struct MsgConnectionOpenTryResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenAck {
     #[prost(string, tag = "1")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub counterparty_connection_id: std::string::String,
+    pub counterparty_connection_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "3")]
-    pub version: ::std::option::Option<Version>,
+    pub version: ::core::option::Option<Version>,
     #[prost(message, optional, tag = "4")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
     #[prost(message, optional, tag = "5")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     /// proof of the initialization the connection on Chain B: `UNITIALIZED ->
     /// TRYOPEN`
-    #[prost(bytes, tag = "6")]
-    pub proof_try: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    pub proof_try: ::prost::alloc::vec::Vec<u8>,
     /// proof of client state included in message
-    #[prost(bytes, tag = "7")]
-    pub proof_client: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub proof_client: ::prost::alloc::vec::Vec<u8>,
     /// proof of client consensus state
-    #[prost(bytes, tag = "8")]
-    pub proof_consensus: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "8")]
+    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "9")]
-    pub consensus_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "10")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgConnectionOpenAckResponse defines the Msg/ConnectionOpenAck response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -211,14 +211,14 @@ pub struct MsgConnectionOpenAckResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenConfirm {
     #[prost(string, tag = "1")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
     /// proof for the change of the connection state on Chain A: `INIT -> OPEN`
-    #[prost(bytes, tag = "2")]
-    pub proof_ack: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
     #[prost(string, tag = "4")]
-    pub signer: std::string::String,
+    pub signer: ::prost::alloc::string::String,
 }
 /// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm response type.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -229,7 +229,7 @@ pub struct MsgConnectionOpenConfirmResponse {}
 pub struct QueryConnectionRequest {
     /// connection unique identifier
     #[prost(string, tag = "1")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
 }
 /// QueryConnectionResponse is the response type for the Query/Connection RPC
 /// method. Besides the connection end, it includes a proof and the height from
@@ -238,20 +238,20 @@ pub struct QueryConnectionRequest {
 pub struct QueryConnectionResponse {
     /// connection associated with the request identifier
     #[prost(message, optional, tag = "1")]
-    pub connection: ::std::option::Option<ConnectionEnd>,
+    pub connection: ::core::option::Option<ConnectionEnd>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryConnectionsRequest is the request type for the Query/Connections RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryConnectionsRequest {
     #[prost(message, optional, tag = "1")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
@@ -261,15 +261,15 @@ pub struct QueryConnectionsRequest {
 pub struct QueryConnectionsResponse {
     /// list of stored connections of the chain.
     #[prost(message, repeated, tag = "1")]
-    pub connections: ::std::vec::Vec<IdentifiedConnection>,
+    pub connections: ::prost::alloc::vec::Vec<IdentifiedConnection>,
     /// pagination response
     #[prost(message, optional, tag = "2")]
-    pub pagination: ::std::option::Option<
+    pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
     /// query block height
     #[prost(message, optional, tag = "3")]
-    pub height: ::std::option::Option<super::super::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryClientConnectionsRequest is the request type for the
 /// Query/ClientConnections RPC method
@@ -277,7 +277,7 @@ pub struct QueryConnectionsResponse {
 pub struct QueryClientConnectionsRequest {
     /// client identifier associated with a connection
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
 }
 /// QueryClientConnectionsResponse is the response type for the
 /// Query/ClientConnections RPC method
@@ -285,13 +285,13 @@ pub struct QueryClientConnectionsRequest {
 pub struct QueryClientConnectionsResponse {
     /// slice of all the connection paths associated with a client.
     #[prost(string, repeated, tag = "1")]
-    pub connection_paths: ::std::vec::Vec<std::string::String>,
+    pub connection_paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was generated
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryConnectionClientStateRequest is the request type for the
 /// Query/ConnectionClientState RPC method
@@ -299,7 +299,7 @@ pub struct QueryClientConnectionsResponse {
 pub struct QueryConnectionClientStateRequest {
     /// connection identifier
     #[prost(string, tag = "1")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
 }
 /// QueryConnectionClientStateResponse is the response type for the
 /// Query/ConnectionClientState RPC method
@@ -308,13 +308,13 @@ pub struct QueryConnectionClientStateResponse {
     /// client state associated with the channel
     #[prost(message, optional, tag = "1")]
     pub identified_client_state:
-        ::std::option::Option<super::super::client::v1::IdentifiedClientState>,
+        ::core::option::Option<super::super::client::v1::IdentifiedClientState>,
     /// merkle proof of existence
-    #[prost(bytes, tag = "2")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
 /// QueryConnectionConsensusStateRequest is the request type for the
 /// Query/ConnectionConsensusState RPC method
@@ -322,7 +322,7 @@ pub struct QueryConnectionClientStateResponse {
 pub struct QueryConnectionConsensusStateRequest {
     /// connection identifier
     #[prost(string, tag = "1")]
-    pub connection_id: std::string::String,
+    pub connection_id: ::prost::alloc::string::String,
     #[prost(uint64, tag = "2")]
     pub revision_number: u64,
     #[prost(uint64, tag = "3")]
@@ -334,14 +334,14 @@ pub struct QueryConnectionConsensusStateRequest {
 pub struct QueryConnectionConsensusStateResponse {
     /// consensus state associated with the channel
     #[prost(message, optional, tag = "1")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
     /// client ID associated with the consensus state
     #[prost(string, tag = "2")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     /// merkle proof of existence
-    #[prost(bytes, tag = "3")]
-    pub proof: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub proof: ::prost::alloc::vec::Vec<u8>,
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "4")]
-    pub proof_height: ::std::option::Option<super::super::client::v1::Height>,
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.core.types.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.types.v1.rs
@@ -3,11 +3,11 @@
 pub struct GenesisState {
     /// ICS002 - Clients genesis state
     #[prost(message, optional, tag = "1")]
-    pub client_genesis: ::std::option::Option<super::super::client::v1::GenesisState>,
+    pub client_genesis: ::core::option::Option<super::super::client::v1::GenesisState>,
     /// ICS003 - Connections genesis state
     #[prost(message, optional, tag = "2")]
-    pub connection_genesis: ::std::option::Option<super::super::connection::v1::GenesisState>,
+    pub connection_genesis: ::core::option::Option<super::super::connection::v1::GenesisState>,
     /// ICS004 - Channel genesis state
     #[prost(message, optional, tag = "3")]
-    pub channel_genesis: ::std::option::Option<super::super::channel::v1::GenesisState>,
+    pub channel_genesis: ::core::option::Option<super::super::channel::v1::GenesisState>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.lightclients.localhost.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.lightclients.localhost.v1.rs
@@ -4,8 +4,8 @@
 pub struct ClientState {
     /// self chain ID
     #[prost(string, tag = "1")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     /// self latest block height
     #[prost(message, optional, tag = "2")]
-    pub height: ::std::option::Option<super::super::super::core::client::v1::Height>,
+    pub height: ::core::option::Option<super::super::super::core::client::v1::Height>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.lightclients.solomachine.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.lightclients.solomachine.v1.rs
@@ -9,7 +9,7 @@ pub struct ClientState {
     #[prost(uint64, tag = "2")]
     pub frozen_sequence: u64,
     #[prost(message, optional, tag = "3")]
-    pub consensus_state: ::std::option::Option<ConsensusState>,
+    pub consensus_state: ::core::option::Option<ConsensusState>,
     /// when set to true, will allow governance to update a solo machine client.
     /// The client will be unfrozen if it is frozen.
     #[prost(bool, tag = "4")]
@@ -21,11 +21,11 @@ pub struct ClientState {
 pub struct ConsensusState {
     /// public key of the solo machine
     #[prost(message, optional, tag = "1")]
-    pub public_key: ::std::option::Option<::prost_types::Any>,
+    pub public_key: ::core::option::Option<::prost_types::Any>,
     /// diversifier allows the same public key to be re-used across different solo machine clients
     /// (potentially on different chains) without being considered misbehaviour.
     #[prost(string, tag = "2")]
-    pub diversifier: std::string::String,
+    pub diversifier: ::prost::alloc::string::String,
     #[prost(uint64, tag = "3")]
     pub timestamp: u64,
 }
@@ -37,36 +37,36 @@ pub struct Header {
     pub sequence: u64,
     #[prost(uint64, tag = "2")]
     pub timestamp: u64,
-    #[prost(bytes, tag = "3")]
-    pub signature: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
-    pub new_public_key: ::std::option::Option<::prost_types::Any>,
+    pub new_public_key: ::core::option::Option<::prost_types::Any>,
     #[prost(string, tag = "5")]
-    pub new_diversifier: std::string::String,
+    pub new_diversifier: ::prost::alloc::string::String,
 }
 /// Misbehaviour defines misbehaviour for a solo machine which consists
 /// of a sequence and two signatures over different messages at that sequence.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Misbehaviour {
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     #[prost(uint64, tag = "2")]
     pub sequence: u64,
     #[prost(message, optional, tag = "3")]
-    pub signature_one: ::std::option::Option<SignatureAndData>,
+    pub signature_one: ::core::option::Option<SignatureAndData>,
     #[prost(message, optional, tag = "4")]
-    pub signature_two: ::std::option::Option<SignatureAndData>,
+    pub signature_two: ::core::option::Option<SignatureAndData>,
 }
 /// SignatureAndData contains a signature and the data signed over to create that
 /// signature.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureAndData {
-    #[prost(bytes, tag = "1")]
-    pub signature: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration = "DataType", tag = "2")]
     pub data_type: i32,
-    #[prost(bytes, tag = "3")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "4")]
     pub timestamp: u64,
 }
@@ -74,8 +74,8 @@ pub struct SignatureAndData {
 /// signature.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimestampedSignatureData {
-    #[prost(bytes, tag = "1")]
-    pub signature_data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature_data: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub timestamp: u64,
 }
@@ -87,90 +87,91 @@ pub struct SignBytes {
     #[prost(uint64, tag = "2")]
     pub timestamp: u64,
     #[prost(string, tag = "3")]
-    pub diversifier: std::string::String,
+    pub diversifier: ::prost::alloc::string::String,
     /// type of the data used
     #[prost(enumeration = "DataType", tag = "4")]
     pub data_type: i32,
     /// marshaled data
-    #[prost(bytes, tag = "5")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// HeaderData returns the SignBytes data for update verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeaderData {
     /// header public key
     #[prost(message, optional, tag = "1")]
-    pub new_pub_key: ::std::option::Option<::prost_types::Any>,
+    pub new_pub_key: ::core::option::Option<::prost_types::Any>,
     /// header diversifier
     #[prost(string, tag = "2")]
-    pub new_diversifier: std::string::String,
+    pub new_diversifier: ::prost::alloc::string::String,
 }
 /// ClientStateData returns the SignBytes data for client state verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientStateData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub client_state: ::std::option::Option<::prost_types::Any>,
+    pub client_state: ::core::option::Option<::prost_types::Any>,
 }
 /// ConsensusStateData returns the SignBytes data for consensus state
 /// verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusStateData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
 }
 /// ConnectionStateData returns the SignBytes data for connection state
 /// verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConnectionStateData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub connection: ::std::option::Option<super::super::super::core::connection::v1::ConnectionEnd>,
+    pub connection:
+        ::core::option::Option<super::super::super::core::connection::v1::ConnectionEnd>,
 }
 /// ChannelStateData returns the SignBytes data for channel state
 /// verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelStateData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub channel: ::std::option::Option<super::super::super::core::channel::v1::Channel>,
+    pub channel: ::core::option::Option<super::super::super::core::channel::v1::Channel>,
 }
 /// PacketCommitmentData returns the SignBytes data for packet commitment
 /// verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketCommitmentData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub commitment: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub commitment: ::prost::alloc::vec::Vec<u8>,
 }
 /// PacketAcknowledgementData returns the SignBytes data for acknowledgement
 /// verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketAcknowledgementData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub acknowledgement: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
 }
 /// PacketReceiptAbsenceData returns the SignBytes data for
 /// packet receipt absence verification.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PacketReceiptAbsenceData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
 }
 /// NextSequenceRecvData returns the SignBytes data for verification of the next
 /// sequence to be received.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextSequenceRecvData {
-    #[prost(bytes, tag = "1")]
-    pub path: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub next_seq_recv: u64,
 }

--- a/cosmos-sdk-proto/src/prost/ibc.lightclients.tendermint.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.lightclients.tendermint.v1.rs
@@ -3,35 +3,35 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientState {
     #[prost(string, tag = "1")]
-    pub chain_id: std::string::String,
+    pub chain_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub trust_level: ::std::option::Option<Fraction>,
+    pub trust_level: ::core::option::Option<Fraction>,
     /// duration of the period since the LastestTimestamp during which the
     /// submitted headers are valid for upgrade
     #[prost(message, optional, tag = "3")]
-    pub trusting_period: ::std::option::Option<::prost_types::Duration>,
+    pub trusting_period: ::core::option::Option<::prost_types::Duration>,
     /// duration of the staking unbonding period
     #[prost(message, optional, tag = "4")]
-    pub unbonding_period: ::std::option::Option<::prost_types::Duration>,
+    pub unbonding_period: ::core::option::Option<::prost_types::Duration>,
     /// defines how much new (untrusted) header's Time can drift into the future.
     #[prost(message, optional, tag = "5")]
-    pub max_clock_drift: ::std::option::Option<::prost_types::Duration>,
+    pub max_clock_drift: ::core::option::Option<::prost_types::Duration>,
     /// Block height when the client was frozen due to a misbehaviour
     #[prost(message, optional, tag = "6")]
-    pub frozen_height: ::std::option::Option<super::super::super::core::client::v1::Height>,
+    pub frozen_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
     /// Latest height the client was updated to
     #[prost(message, optional, tag = "7")]
-    pub latest_height: ::std::option::Option<super::super::super::core::client::v1::Height>,
+    pub latest_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
     /// Proof specifications used in verifying counterparty state
     #[prost(message, repeated, tag = "8")]
-    pub proof_specs: ::std::vec::Vec<super::super::super::super::ics23::ProofSpec>,
+    pub proof_specs: ::prost::alloc::vec::Vec<super::super::super::super::ics23::ProofSpec>,
     /// Path at which next upgraded client will be committed.
     /// Each element corresponds to the key for a single CommitmentProof in the chained proof.
     /// NOTE: ClientState must stored under `{upgradePath}/{upgradeHeight}/clientState`
     /// ConsensusState must be stored under `{upgradepath}/{upgradeHeight}/consensusState`
     /// For SDK chains using the default upgrade module, upgrade_path should be []string{"upgrade", "upgradedIBCState"}`
     #[prost(string, repeated, tag = "9")]
-    pub upgrade_path: ::std::vec::Vec<std::string::String>,
+    pub upgrade_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// This flag, when set to true, will allow governance to recover a client
     /// which has expired
     #[prost(bool, tag = "10")]
@@ -47,23 +47,23 @@ pub struct ConsensusState {
     /// timestamp that corresponds to the block height in which the ConsensusState
     /// was stored.
     #[prost(message, optional, tag = "1")]
-    pub timestamp: ::std::option::Option<::prost_types::Timestamp>,
+    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
     /// commitment root (i.e app hash)
     #[prost(message, optional, tag = "2")]
-    pub root: ::std::option::Option<super::super::super::core::commitment::v1::MerkleRoot>,
-    #[prost(bytes, tag = "3")]
-    pub next_validators_hash: std::vec::Vec<u8>,
+    pub root: ::core::option::Option<super::super::super::core::commitment::v1::MerkleRoot>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub next_validators_hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// Misbehaviour is a wrapper over two conflicting Headers
 /// that implements Misbehaviour interface expected by ICS-02
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Misbehaviour {
     #[prost(string, tag = "1")]
-    pub client_id: std::string::String,
+    pub client_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub header_1: ::std::option::Option<Header>,
+    pub header_1: ::core::option::Option<Header>,
     #[prost(message, optional, tag = "3")]
-    pub header_2: ::std::option::Option<Header>,
+    pub header_2: ::core::option::Option<Header>,
 }
 /// Header defines the Tendermint client consensus Header.
 /// It encapsulates all the information necessary to update from a trusted
@@ -80,13 +80,13 @@ pub struct Misbehaviour {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Header {
     #[prost(message, optional, tag = "1")]
-    pub signed_header: ::std::option::Option<::tendermint_proto::types::SignedHeader>,
+    pub signed_header: ::core::option::Option<::tendermint_proto::types::SignedHeader>,
     #[prost(message, optional, tag = "2")]
-    pub validator_set: ::std::option::Option<::tendermint_proto::types::ValidatorSet>,
+    pub validator_set: ::core::option::Option<::tendermint_proto::types::ValidatorSet>,
     #[prost(message, optional, tag = "3")]
-    pub trusted_height: ::std::option::Option<super::super::super::core::client::v1::Height>,
+    pub trusted_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
     #[prost(message, optional, tag = "4")]
-    pub trusted_validators: ::std::option::Option<::tendermint_proto::types::ValidatorSet>,
+    pub trusted_validators: ::core::option::Option<::tendermint_proto::types::ValidatorSet>,
 }
 /// Fraction defines the protobuf message type for tmmath.Fraction that only supports positive values.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/ics23.rs
+++ b/cosmos-sdk-proto/src/prost/ics23.rs
@@ -20,14 +20,14 @@
 ///length-prefix the data before hashing it.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExistenceProof {
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub leaf: ::std::option::Option<LeafOp>,
+    pub leaf: ::core::option::Option<LeafOp>,
     #[prost(message, repeated, tag = "4")]
-    pub path: ::std::vec::Vec<InnerOp>,
+    pub path: ::prost::alloc::vec::Vec<InnerOp>,
 }
 ///
 ///NonExistenceProof takes a proof of two neighbors, one left of the desired key,
@@ -36,20 +36,21 @@ pub struct ExistenceProof {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NonExistenceProof {
     /// TODO: remove this as unnecessary??? we prove a range
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub left: ::std::option::Option<ExistenceProof>,
+    pub left: ::core::option::Option<ExistenceProof>,
     #[prost(message, optional, tag = "3")]
-    pub right: ::std::option::Option<ExistenceProof>,
+    pub right: ::core::option::Option<ExistenceProof>,
 }
 ///
 ///CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommitmentProof {
     #[prost(oneof = "commitment_proof::Proof", tags = "1, 2, 3, 4")]
-    pub proof: ::std::option::Option<commitment_proof::Proof>,
+    pub proof: ::core::option::Option<commitment_proof::Proof>,
 }
+/// Nested message and enum types in `CommitmentProof`.
 pub mod commitment_proof {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Proof {
@@ -90,8 +91,8 @@ pub struct LeafOp {
     pub length: i32,
     /// prefix is a fixed bytes that may optionally be included at the beginning to differentiate
     /// a leaf node from an inner node.
-    #[prost(bytes, tag = "5")]
-    pub prefix: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub prefix: ::prost::alloc::vec::Vec<u8>,
 }
 ///*
 ///InnerOp represents a merkle-proof step that is not a leaf.
@@ -113,10 +114,10 @@ pub struct LeafOp {
 pub struct InnerOp {
     #[prost(enumeration = "HashOp", tag = "1")]
     pub hash: i32,
-    #[prost(bytes, tag = "2")]
-    pub prefix: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub suffix: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub prefix: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub suffix: ::prost::alloc::vec::Vec<u8>,
 }
 ///*
 ///ProofSpec defines what the expected parameters are for a given proof type.
@@ -134,9 +135,9 @@ pub struct ProofSpec {
     /// any field in the ExistenceProof must be the same as in this spec.
     /// except Prefix, which is just the first bytes of prefix (spec can be longer)
     #[prost(message, optional, tag = "1")]
-    pub leaf_spec: ::std::option::Option<LeafOp>,
+    pub leaf_spec: ::core::option::Option<LeafOp>,
     #[prost(message, optional, tag = "2")]
-    pub inner_spec: ::std::option::Option<InnerSpec>,
+    pub inner_spec: ::core::option::Option<InnerSpec>,
     /// max_depth (if > 0) is the maximum number of InnerOps allowed (mainly for fixed-depth tries)
     #[prost(int32, tag = "3")]
     pub max_depth: i32,
@@ -159,7 +160,7 @@ pub struct InnerSpec {
     /// iavl tree is [0, 1] (left then right)
     /// merk is [0, 2, 1] (left, right, here)
     #[prost(int32, repeated, tag = "1")]
-    pub child_order: ::std::vec::Vec<i32>,
+    pub child_order: ::prost::alloc::vec::Vec<i32>,
     #[prost(int32, tag = "2")]
     pub child_size: i32,
     #[prost(int32, tag = "3")]
@@ -167,8 +168,8 @@ pub struct InnerSpec {
     #[prost(int32, tag = "4")]
     pub max_prefix_length: i32,
     /// empty child is the prehash image that is used when one child is nil (eg. 20 bytes of 0)
-    #[prost(bytes, tag = "5")]
-    pub empty_child: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub empty_child: ::prost::alloc::vec::Vec<u8>,
     /// hash is the algorithm that must be used for each InnerOp
     #[prost(enumeration = "HashOp", tag = "6")]
     pub hash: i32,
@@ -178,14 +179,15 @@ pub struct InnerSpec {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchProof {
     #[prost(message, repeated, tag = "1")]
-    pub entries: ::std::vec::Vec<BatchEntry>,
+    pub entries: ::prost::alloc::vec::Vec<BatchEntry>,
 }
 /// Use BatchEntry not CommitmentProof, to avoid recursion
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchEntry {
     #[prost(oneof = "batch_entry::Proof", tags = "1, 2")]
-    pub proof: ::std::option::Option<batch_entry::Proof>,
+    pub proof: ::core::option::Option<batch_entry::Proof>,
 }
+/// Nested message and enum types in `BatchEntry`.
 pub mod batch_entry {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Proof {
@@ -200,16 +202,17 @@ pub mod batch_entry {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedBatchProof {
     #[prost(message, repeated, tag = "1")]
-    pub entries: ::std::vec::Vec<CompressedBatchEntry>,
+    pub entries: ::prost::alloc::vec::Vec<CompressedBatchEntry>,
     #[prost(message, repeated, tag = "2")]
-    pub lookup_inners: ::std::vec::Vec<InnerOp>,
+    pub lookup_inners: ::prost::alloc::vec::Vec<InnerOp>,
 }
 /// Use BatchEntry not CommitmentProof, to avoid recursion
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedBatchEntry {
     #[prost(oneof = "compressed_batch_entry::Proof", tags = "1, 2")]
-    pub proof: ::std::option::Option<compressed_batch_entry::Proof>,
+    pub proof: ::core::option::Option<compressed_batch_entry::Proof>,
 }
+/// Nested message and enum types in `CompressedBatchEntry`.
 pub mod compressed_batch_entry {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Proof {
@@ -221,25 +224,25 @@ pub mod compressed_batch_entry {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedExistenceProof {
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub leaf: ::std::option::Option<LeafOp>,
+    pub leaf: ::core::option::Option<LeafOp>,
     /// these are indexes into the lookup_inners table in CompressedBatchProof
     #[prost(int32, repeated, tag = "4")]
-    pub path: ::std::vec::Vec<i32>,
+    pub path: ::prost::alloc::vec::Vec<i32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedNonExistenceProof {
     /// TODO: remove this as unnecessary??? we prove a range
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub left: ::std::option::Option<CompressedExistenceProof>,
+    pub left: ::core::option::Option<CompressedExistenceProof>,
     #[prost(message, optional, tag = "3")]
-    pub right: ::std::option::Option<CompressedExistenceProof>,
+    pub right: ::core::option::Option<CompressedExistenceProof>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -15,8 +15,8 @@ cosmos-sdk-proto = { version = "0.2", default-features = false, path = "../cosmo
 ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }
-prost = "0.6"
-prost-types = "0.6"
+prost = "0.7"
+prost-types = "0.7"
 rust_decimal = "1.9"
 tendermint = "0.17"
 thiserror = "1"

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 
 [dependencies]
-prost = "0.6"
-prost-build = "0.6"
-tonic = "0.3.1"
-tonic-build = "0.3.1"
+prost = "0.7"
+prost-build = "0.7"
+tonic = "0.4"
+tonic-build = "0.4"
 regex = "1"
 tempdir = "0.3"
 walkdir = "2"


### PR DESCRIPTION
Also bumps the following dependencies:

- `prost`, `prost-types`, `prost-build` => v0.7
- `tonic`, `tonic-build` => v0.4