### PR TITLE
Add staking functions to cosmos-sdk

### DIFF
--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod bank;
 pub mod crypto;
+pub mod staking;
 pub mod tx;
 
 #[cfg(feature = "dev")]

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -166,10 +166,10 @@ pub struct MsgBeginRedelegate {
     pub delegator_address: AccountId,
 
     /// Source validator's address.
-    pub src_validator_address: AccountId,
+    pub validator_src_address: AccountId,
 
     /// Destination validator's address.
-    pub dst_validator_address: AccountId,
+    pub validator_dst_address: AccountId,
 
     /// Amount to UnDelegate
     pub amount: Option<Coin>,
@@ -207,8 +207,8 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginR
         };
         Ok(MsgBeginRedelegate {
             delegator_address: proto.delegator_address.parse()?,
-            src_validator_address: proto.src_validator_address.parse()?,
-            dst_validator_address: proto.dst_validator_address.parse()?,
+            validator_src_address: proto.validator_src_address.parse()?,
+            validator_dst_address: proto.validator_dst_address.parse()?,
             amount,
         })
     }
@@ -232,8 +232,8 @@ impl From<&MsgBeginRedelegate> for proto::cosmos::staking::v1beta1::MsgBeginRede
         };
         proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
             delegator_address: msg.delegator_address.to_string(),
-            src_validator_address: msg.src_validator_address.to_string(),
-            dst_validator_address: msg.dst_validator_address.to_string(),
+            validator_src_address: msg.validator_src_address.to_string(),
+            validator_dst_address: msg.validator_dst_address.to_string(),
             amount: proto_amount,
         }
     }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -7,6 +7,7 @@ use crate::{
     tx::{Msg, MsgType},
     AccountId, Coin, Result,
 };
+use std::convert::{TryFrom, TryInto};
 
 /// MsgSend represents a message to send coins from one account to another.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -2,9 +2,11 @@
 //!
 //! <https://docs.cosmos.network/master/modules/staking/>
 
-use cosmos_sdk::tx::{Msg, MsgProto, MsgType};
-use cosmos_sdk::{proto, AccountId, Coin, Result};
-use std::convert::{TryFrom, TryInto};
+use crate::{
+    proto,
+    tx::{Msg, MsgType},
+    AccountId, Coin, Result,
+};
 
 /// MsgSend represents a message to send coins from one account to another.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -69,6 +71,6 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
     }
 }
 
-impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
-    const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
-}
+// impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
+//     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
+// }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -73,5 +73,5 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
 }
 
 // impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
-//     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
+//     const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgDelegate";
 // }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -63,7 +63,7 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
         proto::cosmos::staking::v1beta1::MsgDelegate {
             delegator_address: msg.delegator_address.to_string(),
             validator_address: msg.validator_address.to_string(),
-            amount: msg.amount.into(),
+            amount: None, // msg.amount.into(),
         }
     }
 }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -44,10 +44,18 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
     type Error = eyre::Report;
 
     fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
+        let amount = if let Some(amount) = &proto.amount {
+            Some(Coin {
+                denom: amount.denom.parse()?,
+                amount: amount.amount.parse()?,
+            })
+        } else {
+            None
+        };
         Ok(MsgDelegate {
             delegator_address: proto.delegator_address.parse()?,
             validator_address: proto.validator_address.parse()?,
-            amount: None, // proto.amount.try_into()?,
+            amount,
         })
     }
 }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -158,3 +158,83 @@ impl From<&MsgUndelegate> for proto::cosmos::staking::v1beta1::MsgUndelegate {
         }
     }
 }
