### PR TITLE
rebuild-protos: fix name of build step

### DIFF
--- a/.github/workflows/rebuild-protos.yml
+++ b/.github/workflows/rebuild-protos.yml
@@ -21,11 +21,10 @@ jobs:
         run: |
           message=$(cargo run --quiet -- --github)
           echo "::set-output name=commit_message::${message}"
-
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3.5.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: ${{ steps.assign.outputs.commit_message }}
-          title: ${{ steps.assign.outputs.commit_message }}
+          commit-message: ${{ steps.build.outputs.commit_message }}
+          title: ${{ steps.build.outputs.commit_message }}
           branch: rebuild-protos


### PR DESCRIPTION
Fixes a bit of copypasta from the action I based this on.

A local test of running `cargo run --quiet -- --github` in the `proto-build` directory showed it was working:

```
$ echo $message
Rebuild protos with proto-build (cosmos-sdk rev: v0.42.3)
```

...but the step name being passed to `create-pull-request` was incorrect.