### PR TITLE
Expand cosmos-sdk-proto to include all upstream proto files

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -27,10 +27,10 @@ pub mod cosmos {
         }
     }
 
-    /// Proof-of-Stake layer for public blockchains.
-    pub mod staking {
+    /// Balances.
+    pub mod bank {
         pub mod v1beta1 {
-            include!("prost/cosmos.staking.v1beta1.rs");
+            include!("prost/cosmos.bank.v1beta1.rs");
         }
     }
 
@@ -92,6 +92,13 @@ pub mod cosmos {
         }
     }
 
+    /// Crisis handling
+    pub mod crisis {
+        pub mod v1beta1 {
+            include!("prost/cosmos.crisis.v1beta1.rs");
+        }
+    }
+
     /// Cryptographic primitives.
     pub mod crypto {
         /// Multi-signature support.
@@ -99,6 +106,62 @@ pub mod cosmos {
             pub mod v1beta1 {
                 include!("prost/cosmos.crypto.multisig.v1beta1.rs");
             }
+        }
+    }
+
+    /// Messages and services handling token distribution
+    pub mod distribution {
+        pub mod v1beta1 {
+            include!("prost/cosmos.distribution.v1beta1.rs");
+        }
+    }
+
+    /// Messages and services handling evidence
+    pub mod evidence {
+        pub mod v1beta1 {
+            include!("prost/cosmos.evidence.v1beta1.rs");
+        }
+    }
+
+    /// Messages and services handling gentx's
+    pub mod genutil {
+        pub mod v1beta1 {
+            include!("prost/cosmos.genutil.v1beta1.rs");
+        }
+    }
+
+    /// Messages and services handling governance
+    pub mod gov {
+        pub mod v1beta1 {
+            include!("prost/cosmos.gov.v1beta1.rs");
+        }
+    }
+
+    /// Messages and services handling minting
+    pub mod mint {
+        pub mod v1beta1 {
+            include!("prost/cosmos.mint.v1beta1.rs");
+        }
+    }
+
+    /// Messages and services handling chain parameters
+    pub mod params {
+        pub mod v1beta1 {
+            include!("prost/cosmos.params.v1beta1.rs");
+        }
+    }
+
+    /// Handling slashing parameters and unjailing
+    pub mod slashing {
+        pub mod v1beta1 {
+            include!("prost/cosmos.slashing.v1beta1.rs");
+        }
+    }
+
+    /// Proof-of-Stake layer for public blockchains.
+    pub mod staking {
+        pub mod v1beta1 {
+            include!("prost/cosmos.staking.v1beta1.rs");
         }
     }
 
@@ -116,10 +179,17 @@ pub mod cosmos {
         }
     }
 
-    /// Balances.
-    pub mod bank {
+    /// Services for the upgrade module.
+    pub mod upgrade {
         pub mod v1beta1 {
-            include!("prost/cosmos.bank.v1beta1.rs");
+            include!("prost/cosmos.upgrade.v1beta1.rs");
+        }
+    }
+
+    /// Services and tx's for the vesting module.
+    pub mod vesting {
+        pub mod v1beta1 {
+            include!("prost/cosmos.vesting.v1beta1.rs");
         }
     }
 }

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.3.0"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]

--- a/cosmos-sdk-proto/src/prost/cosmos.bank.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.bank.v1beta1.rs
@@ -338,3 +338,107 @@ pub mod query_client {
         }
     }
 }
