### PR TITLE
cosmos-tx: flatten API

### DIFF
--- a/cosmos-tx/src/lib.rs
+++ b/cosmos-tx/src/lib.rs
@@ -7,12 +7,12 @@
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 
-pub mod builder;
-pub mod decimal;
-pub mod error;
-pub mod msg;
+mod builder;
+mod decimal;
+mod error;
+mod msg;
 
-pub use crate::{builder::Builder, decimal::Decimal, error::Error};
+pub use crate::{builder::Builder, decimal::Decimal, error::Error, msg::Msg};
 pub use k256::ecdsa::{Signature, VerifyingKey};
 
 /// Transaction signer for ECDSA/secp256k1 signatures


### PR DESCRIPTION
The current implementation consists of a number of single-type modules which are re-exported at the toplevel.

This commit removes the `pub` from modules to eliminate the module hierarchy, which makes the relevant types easier to find at-a-glance when reading the corresponding `rustdoc` documentation.

## Before

<img width="617" alt="Screen Shot 2021-04-01 at 10 14 51 AM" src="https://user-images.githubusercontent.com/37432020/113330441-9629ab00-92d3-11eb-99f2-c4ff1168c3ce.png">

## After

<img width="645" alt="Screen Shot 2021-04-01 at 10 16 06 AM" src="https://user-images.githubusercontent.com/37432020/113330458-9b86f580-92d3-11eb-88ac-b0ca288a8afa.png">
