### PR TITLE
cosmos-sdk-rs v0.3.0

### DIFF
--- a/cosmos-sdk-rs/CHANGELOG.md
+++ b/cosmos-sdk-rs/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-08-02)
+### Added
+- Basic `cosmwasm` support ([#96])
+- Distribution module ([#114])
+
+### Changed
+- Update protobufs for cosmos-sdk 0.43.0-rc2 ([#108])
+- Bump `tendermint-rs` to v0.21 ([#110])
+- Bump `cosmos-sdk-proto` to v0.6 ([#111])
+- Made admin field optional in `MsgInstantiateContract` ([#115])
+
+[#96]: https://github.com/cosmos/cosmos-rust/pull/96
+[#108]: https://github.com/cosmos/cosmos-rust/pull/108
+[#110]: https://github.com/cosmos/cosmos-rust/pull/110
+[#111]: https://github.com/cosmos/cosmos-rust/pull/111
+[#114]: https://github.com/cosmos/cosmos-rust/pull/114
+[#115]: https://github.com/cosmos/cosmos-rust/pull/115
+
 ## 0.2.0 (2021-06-24)
 ### Added
 - Staking functions ([#82])

--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos_sdk"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/cosmos-sdk-rs/src/cosmwasm.rs
+++ b/cosmos-sdk-rs/src/cosmwasm.rs
@@ -1,6 +1,7 @@
 //! CosmWasm messages
 //!
-//! <https://github.com/CosmWasm/wasmd/tree/master/docs/>
+//! - Tutorial: <https://docs.cosmwasm.com/>
+//! - Protocol Docs: <https://github.com/CosmWasm/wasmd/blob/master/docs/proto/proto.md>
 
 pub use crate::proto::cosmwasm::wasm::v1beta1::AccessType;
 use crate::{

--- a/cosmos-sdk-rs/src/lib.rs
+++ b/cosmos-sdk-rs/src/lib.rs
@@ -13,6 +13,8 @@
 //!
 //! ## Features
 //!
+//! - [CosmWasm][`cosmwasm`]: messages used by smart contracts written using CosmWasm
+//! - [Staking][`staking`]: support for staking with validators
 //! - [Transactions][`tx`]: build, sign, and/or parse Cosmos SDK transactions
 //!
 //! [Cosmos]: https://cosmos.network/
@@ -21,7 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk/0.2.0"
+    html_root_url = "https://docs.rs/cosmos-sdk/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Added
- Basic `cosmwasm` support ([#96])
- Distribution module ([#114])

### Changed
- Update protobufs for cosmos-sdk 0.43.0-rc2 ([#108])
- Bump `tendermint-rs` to v0.21 ([#110])
- Bump `cosmos-sdk-proto` to v0.6 ([#111])
- Made admin field optional in `MsgInstantiateContract` ([#115])

[#96]: https://github.com/cosmos/cosmos-rust/pull/96
[#108]: https://github.com/cosmos/cosmos-rust/pull/108
[#110]: https://github.com/cosmos/cosmos-rust/pull/110
[#111]: https://github.com/cosmos/cosmos-rust/pull/111
[#114]: https://github.com/cosmos/cosmos-rust/pull/114
[#115]: https://github.com/cosmos/cosmos-rust/pull/115