+/// MsgSend represents a message to send coins from one account to another.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSend {
+    #[prost(string, tag = "1")]
+    pub from_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub to_address: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgSendResponse defines the Msg/Send response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSendResponse {}
+/// MsgMultiSend represents an arbitrary multi-in, multi-out send message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgMultiSend {
+    #[prost(message, repeated, tag = "1")]
+    pub inputs: ::prost::alloc::vec::Vec<Input>,
+    #[prost(message, repeated, tag = "2")]
+    pub outputs: ::prost::alloc::vec::Vec<Output>,
+}
+/// MsgMultiSendResponse defines the Msg/MultiSend response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgMultiSendResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the bank Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Send defines a method for sending coins from one account to another account."]
+        pub async fn send(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSend>,
+        ) -> Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.bank.v1beta1.Msg/Send");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " MultiSend defines a method for sending coins from some accounts to other accounts."]
+        pub async fn multi_send(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgMultiSend>,
+        ) -> Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.bank.v1beta1.Msg/MultiSend");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.capability.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.capability.v1beta1.rs
@@ -1,0 +1,44 @@
+/// Capability defines an implementation of an object capability. The index
+/// provided to a Capability must be globally unique.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Capability {
+    #[prost(uint64, tag = "1")]
+    pub index: u64,
+}
+/// Owner defines a single capability owner. An owner is defined by the name of
+/// capability and the module name.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Owner {
+    #[prost(string, tag = "1")]
+    pub module: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+/// CapabilityOwners defines a set of owners of a single Capability. The set of
+/// owners must be unique.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CapabilityOwners {
+    #[prost(message, repeated, tag = "1")]
+    pub owners: ::prost::alloc::vec::Vec<Owner>,
+}
+/// GenesisOwners defines the capability owners with their corresponding index.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisOwners {
+    /// index is the index of the capability owner.
+    #[prost(uint64, tag = "1")]
+    pub index: u64,
+    /// index_owners are the owners at the given index.
+    #[prost(message, optional, tag = "2")]
+    pub index_owners: ::core::option::Option<CapabilityOwners>,
+}
+/// GenesisState defines the capability module's genesis state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    /// index is the capability global index.
+    #[prost(uint64, tag = "1")]
+    pub index: u64,
+    /// owners represents a map from index to owners of the capability index
+    /// index key is string to allow amino marshalling.
+    #[prost(message, repeated, tag = "2")]
+    pub owners: ::prost::alloc::vec::Vec<GenesisOwners>,
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.crisis.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.crisis.v1beta1.rs
@@ -1,0 +1,79 @@
+/// MsgVerifyInvariant represents a message to verify a particular invariance.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVerifyInvariant {
+    #[prost(string, tag = "1")]
+    pub sender: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub invariant_module_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub invariant_route: ::prost::alloc::string::String,
+}
+/// MsgVerifyInvariantResponse defines the Msg/VerifyInvariant response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVerifyInvariantResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the bank Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " VerifyInvariant defines a method to verify a particular invariance."]
+        pub async fn verify_invariant(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgVerifyInvariant>,
+        ) -> Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.crisis.v1beta1.Msg/VerifyInvariant");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.crypto.ed25519.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.crypto.ed25519.rs
@@ -1,0 +1,16 @@
+/// PubKey defines a ed25519 public key
+/// Key is the compressed form of the pubkey. The first byte depends is a 0x02 byte
+/// if the y-coordinate is the lexicographically largest of the two associated with
+/// the x-coordinate. Otherwise the first byte is a 0x03.
+/// This prefix is followed with the x-coordinate.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PubKey {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+}
+/// PrivKey defines a ed25519 private key.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PrivKey {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.crypto.multisig.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.crypto.multisig.rs
@@ -1,0 +1,10 @@
+/// LegacyAminoPubKey specifies a public key type
+/// which nests multiple public keys and a threshold,
+/// it uses legacy amino address rules.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LegacyAminoPubKey {
+    #[prost(uint32, tag = "1")]
+    pub threshold: u32,
+    #[prost(message, repeated, tag = "2")]
+    pub public_keys: ::prost::alloc::vec::Vec<::prost_types::Any>,
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.crypto.secp256k1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.crypto.secp256k1.rs
@@ -1,0 +1,16 @@
+/// PubKey defines a secp256k1 public key
+/// Key is the compressed form of the pubkey. The first byte depends is a 0x02 byte
+/// if the y-coordinate is the lexicographically largest of the two associated with
+/// the x-coordinate. Otherwise the first byte is a 0x03.
+/// This prefix is followed with the x-coordinate.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PubKey {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+}
+/// PrivKey defines a secp256k1 private key.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PrivKey {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.distribution.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.distribution.v1beta1.rs
@@ -1,0 +1,660 @@
+/// Params defines the set of params for the distribution module.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Params {
+    #[prost(string, tag = "1")]
+    pub community_tax: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub base_proposer_reward: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub bonus_proposer_reward: ::prost::alloc::string::String,
+    #[prost(bool, tag = "4")]
+    pub withdraw_addr_enabled: bool,
+}
+/// ValidatorHistoricalRewards represents historical rewards for a validator.
+/// Height is implicit within the store key.
+/// Cumulative reward ratio is the sum from the zeroeth period
+/// until this period of rewards / tokens, per the spec.
+/// The reference count indicates the number of objects
+/// which might need to reference this historical entry at any point.
+/// ReferenceCount =
+///    number of outstanding delegations which ended the associated period (and
+///    might need to read that record)
+///  + number of slashes which ended the associated period (and might need to
+///  read that record)
+///  + one per validator for the zeroeth period, set on initialization
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorHistoricalRewards {
+    #[prost(message, repeated, tag = "1")]
+    pub cumulative_reward_ratio: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+    #[prost(uint32, tag = "2")]
+    pub reference_count: u32,
+}
+/// ValidatorCurrentRewards represents current rewards and current
+/// period for a validator kept as a running counter and incremented
+/// each block as long as the validator's tokens remain constant.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorCurrentRewards {
+    #[prost(message, repeated, tag = "1")]
+    pub rewards: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+    #[prost(uint64, tag = "2")]
+    pub period: u64,
+}
+/// ValidatorAccumulatedCommission represents accumulated commission
+/// for a validator kept as a running counter, can be withdrawn at any time.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorAccumulatedCommission {
+    #[prost(message, repeated, tag = "1")]
+    pub commission: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// ValidatorOutstandingRewards represents outstanding (un-withdrawn) rewards
+/// for a validator inexpensive to track, allows simple sanity checks.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorOutstandingRewards {
+    #[prost(message, repeated, tag = "1")]
+    pub rewards: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// ValidatorSlashEvent represents a validator slash event.
+/// Height is implicit within the store key.
+/// This is needed to calculate appropriate amount of staking tokens
+/// for delegations which are withdrawn after a slash has occurred.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorSlashEvent {
+    #[prost(uint64, tag = "1")]
+    pub validator_period: u64,
+    #[prost(string, tag = "2")]
+    pub fraction: ::prost::alloc::string::String,
+}
+/// ValidatorSlashEvents is a collection of ValidatorSlashEvent messages.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorSlashEvents {
+    #[prost(message, repeated, tag = "1")]
+    pub validator_slash_events: ::prost::alloc::vec::Vec<ValidatorSlashEvent>,
+}
+/// FeePool is the global fee pool for distribution.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FeePool {
+    #[prost(message, repeated, tag = "1")]
+    pub community_pool: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// CommunityPoolSpendProposal details a proposal for use of community funds,
+/// together with how many coins are proposed to be spent, and to which
+/// recipient account.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommunityPoolSpendProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub recipient: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "4")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// DelegatorStartingInfo represents the starting info for a delegator reward
+/// period. It tracks the previous validator period, the delegation's amount of
+/// staking token, and the creation height (to check later on if any slashes have
+/// occurred). NOTE: Even though validators are slashed to whole staking tokens,
+/// the delegators within the validator may be left with less than a full token,
+/// thus sdk.Dec is used.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DelegatorStartingInfo {
+    #[prost(uint64, tag = "1")]
+    pub previous_period: u64,
+    #[prost(string, tag = "2")]
+    pub stake: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "3")]
+    pub height: u64,
+}
+/// DelegationDelegatorReward represents the properties
+/// of a delegator's delegation reward.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DelegationDelegatorReward {
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub reward: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// CommunityPoolSpendProposalWithDeposit defines a CommunityPoolSpendProposal
+/// with a deposit
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommunityPoolSpendProposalWithDeposit {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub recipient: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub amount: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub deposit: ::prost::alloc::string::String,
+}
+/// QueryParamsRequest is the request type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {}
+/// QueryParamsResponse is the response type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    /// params defines the parameters of the module.
+    #[prost(message, optional, tag = "1")]
+    pub params: ::core::option::Option<Params>,
+}
+/// QueryValidatorOutstandingRewardsRequest is the request type for the
+/// Query/ValidatorOutstandingRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorOutstandingRewardsRequest {
+    /// validator_address defines the validator address to query for.
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// QueryValidatorOutstandingRewardsResponse is the response type for the
+/// Query/ValidatorOutstandingRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorOutstandingRewardsResponse {
+    #[prost(message, optional, tag = "1")]
+    pub rewards: ::core::option::Option<ValidatorOutstandingRewards>,
+}
+/// QueryValidatorCommissionRequest is the request type for the
+/// Query/ValidatorCommission RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorCommissionRequest {
+    /// validator_address defines the validator address to query for.
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// QueryValidatorCommissionResponse is the response type for the
+/// Query/ValidatorCommission RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorCommissionResponse {
+    /// commission defines the commision the validator received.
+    #[prost(message, optional, tag = "1")]
+    pub commission: ::core::option::Option<ValidatorAccumulatedCommission>,
+}
+/// QueryValidatorSlashesRequest is the request type for the
+/// Query/ValidatorSlashes RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorSlashesRequest {
+    /// validator_address defines the validator address to query for.
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+    /// starting_height defines the optional starting height to query the slashes.
+    #[prost(uint64, tag = "2")]
+    pub starting_height: u64,
+    /// starting_height defines the optional ending height to query the slashes.
+    #[prost(uint64, tag = "3")]
+    pub ending_height: u64,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "4")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryValidatorSlashesResponse is the response type for the
+/// Query/ValidatorSlashes RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorSlashesResponse {
+    /// slashes defines the slashes the validator received.
+    #[prost(message, repeated, tag = "1")]
+    pub slashes: ::prost::alloc::vec::Vec<ValidatorSlashEvent>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryDelegationRewardsRequest is the request type for the
+/// Query/DelegationRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegationRewardsRequest {
+    /// delegator_address defines the delegator address to query for.
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    /// validator_address defines the validator address to query for.
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// QueryDelegationRewardsResponse is the response type for the
+/// Query/DelegationRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegationRewardsResponse {
+    /// rewards defines the rewards accrued by a delegation.
+    #[prost(message, repeated, tag = "1")]
+    pub rewards: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// QueryDelegationTotalRewardsRequest is the request type for the
+/// Query/DelegationTotalRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegationTotalRewardsRequest {
+    /// delegator_address defines the delegator address to query for.
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+}
+/// QueryDelegationTotalRewardsResponse is the response type for the
+/// Query/DelegationTotalRewards RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegationTotalRewardsResponse {
+    /// rewards defines all the rewards accrued by a delegator.
+    #[prost(message, repeated, tag = "1")]
+    pub rewards: ::prost::alloc::vec::Vec<DelegationDelegatorReward>,
+    /// total defines the sum of all the rewards.
+    #[prost(message, repeated, tag = "2")]
+    pub total: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+/// QueryDelegatorValidatorsRequest is the request type for the
+/// Query/DelegatorValidators RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegatorValidatorsRequest {
+    /// delegator_address defines the delegator address to query for.
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+}
+/// QueryDelegatorValidatorsResponse is the response type for the
+/// Query/DelegatorValidators RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegatorValidatorsResponse {
+    /// validators defines the validators a delegator is delegating for.
+    #[prost(string, repeated, tag = "1")]
+    pub validators: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// QueryDelegatorWithdrawAddressRequest is the request type for the
+/// Query/DelegatorWithdrawAddress RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegatorWithdrawAddressRequest {
+    /// delegator_address defines the delegator address to query for.
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+}
+/// QueryDelegatorWithdrawAddressResponse is the response type for the
+/// Query/DelegatorWithdrawAddress RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDelegatorWithdrawAddressResponse {
+    /// withdraw_address defines the delegator address to query for.
+    #[prost(string, tag = "1")]
+    pub withdraw_address: ::prost::alloc::string::String,
+}
+/// QueryCommunityPoolRequest is the request type for the Query/CommunityPool RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryCommunityPoolRequest {}
+/// QueryCommunityPoolResponse is the response type for the Query/CommunityPool
+/// RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryCommunityPoolResponse {
+    /// pool defines community pool's coins.
+    #[prost(message, repeated, tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query defines the gRPC querier service for distribution module."]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Params queries params of the distribution module."]
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.distribution.v1beta1.Query/Params");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " ValidatorOutstandingRewards queries rewards of a validator address."]
+        pub async fn validator_outstanding_rewards(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryValidatorOutstandingRewardsRequest>,
+        ) -> Result<tonic::Response<super::QueryValidatorOutstandingRewardsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/ValidatorOutstandingRewards",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " ValidatorCommission queries accumulated commission for a validator."]
+        pub async fn validator_commission(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryValidatorCommissionRequest>,
+        ) -> Result<tonic::Response<super::QueryValidatorCommissionResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/ValidatorCommission",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " ValidatorSlashes queries slash events of a validator."]
+        pub async fn validator_slashes(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryValidatorSlashesRequest>,
+        ) -> Result<tonic::Response<super::QueryValidatorSlashesResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/ValidatorSlashes",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " DelegationRewards queries the total rewards accrued by a delegation."]
+        pub async fn delegation_rewards(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDelegationRewardsRequest>,
+        ) -> Result<tonic::Response<super::QueryDelegationRewardsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/DelegationRewards",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " DelegationTotalRewards queries the total rewards accrued by a each"]
+        #[doc = " validator."]
+        pub async fn delegation_total_rewards(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDelegationTotalRewardsRequest>,
+        ) -> Result<tonic::Response<super::QueryDelegationTotalRewardsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/DelegationTotalRewards",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " DelegatorValidators queries the validators of a delegator."]
+        pub async fn delegator_validators(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
+        ) -> Result<tonic::Response<super::QueryDelegatorValidatorsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/DelegatorValidators",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " DelegatorWithdrawAddress queries withdraw address of a delegator."]
+        pub async fn delegator_withdraw_address(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDelegatorWithdrawAddressRequest>,
+        ) -> Result<tonic::Response<super::QueryDelegatorWithdrawAddressResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/DelegatorWithdrawAddress",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " CommunityPool queries the community pool coins."]
+        pub async fn community_pool(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryCommunityPoolRequest>,
+        ) -> Result<tonic::Response<super::QueryCommunityPoolResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/CommunityPool",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}
+/// MsgSetWithdrawAddress sets the withdraw address for
+/// a delegator (or validator self-delegation).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetWithdrawAddress {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub withdraw_address: ::prost::alloc::string::String,
+}
+/// MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetWithdrawAddressResponse {}
+/// MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
+/// from a single validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawDelegatorReward {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawDelegatorRewardResponse {}
+/// MsgWithdrawValidatorCommission withdraws the full commission to the validator
+/// address.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawValidatorCommission {
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawValidatorCommissionResponse {}
+/// MsgFundCommunityPool allows an account to directly
+/// fund the community pool.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgFundCommunityPool {
+    #[prost(message, repeated, tag = "1")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+}
+/// MsgFundCommunityPoolResponse defines the Msg/FundCommunityPool response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgFundCommunityPoolResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the distribution Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " SetWithdrawAddress defines a method to change the withdraw address"]
+        #[doc = " for a delegator (or validator self-delegation)."]
+        pub async fn set_withdraw_address(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSetWithdrawAddress>,
+        ) -> Result<tonic::Response<super::MsgSetWithdrawAddressResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/SetWithdrawAddress",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " WithdrawDelegatorReward defines a method to withdraw rewards of delegator"]
+        #[doc = " from a single validator."]
+        pub async fn withdraw_delegator_reward(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgWithdrawDelegatorReward>,
+        ) -> Result<tonic::Response<super::MsgWithdrawDelegatorRewardResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/WithdrawDelegatorReward",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " WithdrawValidatorCommission defines a method to withdraw the"]
+        #[doc = " full commission to the validator address."]
+        pub async fn withdraw_validator_commission(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgWithdrawValidatorCommission>,
+        ) -> Result<tonic::Response<super::MsgWithdrawValidatorCommissionResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/WithdrawValidatorCommission",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " FundCommunityPool defines a method to allow an account to directly"]
+        #[doc = " fund the community pool."]
+        pub async fn fund_community_pool(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgFundCommunityPool>,
+        ) -> Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/FundCommunityPool",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.evidence.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.evidence.v1beta1.rs
@@ -1,0 +1,198 @@
+/// QueryEvidenceRequest is the request type for the Query/Evidence RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryEvidenceRequest {
+    /// evidence_hash defines the hash of the requested evidence.
+    #[prost(bytes = "vec", tag = "1")]
+    pub evidence_hash: ::prost::alloc::vec::Vec<u8>,
+}
+/// QueryEvidenceResponse is the response type for the Query/Evidence RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryEvidenceResponse {
+    /// evidence returns the requested evidence.
+    #[prost(message, optional, tag = "1")]
+    pub evidence: ::core::option::Option<::prost_types::Any>,
+}
+/// QueryEvidenceRequest is the request type for the Query/AllEvidence RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAllEvidenceRequest {
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "1")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryAllEvidenceResponse is the response type for the Query/AllEvidence RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAllEvidenceResponse {
+    /// evidence returns all evidences.
+    #[prost(message, repeated, tag = "1")]
+    pub evidence: ::prost::alloc::vec::Vec<::prost_types::Any>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query defines the gRPC querier service."]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Evidence queries evidence based on evidence hash."]
+        pub async fn evidence(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryEvidenceRequest>,
+        ) -> Result<tonic::Response<super::QueryEvidenceResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.evidence.v1beta1.Query/Evidence");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " AllEvidence queries all evidence."]
+        pub async fn all_evidence(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryAllEvidenceRequest>,
+        ) -> Result<tonic::Response<super::QueryAllEvidenceResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.evidence.v1beta1.Query/AllEvidence");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}
+/// MsgSubmitEvidence represents a message that supports submitting arbitrary
+/// Evidence of misbehavior such as equivocation or counterfactual signing.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitEvidence {
+    #[prost(string, tag = "1")]
+    pub submitter: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub evidence: ::core::option::Option<::prost_types::Any>,
+}
+/// MsgSubmitEvidenceResponse defines the Msg/SubmitEvidence response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitEvidenceResponse {
+    /// hash defines the hash of the evidence.
+    #[prost(bytes = "vec", tag = "4")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the evidence Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " SubmitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or"]
+        #[doc = " counterfactual signing."]
+        pub async fn submit_evidence(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSubmitEvidence>,
+        ) -> Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.evidence.v1beta1.Msg/SubmitEvidence");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.genutil.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.genutil.v1beta1.rs
@@ -1,0 +1,7 @@
+/// GenesisState defines the raw genesis transaction in JSON.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    /// gen_txs defines the genesis transactions.
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub gen_txs: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.gov.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.gov.v1beta1.rs
@@ -1,0 +1,592 @@
+/// TextProposal defines a standard text proposal whose changes need to be
+/// manually updated in case of approval.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TextProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+}
+/// Deposit defines an amount deposited by an account address to an active
+/// proposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Deposit {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// Proposal defines the core field members of a governance proposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Proposal {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub content: ::core::option::Option<::prost_types::Any>,
+    #[prost(enumeration = "ProposalStatus", tag = "3")]
+    pub status: i32,
+    #[prost(message, optional, tag = "4")]
+    pub final_tally_result: ::core::option::Option<TallyResult>,
+    #[prost(message, optional, tag = "5")]
+    pub submit_time: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, optional, tag = "6")]
+    pub deposit_end_time: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, repeated, tag = "7")]
+    pub total_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, optional, tag = "8")]
+    pub voting_start_time: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(message, optional, tag = "9")]
+    pub voting_end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// TallyResult defines a standard tally for a governance proposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TallyResult {
+    #[prost(string, tag = "1")]
+    pub yes: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub abstain: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub no: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub no_with_veto: ::prost::alloc::string::String,
+}
+/// Vote defines a vote on a governance proposal.
+/// A Vote consists of a proposal ID, the voter, and the vote option.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Vote {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(enumeration = "VoteOption", tag = "3")]
+    pub option: i32,
+}
+/// DepositParams defines the params for deposits on governance proposals.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DepositParams {
+    ///  Minimum deposit for a proposal to enter voting period.
+    #[prost(message, repeated, tag = "1")]
+    pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    ///  Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    ///  months.
+    #[prost(message, optional, tag = "2")]
+    pub max_deposit_period: ::core::option::Option<::prost_types::Duration>,
+}
+/// VotingParams defines the params for voting on governance proposals.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VotingParams {
+    ///  Length of the voting period.
+    #[prost(message, optional, tag = "1")]
+    pub voting_period: ::core::option::Option<::prost_types::Duration>,
+}
+/// TallyParams defines the params for tallying votes on governance proposals.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TallyParams {
+    ///  Minimum percentage of total stake needed to vote for a result to be
+    ///  considered valid.
+    #[prost(bytes = "vec", tag = "1")]
+    pub quorum: ::prost::alloc::vec::Vec<u8>,
+    ///  Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    #[prost(bytes = "vec", tag = "2")]
+    pub threshold: ::prost::alloc::vec::Vec<u8>,
+    ///  Minimum value of Veto votes to Total votes ratio for proposal to be
+    ///  vetoed. Default value: 1/3.
+    #[prost(bytes = "vec", tag = "3")]
+    pub veto_threshold: ::prost::alloc::vec::Vec<u8>,
+}
+/// VoteOption enumerates the valid vote options for a given governance proposal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum VoteOption {
+    /// VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+    Unspecified = 0,
+    /// VOTE_OPTION_YES defines a yes vote option.
+    Yes = 1,
+    /// VOTE_OPTION_ABSTAIN defines an abstain vote option.
+    Abstain = 2,
+    /// VOTE_OPTION_NO defines a no vote option.
+    No = 3,
+    /// VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
+    NoWithVeto = 4,
+}
+/// ProposalStatus enumerates the valid statuses of a proposal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ProposalStatus {
+    /// PROPOSAL_STATUS_UNSPECIFIED defines the default propopsal status.
+    Unspecified = 0,
+    /// PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
+    /// period.
+    DepositPeriod = 1,
+    /// PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
+    /// period.
+    VotingPeriod = 2,
+    /// PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
+    /// passed.
+    Passed = 3,
+    /// PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
+    /// been rejected.
+    Rejected = 4,
+    /// PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
+    /// failed.
+    Failed = 5,
+}
+/// QueryProposalRequest is the request type for the Query/Proposal RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryProposalRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+}
+/// QueryProposalResponse is the response type for the Query/Proposal RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryProposalResponse {
+    #[prost(message, optional, tag = "1")]
+    pub proposal: ::core::option::Option<Proposal>,
+}
+/// QueryProposalsRequest is the request type for the Query/Proposals RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryProposalsRequest {
+    /// proposal_status defines the status of the proposals.
+    #[prost(enumeration = "ProposalStatus", tag = "1")]
+    pub proposal_status: i32,
+    /// voter defines the voter address for the proposals.
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    /// depositor defines the deposit addresses from the proposals.
+    #[prost(string, tag = "3")]
+    pub depositor: ::prost::alloc::string::String,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "4")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryProposalsResponse is the response type for the Query/Proposals RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryProposalsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub proposals: ::prost::alloc::vec::Vec<Proposal>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryVoteRequest is the request type for the Query/Vote RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryVoteRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    /// voter defines the oter address for the proposals.
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+}
+/// QueryVoteResponse is the response type for the Query/Vote RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryVoteResponse {
+    /// vote defined the queried vote.
+    #[prost(message, optional, tag = "1")]
+    pub vote: ::core::option::Option<Vote>,
+}
+/// QueryVotesRequest is the request type for the Query/Votes RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryVotesRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryVotesResponse is the response type for the Query/Votes RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryVotesResponse {
+    /// votes defined the queried votes.
+    #[prost(message, repeated, tag = "1")]
+    pub votes: ::prost::alloc::vec::Vec<Vote>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryParamsRequest is the request type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {
+    /// params_type defines which parameters to query for, can be one of "voting",
+    /// "tallying" or "deposit".
+    #[prost(string, tag = "1")]
+    pub params_type: ::prost::alloc::string::String,
+}
+/// QueryParamsResponse is the response type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    /// voting_params defines the parameters related to voting.
+    #[prost(message, optional, tag = "1")]
+    pub voting_params: ::core::option::Option<VotingParams>,
+    /// deposit_params defines the parameters related to deposit.
+    #[prost(message, optional, tag = "2")]
+    pub deposit_params: ::core::option::Option<DepositParams>,
+    /// tally_params defines the parameters related to tally.
+    #[prost(message, optional, tag = "3")]
+    pub tally_params: ::core::option::Option<TallyParams>,
+}
+/// QueryDepositRequest is the request type for the Query/Deposit RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDepositRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+}
+/// QueryDepositResponse is the response type for the Query/Deposit RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDepositResponse {
+    /// deposit defines the requested deposit.
+    #[prost(message, optional, tag = "1")]
+    pub deposit: ::core::option::Option<Deposit>,
+}
+/// QueryDepositsRequest is the request type for the Query/Deposits RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDepositsRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryDepositsResponse is the response type for the Query/Deposits RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryDepositsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub deposits: ::prost::alloc::vec::Vec<Deposit>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryTallyResultRequest is the request type for the Query/Tally RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTallyResultRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+}
+/// QueryTallyResultResponse is the response type for the Query/Tally RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTallyResultResponse {
+    /// tally defines the requested tally.
+    #[prost(message, optional, tag = "1")]
+    pub tally: ::core::option::Option<TallyResult>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query defines the gRPC querier service for gov module"]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Proposal queries proposal details based on ProposalID."]
+        pub async fn proposal(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryProposalRequest>,
+        ) -> Result<tonic::Response<super::QueryProposalResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Proposal");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Proposals queries all proposals based on given status."]
+        pub async fn proposals(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryProposalsRequest>,
+        ) -> Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Proposals");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Vote queries voted information based on proposalID, voterAddr."]
+        pub async fn vote(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryVoteRequest>,
+        ) -> Result<tonic::Response<super::QueryVoteResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Vote");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Votes queries votes of a given proposal."]
+        pub async fn votes(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryVotesRequest>,
+        ) -> Result<tonic::Response<super::QueryVotesResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Votes");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Params queries all parameters of the gov module."]
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Params");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Deposit queries single deposit information based proposalID, depositAddr."]
+        pub async fn deposit(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDepositRequest>,
+        ) -> Result<tonic::Response<super::QueryDepositResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Deposit");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Deposits queries all deposits of a single proposal."]
+        pub async fn deposits(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryDepositsRequest>,
+        ) -> Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/Deposits");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " TallyResult queries the tally of a proposal vote."]
+        pub async fn tally_result(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryTallyResultRequest>,
+        ) -> Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Query/TallyResult");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}
+/// MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
+/// proposal Content.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitProposal {
+    #[prost(message, optional, tag = "1")]
+    pub content: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, repeated, tag = "2")]
+    pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(string, tag = "3")]
+    pub proposer: ::prost::alloc::string::String,
+}
+/// MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitProposalResponse {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+}
+/// MsgVote defines a message to cast a vote.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVote {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(enumeration = "VoteOption", tag = "3")]
+    pub option: i32,
+}
+/// MsgVoteResponse defines the Msg/Vote response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVoteResponse {}
+/// MsgDeposit defines a message to submit a deposit to an existing proposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDeposit {
+    #[prost(uint64, tag = "1")]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgDepositResponse defines the Msg/Deposit response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDepositResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the bank Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " SubmitProposal defines a method to create new proposal given a content."]
+        pub async fn submit_proposal(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
+        ) -> Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Msg/SubmitProposal");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Vote defines a method to add a vote on a specific proposal."]
+        pub async fn vote(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgVote>,
+        ) -> Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Msg/Vote");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Deposit defines a method to add deposit on a specific proposal."]
+        pub async fn deposit(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgDeposit>,
+        ) -> Result<tonic::Response<super::MsgDepositResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1beta1.Msg/Deposit");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.mint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.mint.v1beta1.rs
@@ -1,0 +1,161 @@
+/// Minter represents the minting state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Minter {
+    /// current annual inflation rate
+    #[prost(string, tag = "1")]
+    pub inflation: ::prost::alloc::string::String,
+    /// current annual expected provisions
+    #[prost(string, tag = "2")]
+    pub annual_provisions: ::prost::alloc::string::String,
+}
+/// Params holds parameters for the mint module.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Params {
+    /// type of coin to mint
+    #[prost(string, tag = "1")]
+    pub mint_denom: ::prost::alloc::string::String,
+    /// maximum annual change in inflation rate
+    #[prost(string, tag = "2")]
+    pub inflation_rate_change: ::prost::alloc::string::String,
+    /// maximum inflation rate
+    #[prost(string, tag = "3")]
+    pub inflation_max: ::prost::alloc::string::String,
+    /// minimum inflation rate
+    #[prost(string, tag = "4")]
+    pub inflation_min: ::prost::alloc::string::String,
+    /// goal of percent bonded atoms
+    #[prost(string, tag = "5")]
+    pub goal_bonded: ::prost::alloc::string::String,
+    /// expected blocks per year
+    #[prost(uint64, tag = "6")]
+    pub blocks_per_year: u64,
+}
+/// QueryParamsRequest is the request type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {}
+/// QueryParamsResponse is the response type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    /// params defines the parameters of the module.
+    #[prost(message, optional, tag = "1")]
+    pub params: ::core::option::Option<Params>,
+}
+/// QueryInflationRequest is the request type for the Query/Inflation RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryInflationRequest {}
+/// QueryInflationResponse is the response type for the Query/Inflation RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryInflationResponse {
+    /// inflation is the current minting inflation value.
+    #[prost(bytes = "vec", tag = "1")]
+    pub inflation: ::prost::alloc::vec::Vec<u8>,
+}
+/// QueryAnnualProvisionsRequest is the request type for the
+/// Query/AnnualProvisions RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAnnualProvisionsRequest {}
+/// QueryAnnualProvisionsResponse is the response type for the
+/// Query/AnnualProvisions RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAnnualProvisionsResponse {
+    /// annual_provisions is the current minting annual provisions value.
+    #[prost(bytes = "vec", tag = "1")]
+    pub annual_provisions: ::prost::alloc::vec::Vec<u8>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query provides defines the gRPC querier service."]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Params returns the total set of minting parameters."]
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.mint.v1beta1.Query/Params");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Inflation returns the current minting inflation value."]
+        pub async fn inflation(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryInflationRequest>,
+        ) -> Result<tonic::Response<super::QueryInflationResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.mint.v1beta1.Query/Inflation");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " AnnualProvisions current minting annual provisions value."]
+        pub async fn annual_provisions(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryAnnualProvisionsRequest>,
+        ) -> Result<tonic::Response<super::QueryAnnualProvisionsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.mint.v1beta1.Query/AnnualProvisions");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.params.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.params.v1beta1.rs
@@ -1,0 +1,104 @@
+/// ParameterChangeProposal defines a proposal to change one or more parameters.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ParameterChangeProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub changes: ::prost::alloc::vec::Vec<ParamChange>,
+}
+/// ParamChange defines an individual parameter change, for use in
+/// ParameterChangeProposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ParamChange {
+    #[prost(string, tag = "1")]
+    pub subspace: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub value: ::prost::alloc::string::String,
+}
+/// QueryParamsRequest is request type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {
+    /// subspace defines the module to query the parameter for.
+    #[prost(string, tag = "1")]
+    pub subspace: ::prost::alloc::string::String,
+    /// key defines the key of the parameter in the subspace.
+    #[prost(string, tag = "2")]
+    pub key: ::prost::alloc::string::String,
+}
+/// QueryParamsResponse is response type for the Query/Params RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    /// param defines the queried parameter.
+    #[prost(message, optional, tag = "1")]
+    pub param: ::core::option::Option<ParamChange>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query defines the gRPC querier service."]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Params queries a specific parameter of a module, given its subspace and"]
+        #[doc = " key."]
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.params.v1beta1.Query/Params");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.slashing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.slashing.v1beta1.rs
@@ -1,0 +1,253 @@
+/// ValidatorSigningInfo defines a validator's signing info for monitoring their
+/// liveness activity.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorSigningInfo {
+    #[prost(string, tag = "1")]
+    pub address: ::prost::alloc::string::String,
+    /// height at which validator was first a candidate OR was unjailed
+    #[prost(int64, tag = "2")]
+    pub start_height: i64,
+    /// index offset into signed block bit array
+    #[prost(int64, tag = "3")]
+    pub index_offset: i64,
+    /// timestamp validator cannot be unjailed until
+    #[prost(message, optional, tag = "4")]
+    pub jailed_until: ::core::option::Option<::prost_types::Timestamp>,
+    /// whether or not a validator has been tombstoned (killed out of validator
+    /// set)
+    #[prost(bool, tag = "5")]
+    pub tombstoned: bool,
+    /// missed blocks counter (to avoid scanning the array every time)
+    #[prost(int64, tag = "6")]
+    pub missed_blocks_counter: i64,
+}
+/// Params represents the parameters used for by the slashing module.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Params {
+    #[prost(int64, tag = "1")]
+    pub signed_blocks_window: i64,
+    #[prost(bytes = "vec", tag = "2")]
+    pub min_signed_per_window: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub downtime_jail_duration: ::core::option::Option<::prost_types::Duration>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub slash_fraction_double_sign: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub slash_fraction_downtime: ::prost::alloc::vec::Vec<u8>,
+}
+/// QueryParamsRequest is the request type for the Query/Params RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {}
+/// QueryParamsResponse is the response type for the Query/Params RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    #[prost(message, optional, tag = "1")]
+    pub params: ::core::option::Option<Params>,
+}
+/// QuerySigningInfoRequest is the request type for the Query/SigningInfo RPC
+/// method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySigningInfoRequest {
+    /// cons_address is the address to query signing info of
+    #[prost(string, tag = "1")]
+    pub cons_address: ::prost::alloc::string::String,
+}
+/// QuerySigningInfoResponse is the response type for the Query/SigningInfo RPC
+/// method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySigningInfoResponse {
+    /// val_signing_info is the signing info of requested val cons address
+    #[prost(message, optional, tag = "1")]
+    pub val_signing_info: ::core::option::Option<ValidatorSigningInfo>,
+}
+/// QuerySigningInfosRequest is the request type for the Query/SigningInfos RPC
+/// method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySigningInfosRequest {
+    #[prost(message, optional, tag = "1")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QuerySigningInfosResponse is the response type for the Query/SigningInfos RPC
+/// method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySigningInfosResponse {
+    /// info is the signing info of all validators
+    #[prost(message, repeated, tag = "1")]
+    pub info: ::prost::alloc::vec::Vec<ValidatorSigningInfo>,
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query provides defines the gRPC querier service"]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Params queries the parameters of slashing module"]
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.slashing.v1beta1.Query/Params");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " SigningInfo queries the signing info of given cons address"]
+        pub async fn signing_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QuerySigningInfoRequest>,
+        ) -> Result<tonic::Response<super::QuerySigningInfoResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.slashing.v1beta1.Query/SigningInfo");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " SigningInfos queries signing info of all validators"]
+        pub async fn signing_infos(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QuerySigningInfosRequest>,
+        ) -> Result<tonic::Response<super::QuerySigningInfosResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.slashing.v1beta1.Query/SigningInfos");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}
+/// MsgUnjail defines the Msg/Unjail request type
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUnjail {
+    #[prost(string, tag = "1")]
+    pub validator_addr: ::prost::alloc::string::String,
+}
+/// MsgUnjailResponse defines the Msg/Unjail response type
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUnjailResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the slashing Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " Unjail defines a method for unjailing a jailed validator, thus returning"]
+        #[doc = " them into the bonded validator set, so they can begin receiving provisions"]
+        #[doc = " and rewards again."]
+        pub async fn unjail(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUnjail>,
+        ) -> Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.slashing.v1beta1.Msg/Unjail");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.staking.v1beta1.rs
@@ -839,3 +839,225 @@ pub mod query_client {
         }
     }
 }
