### PR TITLE
Import bank proto and service definitions

### DIFF
--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -115,6 +115,13 @@ pub mod cosmos {
             include!("prost/cosmos.tx.v1beta1.rs");
         }
     }
+
+    /// Balances.
+    pub mod bank {
+        pub mod v1beta1 {
+            include!("prost/cosmos.bank.v1beta1.rs");
+        }
+    }
 }
 
 /// IBC protobuf definitions.


### PR DESCRIPTION
In what seems to be a simple oversight bank proto and services have been
compiled but not imported and exposed to users of the Crate. This patch
resolves that issue just by adding the import. No other changes are
required.