### PR TITLE
cosmos-sdk-proto v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-02-01)
+### Changed
+- Bump `cosmos-sdk` rev to v0.40.0 ([#37])
+- Bump `tendermint` crate dependency to v0.18 ([#45])
+- Bump `prost`, `prost-types`, `prost-build` to v0.7 ([#45])
+- Bump `tonic`, `tonic-build` to v0.4 ([#45])
+
+[#37]: https://github.com/cosmos/cosmos-rust/pull/37
+[#45]: https://github.com/cosmos/cosmos-rust/pull/45
+[#45]: https://github.com/cosmos/cosmos-rust/pull/45
+[#45]: https://github.com/cosmos/cosmos-rust/pull/45
+
 ## 0.2.0 (2020-01-04)
 ### Added
 - `grpc` crate feature ([#8])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
-authors = ["Justin Kilpatrick <justin@althea.net>", "Greg Szabo <greg@informal.systems>"]
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+authors = [
+    "Justin Kilpatrick <justin@althea.net>",
+    "Greg Szabo <greg@informal.systems>",
+    "Tony Arcieri <tony@iqlusion.io>"
+]
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/master/cosmos-sdk-proto"

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.1.2"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.2", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.3", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Bump `cosmos-sdk` rev to v0.40.0 ([#37])
- Bump `tendermint` crate dependency to v0.18 ([#45])
- Bump `prost`, `prost-types`, `prost-build` to v0.7 ([#45])
- Bump `tonic`, `tonic-build` to v0.4 ([#45])

[#37]: https://github.com/cosmos/cosmos-rust/pull/37
[#45]: https://github.com/cosmos/cosmos-rust/pull/45
[#45]: https://github.com/cosmos/cosmos-rust/pull/45
[#45]: https://github.com/cosmos/cosmos-rust/pull/45