### PR TITLE
New protos for vesting accounts

### DIFF
--- a/cosmos-sdk-proto/src/prost/cosmos.vesting.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos.vesting.v1beta1.rs
@@ -85,3 +85,54 @@ pub mod msg_client {
         }
     }
 }
+/// BaseVestingAccount implements the VestingAccount interface. It contains all
+/// the necessary fields needed for any vesting account implementation.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BaseVestingAccount {
+    #[prost(message, optional, tag = "1")]
+    pub base_account: ::core::option::Option<super::super::auth::v1beta1::BaseAccount>,
+    #[prost(message, repeated, tag = "2")]
+    pub original_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, repeated, tag = "3")]
+    pub delegated_free: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, repeated, tag = "4")]
+    pub delegated_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(int64, tag = "5")]
+    pub end_time: i64,
+}
+/// ContinuousVestingAccount implements the VestingAccount interface. It
+/// continuously vests by unlocking coins linearly with respect to time.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContinuousVestingAccount {
+    #[prost(message, optional, tag = "1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+    #[prost(int64, tag = "2")]
+    pub start_time: i64,
+}
+/// DelayedVestingAccount implements the VestingAccount interface. It vests all
+/// coins after a specific time, but non prior. In other words, it keeps them
+/// locked until a specified time.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DelayedVestingAccount {
+    #[prost(message, optional, tag = "1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+}
+/// Period defines a length of time and amount of coins that will vest.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Period {
+    #[prost(int64, tag = "1")]
+    pub length: i64,
+    #[prost(message, repeated, tag = "2")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// PeriodicVestingAccount implements the VestingAccount interface. It
+/// periodically vests by unlocking coins during each specified period.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PeriodicVestingAccount {
+    #[prost(message, optional, tag = "1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+    #[prost(int64, tag = "2")]
+    pub start_time: i64,
+    #[prost(message, repeated, tag = "3")]
+    pub vesting_periods: ::prost::alloc::vec::Vec<Period>,
+}

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -350,6 +350,7 @@ fn compile_proto_services(out_dir: impl AsRef<Path>) {
         sdk_dir.join("proto/cosmos/tx/v1beta1/tx.proto"),
         sdk_dir.join("proto/cosmos/upgrade/v1beta1/query.proto"),
         sdk_dir.join("proto/cosmos/vesting/v1beta1/tx.proto"),
+        sdk_dir.join("proto/cosmos/vesting/v1beta1/vesting.proto"),
     ];
 
     // List available paths for dependencies


### PR DESCRIPTION
**Changed**

- Rebuild protos with cosmos-sdk v0.43.0 (added "proto/cosmos/vesting/v1beta1/vesting.proto" to proto paths)