### PR TITLE
Bump cosmos-sdk-proto release

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -1,11 +1,37 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2020-02-01)
+## 0.5.0 (2021-04-10)
+
 ### Changed
+
+- Add support for crypto proto and services ([#73])
+- Update tendermint crate ([#72])
+
+[#72]: https://github.com/cosmos/cosmos-rust/pull/72
+[#73]: https://github.com/cosmos/cosmos-rust/pull/73
+
+## 0.4.0 (2021-04-02)
+
+### Changed
+
+- Add support for bank proto and services ([#61])
+- Add support for tendermint proto and services ([#57])
+- Add support for bank, crisis, distribution, evidence, genutil, gov, mint, params, slashing, staking upgrade and vesting proto and services ([#64])
+- Bump COSMOS_REV to v0.42.3 ([#57])
+
+[#57]: https://github.com/cosmos/cosmos-rust/pull/57
+[#61]: https://github.com/cosmos/cosmos-rust/pull/61
+[#61]: https://github.com/cosmos/cosmos-rust/pull/64
+
+## 0.3.0 (2020-02-01)
+
+### Changed
+
 - Bump `cosmos-sdk` rev to v0.40.0 ([#37])
 - Bump `tendermint` crate dependency to v0.18 ([#45])
 - Bump `prost`, `prost-types`, `prost-build` to v0.7 ([#45])
@@ -17,10 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#45]: https://github.com/cosmos/cosmos-rust/pull/45
 
 ## 0.2.0 (2020-01-04)
+
 ### Added
+
 - `grpc` crate feature ([#8])
 
 ### Changed
+
 - Bump `cosmos-sdk` rev to v0.40.0-rc6 ([#32])
 - Bump `tendermint` + `tendermint-proto` crate dependencies to v0.17 ([#18])
 - Format `prost`/`tonic` output with `rustfmt` ([#17])
@@ -33,4 +62,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.2 (2020-11-30)
 
 ## 0.1.1 (2020-11-30)
+
 - Initial release

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.4.0"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]

--- a/cosmos-tx/Cargo.toml
+++ b/cosmos-tx/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = {version = "0.4", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = {version = "0.5", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.10", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.7", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
This release bump just gets the crypto structs into a crates.io release.
Very minor change overall.