### PR TITLE
cosmos-sdk-rs v0.1.1

### DIFF
--- a/cosmos-sdk-rs/CHANGELOG.md
+++ b/cosmos-sdk-rs/CHANGELOG.md
@@ -4,11 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0-pre (2021-01-04)
-### Added
-- Initial transaction builder and signer ([#6])
-
-[#6]: https://github.com/cosmos/cosmos-rust/pull/6
-
-## 0.1.0 (2020-12-07)
+## 0.1.1 (2021-04-13)
 - Initial release

--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "cosmos-sdk"
-version = "0.1.0-pre" # Also update html_root_url in lib.rs when bumping this
+name = "cosmos_sdk"
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -3,6 +3,14 @@
 //! Framework for building [Cosmos] blockchain applications in Rust, modeled off
 //! of the [Cosmos SDK for Golang].
 //!
+//! ## About
+//!
+//! This library is presently designed to serve as a *client* for interacting
+//! with the Golang implementation of the Cosmos SDK.
+//!
+//! It does not implement server-side functionality (yet), such as hooks
+//! and message passing.
+//!
 //! ## Features
 //!
 //! - [Transactions][`tx`]: build, sign, and/or parse Cosmos SDK transactions
@@ -13,7 +21,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-rs/0.1.0-pre"
+    html_root_url = "https://docs.rs/cosmos-sdk/0.1.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
Initial release under the `cosmos-sdk` crate name.