+/// MsgCreateValidator defines a SDK message for creating a new validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateValidator {
+    #[prost(message, optional, tag = "1")]
+    pub description: ::core::option::Option<Description>,
+    #[prost(message, optional, tag = "2")]
+    pub commission: ::core::option::Option<CommissionRates>,
+    #[prost(string, tag = "3")]
+    pub min_self_delegation: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "6")]
+    pub pubkey: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, optional, tag = "7")]
+    pub value: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgCreateValidatorResponse defines the Msg/CreateValidator response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateValidatorResponse {}
+/// MsgEditValidator defines a SDK message for editing an existing validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgEditValidator {
+    #[prost(message, optional, tag = "1")]
+    pub description: ::core::option::Option<Description>,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    /// We pass a reference to the new commission rate and min self delegation as
+    /// it's not mandatory to update. If not updated, the deserialized rate will be
+    /// zero with no way to distinguish if an update was intended.
+    /// REF: #2373
+    #[prost(string, tag = "3")]
+    pub commission_rate: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub min_self_delegation: ::prost::alloc::string::String,
+}
+/// MsgEditValidatorResponse defines the Msg/EditValidator response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgEditValidatorResponse {}
+/// MsgDelegate defines a SDK message for performing a delegation of coins
+/// from a delegator to a validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgDelegateResponse defines the Msg/Delegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDelegateResponse {}
+/// MsgBeginRedelegate defines a SDK message for performing a redelegation
+/// of coins from a delegator and source validator to a destination validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgBeginRedelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_src_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub validator_dst_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "4")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgBeginRedelegateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// MsgUndelegate defines a SDK message for performing an undelegation from a
+/// delegate and a validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUndelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgUndelegateResponse defines the Msg/Undelegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUndelegateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the staking Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " CreateValidator defines a method for creating a new validator."]
+        pub async fn create_validator(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgCreateValidator>,
+        ) -> Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/CreateValidator");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " EditValidator defines a method for editing an existing validator."]
+        pub async fn edit_validator(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgEditValidator>,
+        ) -> Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/EditValidator");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Delegate defines a method for performing a delegation of coins"]
+        #[doc = " from a delegator to a validator."]
+        pub async fn delegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgDelegate>,
+        ) -> Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/Delegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " BeginRedelegate defines a method for performing a redelegation"]
+        #[doc = " of coins from a delegator and source validator to a destination validator."]
+        pub async fn begin_redelegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgBeginRedelegate>,
+        ) -> Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/BeginRedelegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " Undelegate defines a method for performing an undelegation from a"]
+        #[doc = " delegate and a validator."]
+        pub async fn undelegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUndelegate>,
+        ) -> Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/Undelegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.upgrade.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.upgrade.v1beta1.rs
@@ -1,0 +1,199 @@
+/// Plan specifies information about a planned upgrade and when it should occur.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Plan {
+    /// Sets the name for the upgrade. This name will be used by the upgraded
+    /// version of the software to apply any special "on-upgrade" commands during
+    /// the first BeginBlock method after the upgrade is applied. It is also used
+    /// to detect whether a software version can handle a given upgrade. If no
+    /// upgrade handler with this name has been set in the software, it will be
+    /// assumed that the software is out-of-date when the upgrade Time or Height is
+    /// reached and the software will exit.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// The time after which the upgrade must be performed.
+    /// Leave set to its zero value to use a pre-defined Height instead.
+    #[prost(message, optional, tag = "2")]
+    pub time: ::core::option::Option<::prost_types::Timestamp>,
+    /// The height at which the upgrade must be performed.
+    /// Only used if Time is not set.
+    #[prost(int64, tag = "3")]
+    pub height: i64,
+    /// Any application specific upgrade info to be included on-chain
+    /// such as a git commit that validators could automatically upgrade to
+    #[prost(string, tag = "4")]
+    pub info: ::prost::alloc::string::String,
+    /// IBC-enabled chains can opt-in to including the upgraded client state in its upgrade plan
+    /// This will make the chain commit to the correct upgraded (self) client state before the upgrade occurs,
+    /// so that connecting chains can verify that the new upgraded client is valid by verifying a proof on the
+    /// previous version of the chain.
+    /// This will allow IBC connections to persist smoothly across planned chain upgrades
+    #[prost(message, optional, tag = "5")]
+    pub upgraded_client_state: ::core::option::Option<::prost_types::Any>,
+}
+/// SoftwareUpgradeProposal is a gov Content type for initiating a software
+/// upgrade.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SoftwareUpgradeProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub plan: ::core::option::Option<Plan>,
+}
+/// CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software
+/// upgrade.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CancelSoftwareUpgradeProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+}
+/// QueryCurrentPlanRequest is the request type for the Query/CurrentPlan RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryCurrentPlanRequest {}
+/// QueryCurrentPlanResponse is the response type for the Query/CurrentPlan RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryCurrentPlanResponse {
+    /// plan is the current upgrade plan.
+    #[prost(message, optional, tag = "1")]
+    pub plan: ::core::option::Option<Plan>,
+}
+/// QueryCurrentPlanRequest is the request type for the Query/AppliedPlan RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAppliedPlanRequest {
+    /// name is the name of the applied plan to query for.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// QueryAppliedPlanResponse is the response type for the Query/AppliedPlan RPC
+/// method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAppliedPlanResponse {
+    /// height is the block height at which the plan was applied.
+    #[prost(int64, tag = "1")]
+    pub height: i64,
+}
+/// QueryUpgradedConsensusStateRequest is the request type for the Query/UpgradedConsensusState
+/// RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryUpgradedConsensusStateRequest {
+    /// last height of the current chain must be sent in request
+    /// as this is the height under which next consensus state is stored
+    #[prost(int64, tag = "1")]
+    pub last_height: i64,
+}
+/// QueryUpgradedConsensusStateResponse is the response type for the Query/UpgradedConsensusState
+/// RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryUpgradedConsensusStateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub upgraded_consensus_state: ::core::option::Option<::prost_types::Any>,
+}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Query defines the gRPC upgrade querier service."]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl QueryClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " CurrentPlan queries the current upgrade plan."]
+        pub async fn current_plan(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryCurrentPlanRequest>,
+        ) -> Result<tonic::Response<super::QueryCurrentPlanResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.upgrade.v1beta1.Query/CurrentPlan");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " AppliedPlan queries a previously applied upgrade plan by its name."]
+        pub async fn applied_plan(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryAppliedPlanRequest>,
+        ) -> Result<tonic::Response<super::QueryAppliedPlanResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.upgrade.v1beta1.Query/AppliedPlan");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        #[doc = " UpgradedConsensusState queries the consensus state that will serve"]
+        #[doc = " as a trusted kernel for the next version of this chain. It will only be"]
+        #[doc = " stored at the last height of this chain."]
+        #[doc = " UpgradedConsensusState RPC not supported with legacy querier"]
+        pub async fn upgraded_consensus_state(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryUpgradedConsensusStateRequest>,
+        ) -> Result<tonic::Response<super::QueryUpgradedConsensusStateResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.upgrade.v1beta1.Query/UpgradedConsensusState",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for QueryClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for QueryClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "QueryClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos.vesting.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.vesting.v1beta1.rs
@@ -1,0 +1,87 @@
+/// MsgCreateVestingAccount defines a message that enables creating a vesting
+/// account.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateVestingAccount {
+    #[prost(string, tag = "1")]
+    pub from_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub to_address: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(int64, tag = "4")]
+    pub end_time: i64,
+    #[prost(bool, tag = "5")]
+    pub delayed: bool,
+}
+/// MsgCreateVestingAccountResponse defines the Msg/CreateVestingAccount response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateVestingAccountResponse {}
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+#[doc = r" Generated client implementations."]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use tonic::codegen::*;
+    #[doc = " Msg defines the bank Msg service."]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl MsgClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+            Self { inner }
+        }
+        #[doc = " CreateVestingAccount defines a method that enables creating a vesting"]
+        #[doc = " account."]
+        pub async fn create_vesting_account(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgCreateVestingAccount>,
+        ) -> Result<tonic::Response<super::MsgCreateVestingAccountResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.vesting.v1beta1.Msg/CreateVestingAccount",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+    impl<T: Clone> Clone for MsgClient<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+    impl<T> std::fmt::Debug for MsgClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MsgClient {{ ... }}")
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.applications.transfer.v1.rs
@@ -43,6 +43,16 @@ pub struct Params {
     #[prost(bool, tag = "2")]
     pub receive_enabled: bool,
 }
