### PR TITLE
cosmos-sdk-proto v0.6.2

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,31 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2021-08-24)
+### Added
+- Protos for vesting accounts ([#119])
+
+[#119]: https://github.com/cosmos/cosmos-rust/pull/119
+
 ## 0.6.1 (2021-08-19)
-
 ### Changed
-
 - Rebuild protos with cosmos-sdk v0.43.0  ([#117])
 
 [#117]: https://github.com/cosmos/cosmos-rust/pull/117
 
 ## 0.6.0 (2021-08-02) [YANKED]
-
 ### Added
-
 - Basic `cosmwasm` support ([#96])
 
 ### Changed
-
 - Bump `tendermint-proto` requirement from 0.20 to 0.21 ([#106])
 
 [#96]: https://github.com/cosmos/cosmos-rust/pull/96
 [#106]: https://github.com/cosmos/cosmos-rust/pull/106
 
 ## 0.5.0 (2021-04-10)
-
 ### Changed
-
 - Add support for crypto proto and services ([#73])
 - Update tendermint crate ([#72])
 
@@ -37,9 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/cosmos/cosmos-rust/pull/73
 
 ## 0.4.0 (2021-04-02)
-
 ### Changed
-
 - Add support for bank proto and services ([#61])
 - Add support for tendermint proto and services ([#57])
 - Add support for bank, crisis, distribution, evidence, genutil, gov, mint, params, slashing, staking upgrade and vesting proto and services ([#64])
@@ -50,9 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/cosmos/cosmos-rust/pull/64
 
 ## 0.3.0 (2020-02-01)
-
 ### Changed
-
 - Bump `cosmos-sdk` rev to v0.40.0 ([#37])
 - Bump `tendermint` crate dependency to v0.18 ([#45])
 - Bump `prost`, `prost-types`, `prost-build` to v0.7 ([#45])
@@ -64,13 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#45]: https://github.com/cosmos/cosmos-rust/pull/45
 
 ## 0.2.0 (2020-01-04)
-
 ### Added
-
 - `grpc` crate feature ([#8])
 
 ### Changed
-
 - Bump `cosmos-sdk` rev to v0.40.0-rc6 ([#32])
 - Bump `tendermint` + `tendermint-proto` crate dependencies to v0.17 ([#18])
 - Format `prost`/`tonic` output with `rustfmt` ([#17])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.6.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.2" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.1"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Added
- Protos for vesting accounts ([#119])

[#119]: https://github.com/cosmos/cosmos-rust/pull/119