### PR TITLE
cosmos-sdk-rs v0.2.0

### DIFF
--- a/cosmos-sdk-rs/CHANGELOG.md
+++ b/cosmos-sdk-rs/CHANGELOG.md
@@ -4,5 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-06-24)
+### Added
+- Staking functions ([#82])
+- More detail to `AccountId` parsing errors ([#85])
+- Basic BIP32 support ([#91])
+
+### Changed
+- Bump `tendermint*` crate dependencies to v0.20; MSRV 1.51+ ([#89])
+
+[#82]: https://github.com/cosmos/cosmos-rust/pull/82
+[#85]: https://github.com/cosmos/cosmos-rust/pull/85
+[#89]: https://github.com/cosmos/cosmos-rust/pull/89
+[#91]: https://github.com/cosmos/cosmos-rust/pull/91
+
 ## 0.1.1 (2021-04-13)
 - Initial release

--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos_sdk"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk/0.1.1"
+    html_root_url = "https://docs.rs/cosmos-sdk/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Added
- Staking functions ([#82])
- More detail to `AccountId` parsing errors ([#85])
- Basic BIP32 support ([#91])

### Changed
- Bump `tendermint*` crate dependencies to v0.20; MSRV 1.51+ ([#89])

[#82]: https://github.com/cosmos/cosmos-rust/pull/82
[#85]: https://github.com/cosmos/cosmos-rust/pull/85
[#89]: https://github.com/cosmos/cosmos-rust/pull/89
[#91]: https://github.com/cosmos/cosmos-rust/pull/91