+/// GenesisState defines the ibc-transfer genesis state
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    #[prost(string, tag = "1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub denom_traces: ::prost::alloc::vec::Vec<DenomTrace>,
+    #[prost(message, optional, tag = "3")]
+    pub params: ::core::option::Option<Params>,
+}
 /// QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -90,16 +100,6 @@ pub struct QueryParamsRequest {}
 pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
-    pub params: ::core::option::Option<Params>,
-}
-/// GenesisState defines the ibc-transfer genesis state
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GenesisState {
-    #[prost(string, tag = "1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "2")]
-    pub denom_traces: ::prost::alloc::vec::Vec<DenomTrace>,
-    #[prost(message, optional, tag = "3")]
     pub params: ::core::option::Option<Params>,
 }
 /// MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between

--- a/cosmos-sdk-proto/src/prost/ibc.core.client.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.client.v1.rs
@@ -73,6 +73,46 @@ pub struct Params {
     #[prost(string, repeated, tag = "1")]
     pub allowed_clients: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// GenesisState defines the ibc client submodule's genesis state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    /// client states with their corresponding identifiers
+    #[prost(message, repeated, tag = "1")]
+    pub clients: ::prost::alloc::vec::Vec<IdentifiedClientState>,
+    /// consensus states from each client
+    #[prost(message, repeated, tag = "2")]
+    pub clients_consensus: ::prost::alloc::vec::Vec<ClientConsensusStates>,
+    /// metadata from each client
+    #[prost(message, repeated, tag = "3")]
+    pub clients_metadata: ::prost::alloc::vec::Vec<IdentifiedGenesisMetadata>,
+    #[prost(message, optional, tag = "4")]
+    pub params: ::core::option::Option<Params>,
+    /// create localhost on initialization
+    #[prost(bool, tag = "5")]
+    pub create_localhost: bool,
+    /// the sequence for the next generated client identifier
+    #[prost(uint64, tag = "6")]
+    pub next_client_sequence: u64,
+}
+/// GenesisMetadata defines the genesis type for metadata that clients may return
+/// with ExportMetadata
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisMetadata {
+    /// store key of metadata without clientID-prefix
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    /// metadata value
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// IdentifiedGenesisMetadata has the client metadata with the corresponding client id.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IdentifiedGenesisMetadata {
+    #[prost(string, tag = "1")]
+    pub client_id: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub client_metadata: ::prost::alloc::vec::Vec<GenesisMetadata>,
+}
 /// QueryClientStateRequest is the request type for the Query/ClientState RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -187,46 +227,6 @@ pub struct QueryClientParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
