### PR TITLE
cosmos-sdk-rs: add initial usage docs and `dev` module

### DIFF
--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -22,11 +22,10 @@ subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tendermint = { version = "0.19", default-features = false, features = ["secp256k1"] }
 tendermint-rpc = { version = "0.19", optional = true, features = ["http-client"] }
 thiserror = "1"
-
-[dev-dependencies]
-tokio = "1"
+tokio = { version = "1", optional = true }
 
 [features]
+dev = ["rpc", "tokio"]
 rpc = ["tendermint-rpc"]
 
 [package.metadata.docs.rs]

--- a/cosmos-sdk-rs/src/dev.rs
+++ b/cosmos-sdk-rs/src/dev.rs
@@ -1,0 +1,113 @@
+//! Development-related functionality.
+//!
+//! This module contains support for integration testing against a
+//! Cosmos SDK-compatible full node (gaia) running inside of Docker.
+
+use crate::{
+    rpc::{self, Client},
+    tx::{self, Tx},
+};
+use std::{ffi::OsStr, panic, process, str, time::Duration};
+use tokio::time;
+
+/// Docker image (on Docker Hub) containing a single-node test environment for
+/// [`gaia`], the reference implementation of a Cosmos Hub full node.
+///
+/// [`gaia`]: https://github.com/cosmos/gaia
+pub const GAIA_DOCKER_IMAGE: &str = "jackzampolin/gaiatest";
+
+/// Invoke `docker run` with the given arguments, calling the provided function
+/// after the container has booted and terminating the container after the
+/// provided function completes, catching panics and propagating them to ensure
+/// that the container reliably shuts down.
+///
+/// Prints log output from the container in the event an error occurred.
+pub fn docker_run<A, S, F, R>(args: A, f: F) -> R
+where
+    A: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+    F: FnOnce() -> R + panic::UnwindSafe,
+{
+    let container_id = exec_docker_command("run", args);
+    let result = panic::catch_unwind(f);
+
+    if result.is_err() {
+        let logs = exec_docker_command("logs", &[&container_id]);
+
+        println!("\n---- docker stdout ----");
+        println!("{}", logs);
+    }
+
+    exec_docker_command("kill", &[&container_id]);
+
+    match result {
+        Ok(res) => res,
+        Err(err) => panic::resume_unwind(err),
+    }
+}
+
+/// Execute a given `docker` command, returning what was written to stdout
+/// if the command completed successfully.
+///
+/// Panics if the `docker` process exits with an error code.
+fn exec_docker_command<A, S>(name: &str, args: A) -> String
+where
+    A: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = process::Command::new("docker")
+        .arg(name)
+        .args(args)
+        .stdout(process::Stdio::piped())
+        .output()
+        .unwrap_or_else(|err| panic!("error invoking `docker {}`: {}", name, err));
+
+    if !output.status.success() {
+        panic!("`docker {}` exited with error status: {:?}", name, output);
+    }
+
+    str::from_utf8(&output.stdout)
+        .expect("UTF-8 error decoding docker output")
+        .trim_end()
+        .to_owned()
+}
+
+/// Wait for the node to produce the first block.
+///
+/// This should be used at the beginning of the test lifecycle to ensure
+/// the node is fully booted.
+pub async fn poll_for_first_block(rpc_client: &rpc::HttpClient) {
+    rpc_client
+        .wait_until_healthy(Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let mut attempts_remaining = 25;
+
+    while let Err(e) = rpc_client.latest_block().await {
+        if e.code() != rpc::error::Code::ParseError {
+            panic!("unexpected error waiting for first block: {}", e);
+        }
+
+        if attempts_remaining == 0 {
+            panic!("timeout waiting for first block");
+        }
+
+        attempts_remaining -= 1;
+        time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Wait for a transaction with the given hash to appear in the blockchain
+pub async fn poll_for_tx(rpc_client: &rpc::HttpClient, tx_hash: &tx::Hash) -> Tx {
+    let attempts = 5;
+
+    for _ in 0..attempts {
+        // TODO(tarcieri): handle not found errors
+        if let Ok(tx) = Tx::find_by_hash(rpc_client, tx_hash).await {
+            return tx;
+        }
+    }
+
+    panic!("couldn't find transaction after {} attempts!", attempts);
+}

--- a/cosmos-sdk-rs/src/error.rs
+++ b/cosmos-sdk-rs/src/error.rs
@@ -2,10 +2,11 @@
 
 pub use eyre::{Report, Result};
 
+use crate::tx;
 use thiserror::Error;
 
 /// Kinds of errors.
-#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum Error {
     /// Invalid account.
     #[error("invalid account ID: {id:?}")]
@@ -48,4 +49,13 @@ pub enum Error {
         /// Actual type URL found in the [`prost_types::Any`] message.
         found: String,
     },
+
+    /// Transaction not found.
+    #[error("transaction not found: {hash:?}")]
+    TxNotFound {
+        /// Transaction hash that wasn't found.
+        hash: tx::Hash,
+    },
 }
+
+impl Eq for Error {}

--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -22,6 +22,10 @@ pub mod bank;
 pub mod crypto;
 pub mod tx;
 
+#[cfg(feature = "dev")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
+pub mod dev;
+
 mod base;
 mod decimal;
 mod error;
@@ -38,4 +42,5 @@ pub use cosmos_sdk_proto as proto;
 pub use tendermint;
 
 #[cfg(feature = "rpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rpc")))]
 pub use tendermint_rpc as rpc;

--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -1,4 +1,14 @@
-//! Transaction builder and signer for Cosmos-based blockchains
+//! # Cosmos SDK for Rust
+//!
+//! Framework for building [Cosmos] blockchain applications in Rust, modeled off
+//! of the [Cosmos SDK for Golang].
+//!
+//! ## Features
+//!
+//! - [Transactions][`tx`]: build, sign, and/or parse Cosmos SDK transactions
+//!
+//! [Cosmos]: https://cosmos.network/
+//! [Cosmos SDK for Golang]: https://github.com/cosmos/cosmos-sdk
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(

--- a/cosmos-sdk-rs/src/tx.rs
+++ b/cosmos-sdk-rs/src/tx.rs
@@ -1,4 +1,106 @@
-//! Transactions.
+//! Cosmos SDK transacstion support.
+//!
+//! ## About
+//!
+//! The [Cosmos SDK](https://v1.cosmos.network/sdk) defines a standard
+//! transaction format used by blockchain applications built on the SDK.
+//!
+//! Transactions are comprised of metadata held in contexts and [`Msg`]s
+//! that trigger state changes within a module through the module's [`Msg`] service.
+//!
+//! When users want to interact with an application and make state changes
+//! (e.g. sending coins), they create transactions. Each of a transaction's [`Msg`]s
+//! must be signed using the private key associated with the appropriate account(s),
+//! before the transaction is broadcasted to the network.
+//!
+//! A transaction must then be included in a block, validated, and approved by the
+//! network through the consensus process.
+//!
+//! ## Usage
+//!
+//! The following example illustrates how to build, sign, and parse
+//! a Cosmos SDK transaction:
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! use cosmos_sdk::{
+//!     bank::MsgSend,
+//!     crypto::secp256k1,
+//!     tx::{self, Fee, MsgType, SignDoc, SignerInfo, Tx},
+//!     AccountId, Coin
+//! };
+//!
+//! // Generate sender private key.
+//! // In real world usage, this account would need to be funded before use.
+//! let sender_private_key = secp256k1::SigningKey::random();
+//! let sender_public_key = sender_private_key.public_key();
+//! let sender_account_id = sender_public_key.account_id("cosmos")?;
+//!
+//! // Parse recipient address from Bech32.
+//! let recipient_account_id = "cosmos19dyl0uyzes4k23lscla02n06fc22h4uqsdwq6z"
+//!     .parse::<AccountId>()?;
+//!
+//! ///////////////////////////
+//! // Building transactions //
+//! ///////////////////////////
+//!
+//! // We'll be doing a simple send transaction.
+//! // First we'll create a "Coin" amount to be sent, in this case 1 million uatoms.
+//! let amount = Coin {
+//!     amount: 1_000_000u64.into(),
+//!     denom: "uatom".parse()?,
+//! };
+//!
+//! // Next we'll create a send message (from the "bank" module) for the coin
+//! // amount we created above.
+//! let msg_send = MsgSend {
+//!     from_address: sender_account_id.clone(),
+//!     to_address: recipient_account_id,
+//!     amount: vec![amount.clone()],
+//! };
+//!
+//! // Transaction metadata: chain, account, sequence, gas, fee, timeout, and memo.
+//! let chain_id = "cosmoshub-4".parse()?;
+//! let account_number = 1;
+//! let sequence_number = 0;
+//! let gas = 100_000;
+//! let timeout_height = 9001u16;
+//! let memo = "example memo";
+//!
+//! // Create transaction body from the MsgSend, memo, and timeout height.
+//! let tx_body = tx::Body::new(vec![msg_send.to_msg()?], memo, timeout_height);
+//!
+//! // Create signer info from public key and sequence number.
+//! // This uses a standard "direct" signature from a single signer.
+//! let signer_info = SignerInfo::single_direct(Some(sender_public_key), sequence_number);
+//!
+//! // Compute auth info from signer info by associating a fee.
+//! let auth_info = signer_info.auth_info(Fee::from_amount_and_gas(amount, gas));
+//!
+//! //////////////////////////
+//! // Signing transactions //
+//! //////////////////////////
+//!
+//! // The "sign doc" contains a message to be signed.
+//! let sign_doc = SignDoc::new(&tx_body, &auth_info, &chain_id, account_number)?;
+//!
+//! // Sign the "sign doc" with the sender's private key, producing a signed raw transaction.
+//! let tx_signed = sign_doc.sign(&sender_private_key)?;
+//!
+//! // Serialize the raw transaction as bytes (i.e. `Vec<u8>`).
+//! let tx_bytes = tx_signed.to_bytes()?;
+//!
+//! //////////////////////////
+//! // Parsing transactions //
+//! //////////////////////////
+//!
+//! // Parse the serialized bytes from above into a `cosmos_sdk::Tx`
+//! let tx_parsed = Tx::from_bytes(&tx_bytes)?;
+//! assert_eq!(tx_parsed.body, tx_body);
+//! assert_eq!(tx_parsed.auth_info, auth_info);
+//! # Ok(())
+//! # }
+//! ```
 
 pub mod mode_info;
 
@@ -46,6 +148,13 @@ pub struct Tx {
     /// List of signatures that matches the length and order of [`AuthInfo`]’s `signer_info`s to
     /// allow connecting signature meta information like public key and signing mode by position.
     pub signatures: Vec<secp256k1::Signature>,
+}
+
+impl Tx {
+    /// Parse a [`Tx`] from serialized bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Tx> {
+        Tx::try_from(bytes)
+    }
 }
 
 impl TryFrom<&[u8]> for Tx {

--- a/cosmos-sdk-rs/tests/integration.rs
+++ b/cosmos-sdk-rs/tests/integration.rs
@@ -2,21 +2,16 @@
 //!
 //! Requires Docker.
 
-#![cfg(feature = "rpc")]
+#![cfg(feature = "dev")]
 
 use cosmos_sdk::{
     bank::MsgSend,
     crypto::secp256k1,
-    rpc,
-    rpc::Client,
-    tx::{self, AccountNumber, Fee, MsgType, SignDoc, SignerInfo, Tx},
+    dev, rpc,
+    tx::{self, AccountNumber, Fee, MsgType, SignDoc, SignerInfo},
     Coin,
 };
-use std::{convert::TryFrom, ffi::OsStr, panic, process, str, time::Duration};
-use tokio::time;
-
-/// Name of the Docker image (on Docker Hub) to use
-const DOCKER_IMAGE: &str = "jackzampolin/gaiatest";
+use std::{panic, str};
 
 /// Chain ID to use for tests
 const CHAIN_ID: &str = "cosmos-sdk-test";
@@ -77,17 +72,16 @@ fn msg_send() {
         "-d",
         "-p",
         &format!("{}:{}", RPC_PORT, RPC_PORT),
-        DOCKER_IMAGE,
+        dev::GAIA_DOCKER_IMAGE,
         CHAIN_ID,
         &sender_account_id.to_string(),
     ];
 
-    docker_run(&docker_args, || {
+    dev::docker_run(&docker_args, || {
         init_tokio_runtime().block_on(async {
             let rpc_address = format!("http://localhost:{}", RPC_PORT);
             let rpc_client = rpc::HttpClient::new(rpc_address.as_str()).unwrap();
-
-            wait_for_first_block(&rpc_client).await;
+            dev::poll_for_first_block(&rpc_client).await;
 
             let tx_commit_response = tx_raw.broadcast_commit(&rpc_client).await.unwrap();
 
@@ -99,7 +93,7 @@ fn msg_send() {
                 panic!("deliver_tx failed: {:?}", tx_commit_response.deliver_tx);
             }
 
-            let tx = poll_for_tx(&rpc_client, &tx_commit_response.hash).await;
+            let tx = dev::poll_for_tx(&rpc_client, &tx_commit_response.hash).await;
             assert_eq!(&tx_body, &tx.body);
             assert_eq!(&auth_info, &tx.auth_info);
         })
@@ -112,105 +106,4 @@ fn init_tokio_runtime() -> tokio::runtime::Runtime {
         .enable_all()
         .build()
         .unwrap()
-}
-
-/// Wait for the node to produce the first block
-async fn wait_for_first_block(rpc_client: &rpc::HttpClient) {
-    rpc_client
-        .wait_until_healthy(Duration::from_secs(5))
-        .await
-        .unwrap();
-
-    let mut attempts_remaining = 25;
-
-    while let Err(e) = rpc_client.latest_block().await {
-        if e.code() != rpc::error::Code::ParseError {
-            panic!("unexpected error waiting for first block: {}", e);
-        }
-
-        if attempts_remaining == 0 {
-            panic!("timeout waiting for first block");
-        }
-
-        attempts_remaining -= 1;
-        time::sleep(Duration::from_millis(200)).await;
-    }
-}
-
-/// Wait for a transaction with the given hash to appear in the blockchain
-async fn poll_for_tx(rpc_client: &rpc::HttpClient, tx_hash: &tx::Hash) -> Tx {
-    // Look up the transaction by its hash
-    let tx_query =
-        rpc::query::Query::from(rpc::query::EventType::Tx).and_eq("tx.hash", tx_hash.to_string());
-
-    let attempts = 5;
-
-    for _ in 0..attempts {
-        let tx_response = rpc_client
-            .tx_search(tx_query.clone(), false, 1, 1, rpc::Order::Ascending)
-            .await
-            .unwrap();
-
-        if tx_response.total_count == 1 {
-            return Tx::try_from(tx_response.txs[0].tx.as_bytes()).unwrap();
-        }
-    }
-
-    panic!("couldn't find transaction after {} attempts!", attempts);
-}
-
-/// Invoke `docker run` with the given arguments, calling the provided function
-/// after the container has booted and terminating the container after the
-/// provided function completes, catching panics and propagating them to ensure
-/// that the container reliably shuts down.
-///
-/// Prints log output from the container in the event an error occurred.
-fn docker_run<A, S, F, R>(args: A, f: F) -> R
-where
-    A: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-    F: FnOnce() -> R + panic::UnwindSafe,
-{
-    let container_id = exec_docker_command("run", args);
-    let result = panic::catch_unwind(f);
-
-    if result.is_err() {
-        let logs = exec_docker_command("logs", &[&container_id]);
-
-        println!("\n---- docker stdout ----");
-        println!("{}", logs);
-    }
-
-    exec_docker_command("kill", &[&container_id]);
-
-    match result {
-        Ok(res) => res,
-        Err(err) => panic::resume_unwind(err),
-    }
-}
-
-/// Execute a given `docker` command, returning what was written to stdout
-/// if the command completed successfully.
-///
-/// Panics if the `docker` process exits with an error code
-fn exec_docker_command<A, S>(name: &str, args: A) -> String
-where
-    A: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    let output = process::Command::new("docker")
-        .arg(name)
-        .args(args)
-        .stdout(process::Stdio::piped())
-        .output()
-        .expect(&format!("error invoking `docker {}`", name));
-
-    if !output.status.success() {
-        panic!("`docker {}` exited with error status: {:?}", name, output);
-    }
-
-    str::from_utf8(&output.stdout)
-        .expect("UTF-8 error decoding docker output")
-        .trim_end()
-        .to_owned()
 }


### PR DESCRIPTION
Adds basic documentation for building, signing, and parsing transactions.

Update: went ahead and extracted some of the functions used in the integration test into a `dev` module with the goal of reusing them in downstream consumers of this crate.

TMKMS and Delphi are good candidates for the `dev` module. I imagine there are other use cases that might make sense (e.g. Gravity Orchestrator).

It might make sense to upstream some of that to tendermint-rs? /cc @thanethomson