### PR TITLE
cosmos-tx: add SigningKey type

### DIFF
--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -17,6 +17,7 @@ eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }
 prost = "0.7"
 prost-types = "0.7"
+rand_core = "0.5"
 rust_decimal = "1.9"
-tendermint = "0.18"
+tendermint = { version = "0.18", features = ["secp256k1"] }
 thiserror = "1"

--- a/cosmos-tx/src/lib.rs
+++ b/cosmos-tx/src/lib.rs
@@ -11,9 +11,10 @@ mod builder;
 mod decimal;
 mod error;
 mod msg;
+mod signing_key;
 
-pub use crate::{builder::Builder, decimal::Decimal, error::Error, msg::Msg};
+pub use crate::{
+    builder::Builder, decimal::Decimal, error::Error, msg::Msg, signing_key::SigningKey,
+};
 pub use k256::ecdsa::{Signature, VerifyingKey};
-
-/// Transaction signer for ECDSA/secp256k1 signatures
-pub type Signer = dyn ecdsa::signature::Signer<Signature>;
+pub use tendermint::PublicKey;

--- a/cosmos-tx/src/signing_key.rs
+++ b/cosmos-tx/src/signing_key.rs
@@ -1,0 +1,71 @@
+//! Transaction signing key
+
+use crate::{PublicKey, Signature};
+use core::convert::TryFrom;
+use ecdsa::elliptic_curve::sec1::ToEncodedPoint;
+use eyre::Result;
+use rand_core::{CryptoRng, RngCore};
+
+/// Transaction signing key.
+pub struct SigningKey {
+    inner: Box<dyn Secp256k1Signer>,
+}
+
+impl SigningKey {
+    /// Generate a random signing key.
+    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+        Self {
+            inner: Box::new(k256::ecdsa::SigningKey::random(rng)),
+        }
+    }
+
+    /// Initialize from a raw scalar value (big endian).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let signing_key = k256::ecdsa::SigningKey::from_bytes(bytes)?;
+        Ok(Self {
+            inner: Box::new(signing_key),
+        })
+    }
+
+    /// Sign the given message, returning a signature.
+    pub fn sign(&self, msg: &[u8]) -> Result<Signature> {
+        Ok(self.inner.try_sign(msg)?)
+    }
+
+    /// Get the Tendermint public key for this [`SigningKey`]
+    pub fn public_key(&self) -> PublicKey {
+        self.inner.public_key()
+    }
+}
+
+impl From<Box<dyn Secp256k1Signer>> for SigningKey {
+    fn from(signer: Box<dyn Secp256k1Signer>) -> Self {
+        Self { inner: signer }
+    }
+}
+
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = eyre::Report;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
+    }
+}
+
+/// ECDSA/secp256k1 signer
+pub trait Secp256k1Signer: ecdsa::signature::Signer<Signature> {
+    /// Get the Tendermint public key for this signer
+    fn public_key(&self) -> PublicKey;
+}
+
+impl<T> Secp256k1Signer for T
+where
+    T: ecdsa::signature::Signer<Signature>,
+    k256::ecdsa::VerifyingKey: for<'a> From<&'a T>,
+{
+    fn public_key(&self) -> PublicKey {
+        k256::ecdsa::VerifyingKey::from(self)
+            .to_encoded_point(true)
+            .into()
+    }
+}


### PR DESCRIPTION
Adds a `SigningKey` type which wraps a `Box` containing a concrete
signing key implementation, allowing it to be used with either a
soft-signer (backed by the `k256` crate) or HSM signers that impl
the correct combination of traits (e.g. `yubihsm`)

This type additionally provides methods for obtaining a
`tendermint::PublicKey` for the signer, which is needed for e.g.
computing the relevant account address for the signer.

As it were, obtaining the account address is needed to implement
integration testing, as it's the first parameter we need to pass into a
single-node gaia Docker container.