-}
-/// GenesisState defines the ibc client submodule's genesis state.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GenesisState {
-    /// client states with their corresponding identifiers
-    #[prost(message, repeated, tag = "1")]
-    pub clients: ::prost::alloc::vec::Vec<IdentifiedClientState>,
-    /// consensus states from each client
-    #[prost(message, repeated, tag = "2")]
-    pub clients_consensus: ::prost::alloc::vec::Vec<ClientConsensusStates>,
-    /// metadata from each client
-    #[prost(message, repeated, tag = "3")]
-    pub clients_metadata: ::prost::alloc::vec::Vec<IdentifiedGenesisMetadata>,
-    #[prost(message, optional, tag = "4")]
-    pub params: ::core::option::Option<Params>,
-    /// create localhost on initialization
-    #[prost(bool, tag = "5")]
-    pub create_localhost: bool,
-    /// the sequence for the next generated client identifier
-    #[prost(uint64, tag = "6")]
-    pub next_client_sequence: u64,
-}
-/// GenesisMetadata defines the genesis type for metadata that clients may return
-/// with ExportMetadata
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GenesisMetadata {
-    /// store key of metadata without clientID-prefix
-    #[prost(bytes = "vec", tag = "1")]
-    pub key: ::prost::alloc::vec::Vec<u8>,
-    /// metadata value
-    #[prost(bytes = "vec", tag = "2")]
-    pub value: ::prost::alloc::vec::Vec<u8>,
-}
-/// IdentifiedGenesisMetadata has the client metadata with the corresponding client id.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IdentifiedGenesisMetadata {
-    #[prost(string, tag = "1")]
-    pub client_id: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag = "2")]
-    pub client_metadata: ::prost::alloc::vec::Vec<GenesisMetadata>,
 }
 /// MsgCreateClient defines a message to create an IBC client
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/ibc.core.connection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc.core.connection.v1.rs
@@ -107,6 +107,17 @@ pub enum State {
     /// A connection end has completed the handshake.
     Open = 3,
 }
