### PR TITLE
cosmos-sdk-proto v0.6.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-08-02)
+
+### Added
+
+- Basic `cosmwasm` support ([#96])
+
+### Changed
+
+- Bump `tendermint-proto` requirement from 0.20 to 0.21 ([#106])
+
+[#96]: https://github.com/cosmos/cosmos-rust/pull/96
+[#106]: https://github.com/cosmos/cosmos-rust/pull/106
+
 ## 0.5.0 (2021-04-10)
 
 ### Changed

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",
@@ -17,12 +17,10 @@ keywords   = ["blockchain", "cosmos", "tendermint", "proto"]
 [dependencies]
 prost = "0.7"
 prost-types = "0.7"
+tendermint-proto = "0.21"
 
 # Optional dependencies
 tonic = { version = "0.4", optional = true }
-
-[dependencies.tendermint-proto]
-version = "0.21"
 
 [features]
 default = ["grpc"]

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.5.0"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]

--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.5", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.6", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.12", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.9", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added

- Basic `cosmwasm` support ([#96])

### Changed

- Bump `tendermint-proto` requirement from 0.20 to 0.21 ([#106])

[#96]: https://github.com/cosmos/cosmos-rust/pull/96
[#106]: https://github.com/cosmos/cosmos-rust/pull/106