### PR TITLE
cosmos-sdk-proto v0.6.1

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2021-08-02)
+## 0.6.1 (2021-08-19)
+
+### Changed
+
+- Rebuild protos with cosmos-sdk v0.43.0  ([#117])
+
+[#117]: https://github.com/cosmos/cosmos-rust/pull/117
+
+## 0.6.0 (2021-08-02) [YANKED]
 
 ### Added
 

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.0"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Changed

- Rebuild protos with cosmos-sdk v0.43.0  ([#117])

[#117]: https://github.com/cosmos/cosmos-rust/pull/117