### PR TITLE
README.md: add table of crate descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This is a place for commonly shared rust resources related to the Cosmos ecosystem.
 
+## Crates
+
+| Name                 | Description                 | crates.io | docs.rs | CI Build |
+|----------------------|-----------------------------|-----------|---------|----------|
+| [`cosmos‑sdk‑proto`] | Proto and gRPC definitions  | ![crates.io](https://img.shields.io/crates/v/cosmos-sdk-proto.svg?logo=rust) | ![docs.rs](https://docs.rs/cosmos-sdk-proto/badge.svg) | ![CI](https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg) |
+| [`cosmos‑tx`]        | Transaction signing support | ![crates.io](https://img.shields.io/crates/v/cosmos-tx.svg?logo=rust) | ![docs.rs](https://docs.rs/cosmos-tx/badge.svg) | ![CI](https://github.com/cosmos/cosmos-rust/workflows/cosmos-tx/badge.svg) |
+
 ## Merge Policy
 
 The goal of this repository is to create a place for upstream consensus in the Cosmos Rust community. Different applications will have different requirements from libraries, this repo should strive to contain only code that is useful and actively used by more than one organization.
@@ -28,3 +35,8 @@ all other crates, simply make the required edits in [main.rs](proto-build/main.r
 ## Minimum Supported Rust Version
 
 Rust **1.48**
+
+[//]: # "crates"
+
+[`cosmos‑sdk‑proto`]: https://github.com/cosmos/cosmos-rust/tree/main/cosmos-sdk-proto
+[`cosmos‑tx`]: https://github.com/cosmos/cosmos-rust/tree/main/cosmos-tx

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -23,7 +23,7 @@ Pull requests to expand coverage are welcome.
 Requires Rust **1.48** or newer.
 
 [//]: # "badges"
-[crate-image]: https://img.shields.io/crates/v/cosmos-sdk-proto.svg
+[crate-image]: https://img.shields.io/crates/v/cosmos-sdk-proto.svg?logo=rust
 [crate-link]: https://crates.io/crates/cosmos-sdk-proto
 [docs-image]: https://docs.rs/cosmos-sdk-proto/badge.svg
 [docs-link]: https://docs.rs/cosmos-sdk-proto/

--- a/cosmos-tx/README.md
+++ b/cosmos-tx/README.md
@@ -15,7 +15,7 @@ Transaction builder and signer for [Cosmos]-based blockchains.
 Requires Rust **1.48** or newer.
 
 [//]: # "badges"
-[crate-image]: https://img.shields.io/crates/v/cosmos-tx.svg
+[crate-image]: https://img.shields.io/crates/v/cosmos-tx.svg?logo=rust
 [crate-link]: https://crates.io/crates/cosmos-tx
 [docs-image]: https://docs.rs/cosmos-tx/badge.svg
 [docs-link]: https://docs.rs/cosmos-tx/


### PR DESCRIPTION
Shows the crates available in the repo at-a-glance.

<img width="937" alt="Screen Shot 2021-02-03 at 7 44 51 AM" src="https://user-images.githubusercontent.com/37432020/106771373-bbf84380-65f3-11eb-83b5-bf4f46cbb49b.png">

[Rendered](https://github.com/cosmos/cosmos-rust/blob/fa6dfcace0c602872102712c35c9be5320c91d51/README.md#crates)