+
+/// MsgBeginRedelegate represents a message to redelegate coins from one validator to another.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgBeginRedelegate {
+    /// Delegator's address.
+    pub delegator_address: AccountId,
+
+    /// Source validator's address.
+    pub src_validator_address: AccountId,
+
+    /// Destination validator's address.
+    pub dst_validator_address: AccountId,
+
+    /// Amount to UnDelegate
+    pub amount: Option<Coin>,
+}
+
+impl MsgType for MsgBeginRedelegate {
+    fn from_msg(msg: &Msg) -> Result<Self> {
+        proto::cosmos::staking::v1beta1::MsgBeginRedelegate::from_msg(msg).and_then(TryInto::try_into)
+    }
+
+    fn to_msg(&self) -> Result<Msg> {
+        proto::cosmos::staking::v1beta1::MsgBeginRedelegate::from(self).to_msg()
+    }
+}
+
+impl TryFrom<proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginRedelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: proto::cosmos::staking::v1beta1::MsgBeginRedelegate) -> Result<MsgBeginRedelegate> {
+        MsgBeginRedelegate::try_from(&proto)
+    }
+}
+
+impl TryFrom<&proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginRedelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgBeginRedelegate) -> Result<MsgBeginRedelegate> {
+        let amount = if let Some(amount) = &proto.amount {
+            Some(Coin {
+                denom: amount.denom.parse()?,
+                amount: amount.amount.parse()?,
+            })
+        } else {
+            None
+        };
+        Ok(MsgBeginRedelegate {
+            delegator_address: proto.delegator_address.parse()?,
+            src_validator_address: proto.src_validator_address.parse()?,
+            dst_validator_address: proto.dst_validator_address.parse()?,
+            amount,
+        })
+    }
+}
+
+impl From<MsgBeginRedelegate> for proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+    fn from(coin: MsgBeginRedelegate) -> proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+        proto::cosmos::staking::v1beta1::MsgBeginRedelegate::from(&coin)
+    }
+}
+
+impl From<&MsgBeginRedelegate> for proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+    fn from(msg: &MsgBeginRedelegate) -> proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+        let proto_amount = if let Some(amount) = &msg.amount {
+            Some(proto::cosmos::base::v1beta1::Coin {
+                denom: amount.denom.to_string(),
+                amount: amount.amount.to_string(),
+            })
+        } else {
+            None
+        };
+        proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+            delegator_address: msg.delegator_address.to_string(),
+            src_validator_address: msg.src_validator_address.to_string(),
+            dst_validator_address: msg.dst_validator_address.to_string(),
+            amount: proto_amount,
+        }
+    }
+}

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -42,8 +42,8 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
 
     fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
         Ok(MsgDelegate {
-            delegator_address: proto.from_address.parse()?,
-            validator_address: proto.to_address.parse()?,
+            delegator_address: proto.delegator_address.parse()?,
+            validator_address: proto.validator_address.parse()?,
             amount: proto
                 .amount
                 .iter()

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -47,7 +47,7 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
         Ok(MsgDelegate {
             delegator_address: proto.delegator_address.parse()?,
             validator_address: proto.validator_address.parse()?,
-            amount: proto.amount.try_into()?,
+            amount: None, // proto.amount.try_into()?,
         })
     }
 }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -60,10 +60,18 @@ impl From<MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
 
 impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
     fn from(msg: &MsgDelegate) -> proto::cosmos::staking::v1beta1::MsgDelegate {
+        let proto_amount = if let Some(amount) = &msg.amount {
+            Some(proto::cosmos::base::v1beta1::Coin {
+                denom: amount.denom.to_string(),
+                amount: amount.amount.to_string(),
+            })
+        } else {
+            None
+        };
         proto::cosmos::staking::v1beta1::MsgDelegate {
             delegator_address: msg.delegator_address.to_string(),
             validator_address: msg.validator_address.to_string(),
-            amount: None, // msg.amount.into(),
+            amount: proto_amount,
         }
     }
 }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -9,17 +9,17 @@ use crate::{
 };
 use std::convert::{TryFrom, TryInto};
 
-/// MsgSend represents a message to send coins from one account to another.
+/// MsgDelegate represents a message to delegate coins to a validator.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MsgDelegate {
-    /// Sender's address.
+    /// Delegator's address.
     pub delegator_address: AccountId,
 
-    /// Recipient's address.
+    /// Validator's address.
     pub validator_address: AccountId,
 
     /// Amount to send