+/// GenesisState defines the ibc connection submodule's genesis state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    #[prost(message, repeated, tag = "1")]
+    pub connections: ::prost::alloc::vec::Vec<IdentifiedConnection>,
+    #[prost(message, repeated, tag = "2")]
+    pub client_connection_paths: ::prost::alloc::vec::Vec<ConnectionPaths>,
+    /// the sequence for the next generated connection identifier
+    #[prost(uint64, tag = "3")]
+    pub next_connection_sequence: u64,
+}
 /// QueryConnectionRequest is the request type for the Query/Connection RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -228,17 +239,6 @@ pub struct QueryConnectionConsensusStateResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "4")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-}
-/// GenesisState defines the ibc connection submodule's genesis state.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GenesisState {
-    #[prost(message, repeated, tag = "1")]
-    pub connections: ::prost::alloc::vec::Vec<IdentifiedConnection>,
-    #[prost(message, repeated, tag = "2")]
-    pub client_connection_paths: ::prost::alloc::vec::Vec<ConnectionPaths>,
-    /// the sequence for the next generated connection identifier
-    #[prost(uint64, tag = "3")]
-    pub next_connection_sequence: u64,
 }
 /// MsgConnectionOpenInit defines the msg sent by an account on Chain A to
 /// initialize a connection with Chain B.

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.3", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = {version = "0.4", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -146,12 +146,25 @@ fn compile_protos(out_dir: &Path) {
     // Paths
     let proto_paths = [
         format!("{}/../proto/definitions/mock", root),
-        format!("{}/proto/ibc", sdk_dir.display()),
-        format!("{}/proto/cosmos/tx", sdk_dir.display()),
+        format!("{}/proto/cosmos/auth", sdk_dir.display()),
         format!("{}/proto/cosmos/bank", sdk_dir.display()),
         format!("{}/proto/cosmos/base", sdk_dir.display()),
         format!("{}/proto/cosmos/base/tendermint", sdk_dir.display()),
+        format!("{}/proto/cosmos/capability", sdk_dir.display()),
+        format!("{}/proto/cosmos/crisis", sdk_dir.display()),
+        format!("{}/proto/cosmos/crypto", sdk_dir.display()),
+        format!("{}/proto/cosmos/distribution", sdk_dir.display()),
+        format!("{}/proto/cosmos/evidence", sdk_dir.display()),
+        format!("{}/proto/cosmos/genutil", sdk_dir.display()),
+        format!("{}/proto/cosmos/gov", sdk_dir.display()),
+        format!("{}/proto/cosmos/mint", sdk_dir.display()),
+        format!("{}/proto/cosmos/params", sdk_dir.display()),
+        format!("{}/proto/cosmos/slashing", sdk_dir.display()),
         format!("{}/proto/cosmos/staking", sdk_dir.display()),
+        format!("{}/proto/cosmos/tx", sdk_dir.display()),
+        format!("{}/proto/cosmos/upgrade", sdk_dir.display()),
+        format!("{}/proto/cosmos/vesting", sdk_dir.display()),
+        format!("{}/proto/ibc", sdk_dir.display()),
     ];
 
     let proto_includes_paths = [
@@ -209,11 +222,26 @@ fn compile_proto_services(out_dir: impl AsRef<Path>) {
 
     let proto_services_path = [
         sdk_dir.join("proto/cosmos/auth/v1beta1/query.proto"),
-        sdk_dir.join("proto/cosmos/base/tendermint/v1beta1/query.proto"),
-        sdk_dir.join("proto/cosmos/staking/v1beta1/query.proto"),
         sdk_dir.join("proto/cosmos/bank/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/bank/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/base/tendermint/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/crisis/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/distribution/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/distribution/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/evidence/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/evidence/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/gov/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/gov/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/mint/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/params/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/slashing/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/slashing/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/staking/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/staking/v1beta1/tx.proto"),
         sdk_dir.join("proto/cosmos/tx/v1beta1/service.proto"),
         sdk_dir.join("proto/cosmos/tx/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/upgrade/v1beta1/query.proto"),
+        sdk_dir.join("proto/cosmos/vesting/v1beta1/tx.proto"),
     ];
 
     // List available paths for dependencies


### PR DESCRIPTION
This pull request expands cosmos-sdk-proto to include all files from the upstream cosmos-sdk proto folder. It also adds services relating to transactions to the new modules and existing modules where they where previously missing. This should allow consumers of the library to import use cosmos-sdk-proto for producing many different transaction types without having to trace them down themselves.

During this change I've alphabetized all the proto imports and lists wherever they exist. Purely for ease of keeping track of what modules are or are not imported.

This patch rebuilds the proto files purely for the sake of making sure the tests pass, since the proto will be auto-regenerated once it's merged. Which is a bit of a waste of a commit  but not terrible in exchange for the other benefits. I suppose we could have the tests rebuild proto before running, which would resolve this minor issue. 

I've updated the minor version of cosmos-sdk-proto, since these changes are fully backwards compatible and we've expanded the API surface without changing any existing interfaces.