### PR TITLE
Fix links to `cosmos_sdk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a place for commonly shared rust resources related to the Cosmos ecosyst
 
 | Name                 | Description                 | crates.io | docs.rs | CI Build |
 |----------------------|-----------------------------|-----------|---------|----------|
-| [`cosmos‑sdk`]       | Cosmos SDK for Rust         | ![crates.io](https://img.shields.io/crates/v/cosmos-sdk.svg?logo=rust) | ![docs.rs](https://docs.rs/cosmos-sdk-rs/badge.svg) | ![CI](https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-rs/badge.svg) |
-| [`cosmos‑sdk‑proto`] | Proto and gRPC definitions  | ![crates.io](https://img.shields.io/crates/v/cosmos-sdk-proto.svg?logo=rust) | ![docs.rs](https://docs.rs/cosmos-sdk-proto/badge.svg) | ![CI](https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg) |
+| [`cosmos‑sdk`]       | Cosmos SDK for Rust         | [![crates.io][cosmos-sdk-crate-img]][cosmos-sdk-crate-link] | [![docs.rs][cosmos-sdk-docs-img]][cosmos-sdk-docs-link] | [![CI][cosmos-sdk-ci-img]][cosmos-sdk-ci-link] |
+| [`cosmos‑sdk‑proto`] | Proto and gRPC definitions  | [![crates.io][cosmos-sdk-proto-crate-img]][cosmos-sdk-crate-link] | ![docs.rs][cosmos-sdk-proto-docs-img] | [![CI][cosmos-sdk-proto-ci-img]][cosmos-sdk-proto-ci-link] |
 
 ## Merge Policy
 
@@ -40,3 +40,19 @@ Rust **1.48**
 
 [`cosmos‑sdk`]: https://github.com/cosmos/cosmos-rust/tree/main/cosmos-sdk-rs
 [`cosmos‑sdk‑proto`]: https://github.com/cosmos/cosmos-rust/tree/main/cosmos-sdk-proto
+
+[//]: # "badges"
+
+[cosmos-sdk-crate-img]: https://img.shields.io/crates/v/cosmos_sdk.svg?logo=rust
+[cosmos-sdk-crate-link]: https://crates.io/crates/cosmos_sdk
+[cosmos-sdk-docs-img]: https://docs.rs/cosmos_sdk/badge.svg
+[cosmos-sdk-docs-link]: https://docs.rs/cosmos_sdk/
+[cosmos-sdk-ci-img]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-rs/badge.svg
+[cosmos-sdk-ci-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-rs.yml
+
+[cosmos-sdk-proto-crate-img]: https://img.shields.io/crates/v/cosmos-sdk-proto.svg?logo=rust
+[cosmos-sdk-crate-link]: https://crates.io/crates/cosmos-sdk-proto
+[cosmos-sdk-proto-docs-img]: https://docs.rs/cosmos-sdk-proto/badge.svg
+[cosmos-sdk-proto-docs-link]: https://docs.rs/cosmos-sdk-proto/
+[cosmos-sdk-proto-ci-img]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg
+[cosmos-sdk-proto-ci-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-proto.yml

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -28,7 +28,7 @@ Requires Rust **1.48** or newer.
 [docs-image]: https://docs.rs/cosmos-sdk-proto/badge.svg
 [docs-link]: https://docs.rs/cosmos-sdk-proto/
 [build-image]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-proto/badge.svg
-[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow:cosmos-sdk-proto
+[build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-proto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg

--- a/cosmos-sdk-rs/README.md
+++ b/cosmos-sdk-rs/README.md
@@ -16,12 +16,12 @@ of the [Cosmos SDK for Golang].
 Requires Rust **1.48** or newer.
 
 [//]: # "badges"
-[crate-image]: https://img.shields.io/crates/v/cosmos-sdk.svg?logo=rust
-[crate-link]: https://crates.io/crates/cosmos-sdk
-[docs-image]: https://docs.rs/cosmos-sdk/badge.svg
-[docs-link]: https://docs.rs/cosmos-sdk/
+[crate-image]: https://img.shields.io/crates/v/cosmos_sdk.svg?logo=rust
+[crate-link]: https://crates.io/crates/cosmos_sdk
+[docs-image]: https://docs.rs/cosmos_sdk/badge.svg
+[docs-link]: https://docs.rs/cosmos_sdk/
 [build-image]: https://github.com/cosmos/cosmos-rust/workflows/cosmos-sdk-rs/badge.svg
-[build-link]: https://github.com/cosmos/cosmos-rust/actions?query=workflow:cosmos-sdk-rs
+[build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-rs.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg


### PR DESCRIPTION
Unfortunately it was originally published with an underscore instead of a hyphen, and it's not presently possible to change that.

Hyphens work in place of an underscore in most places, however one place they don't, apparently is the image for docs.rs badges (it does work for links, however).

This commit fixes the badges, uses `cosmos_sdk` in links for consistency with the current name, and linkifies badges in the table in the toplevel README.md.