-    pub amount: Vec<Coin>,
+    pub amount: Option<Coin>,
 }
 
 impl MsgType for MsgDelegate {
@@ -47,11 +47,7 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
         Ok(MsgDelegate {
             delegator_address: proto.delegator_address.parse()?,
             validator_address: proto.validator_address.parse()?,
-            amount: proto
-                .amount
-                .iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<_, _>>()?,
+            amount: proto.amount.parse()?,
         })
     }
 }
@@ -67,7 +63,7 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
         proto::cosmos::staking::v1beta1::MsgDelegate {
             delegator_address: msg.delegator_address.to_string(),
             validator_address: msg.validator_address.to_string(),
-            amount: msg.amount.iter().map(Into::into).collect(),
+            amount: msg.amount.to_string(),
         }
     }
 }

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -1,0 +1,74 @@
+//! Staking module support
+//!
+//! <https://docs.cosmos.network/master/modules/staking/>
+
+use cosmos_sdk::tx::{Msg, MsgProto, MsgType};
+use cosmos_sdk::{proto, AccountId, Coin, Result};
+use std::convert::{TryFrom, TryInto};
+
+/// MsgSend represents a message to send coins from one account to another.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgDelegate {
+    /// Sender's address.
+    pub delegator_address: AccountId,
+
+    /// Recipient's address.
+    pub validator_address: AccountId,
+
+    /// Amount to send
+    pub amount: Vec<Coin>,
+}
+
+impl MsgType for MsgDelegate {
+    fn from_msg(msg: &Msg) -> Result<Self> {
+        proto::cosmos::staking::v1beta1::MsgDelegate::from_msg(msg).and_then(TryInto::try_into)
+    }
+
+    fn to_msg(&self) -> Result<Msg> {
+        proto::cosmos::staking::v1beta1::MsgDelegate::from(self).to_msg()
+    }
+}
+
+impl TryFrom<proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
+        MsgDelegate::try_from(&proto)
+    }
+}
+
+impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
+        Ok(MsgDelegate {
+            delegator_address: proto.from_address.parse()?,
+            validator_address: proto.to_address.parse()?,
+            amount: proto
+                .amount
+                .iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl From<MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
+    fn from(coin: MsgDelegate) -> proto::cosmos::staking::v1beta1::MsgDelegate {
+        proto::cosmos::staking::v1beta1::MsgDelegate::from(&coin)
+    }
+}
+
+impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
+    fn from(msg: &MsgDelegate) -> proto::cosmos::staking::v1beta1::MsgDelegate {
+        proto::cosmos::staking::v1beta1::MsgDelegate {
+            delegator_address: msg.delegator_address.to_string(),
+            validator_address: msg.validator_address.to_string(),
+            amount: msg.amount.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
+    const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
+}

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -84,6 +84,77 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
     }
 }
 
-// impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
-//     const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgDelegate";
-// }
+/// MsgUndelegate represents a message to undelegate coins from a validator.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgUndelegate {
+    /// Delegator's address.
+    pub delegator_address: AccountId,
+
+    /// Validator's address.
+    pub validator_address: AccountId,
+
+    /// Amount to UnDelegate
+    pub amount: Option<Coin>,
+}
+
+impl MsgType for MsgUndelegate {
+    fn from_msg(msg: &Msg) -> Result<Self> {
+        proto::cosmos::staking::v1beta1::MsgUndelegate::from_msg(msg).and_then(TryInto::try_into)
+    }
+
+    fn to_msg(&self) -> Result<Msg> {
+        proto::cosmos::staking::v1beta1::MsgUndelegate::from(self).to_msg()
+    }
+}
+
+impl TryFrom<proto::cosmos::staking::v1beta1::MsgUndelegate> for MsgUndelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: proto::cosmos::staking::v1beta1::MsgUndelegate) -> Result<MsgUndelegate> {
+        MsgUndelegate::try_from(&proto)
+    }
+}
+
+impl TryFrom<&proto::cosmos::staking::v1beta1::MsgUndelegate> for MsgUndelegate {
+    type Error = eyre::Report;
+
+    fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgUndelegate) -> Result<MsgUndelegate> {
+        let amount = if let Some(amount) = &proto.amount {
+            Some(Coin {
+                denom: amount.denom.parse()?,
+                amount: amount.amount.parse()?,
+            })
+        } else {
+            None
+        };
+        Ok(MsgUndelegate {
+            delegator_address: proto.delegator_address.parse()?,
+            validator_address: proto.validator_address.parse()?,
+            amount,
+        })
+    }
+}
+
+impl From<MsgUndelegate> for proto::cosmos::staking::v1beta1::MsgUndelegate {
+    fn from(coin: MsgUndelegate) -> proto::cosmos::staking::v1beta1::MsgUndelegate {
+        proto::cosmos::staking::v1beta1::MsgUndelegate::from(&coin)
+    }
+}
+
+impl From<&MsgUndelegate> for proto::cosmos::staking::v1beta1::MsgUndelegate {
+    fn from(msg: &MsgUndelegate) -> proto::cosmos::staking::v1beta1::MsgUndelegate {
+        let proto_amount = if let Some(amount) = &msg.amount {
+            Some(proto::cosmos::base::v1beta1::Coin {
+                denom: amount.denom.to_string(),
+                amount: amount.amount.to_string(),
+            })
+        } else {
+            None
+        };
+        proto::cosmos::staking::v1beta1::MsgUndelegate {
+            delegator_address: msg.delegator_address.to_string(),
+            validator_address: msg.validator_address.to_string(),
+            amount: proto_amount,
+        }
+    }
+}

