### PR TITLE
CI: constrain when rebuild-protos runs

### DIFF
--- a/.github/workflows/rebuild-protos.yml
+++ b/.github/workflows/rebuild-protos.yml
@@ -3,6 +3,8 @@ name: Rebuild Protos
 on:
   push:
     branches: main
+    paths:
+      - "proto-build/**"
 
 jobs:
   proto-build:


### PR DESCRIPTION
Protos should only be rebuilt if files in `proto-build/` change, e.g. `COSMOS_REV` is bumped or other changes are made to the proto generator.

This should cut down on spurious rebuilds, since unfortunately the generated code does not appear to be fully deterministic.