--- a/cosmos-sdk-rs/src/staking.rs
+++ b/cosmos-sdk-rs/src/staking.rs
@@ -47,7 +47,7 @@ impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
         Ok(MsgDelegate {
             delegator_address: proto.delegator_address.parse()?,
             validator_address: proto.validator_address.parse()?,
-            amount: proto.amount.parse()?,
+            amount: proto.amount.try_into()?,
         })
     }
 }
@@ -63,7 +63,7 @@ impl From<&MsgDelegate> for proto::cosmos::staking::v1beta1::MsgDelegate {
         proto::cosmos::staking::v1beta1::MsgDelegate {
             delegator_address: msg.delegator_address.to_string(),
             validator_address: msg.validator_address.to_string(),
-            amount: msg.amount.to_string(),
+            amount: msg.amount.into(),
         }
     }
 }

--- a/cosmos-sdk-rs/src/tx/msg.rs
+++ b/cosmos-sdk-rs/src/tx/msg.rs
@@ -77,5 +77,5 @@ impl MsgProto for proto::cosmos::bank::v1beta1::MsgSend {
 }
 
 impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
-    const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
+    const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgDelegate";
 }

--- a/cosmos-sdk-rs/src/tx/msg.rs
+++ b/cosmos-sdk-rs/src/tx/msg.rs
@@ -79,3 +79,11 @@ impl MsgProto for proto::cosmos::bank::v1beta1::MsgSend {
 impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
     const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgDelegate";
 }
+
+impl MsgProto for proto::cosmos::staking::v1beta1::MsgUndelegate {
+    const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgUndelegate";
+}
+
+impl MsgProto for proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
+    const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgBeginRedelegate";
+}

--- a/cosmos-sdk-rs/src/tx/msg.rs
+++ b/cosmos-sdk-rs/src/tx/msg.rs
@@ -75,3 +75,7 @@ where
 impl MsgProto for proto::cosmos::bank::v1beta1::MsgSend {
     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgSend";
 }
+
+impl MsgProto for proto::cosmos::bank::v1beta1::MsgDelegate {
+    const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
+}

--- a/cosmos-sdk-rs/src/tx/msg.rs
+++ b/cosmos-sdk-rs/src/tx/msg.rs
@@ -76,6 +76,6 @@ impl MsgProto for proto::cosmos::bank::v1beta1::MsgSend {
     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgSend";
 }
 
-impl MsgProto for proto::cosmos::bank::v1beta1::MsgDelegate {
+impl MsgProto for proto::cosmos::staking::v1beta1::MsgDelegate {
     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgDelegate";
 }


### PR DESCRIPTION
Add staking functions to the cosmos-sdk by extending to existing protobuf methods:

- MsgDelegate
- MsgUnDelegate
- MsgBeginRedelegate