### PR TITLE
cosmos-sdk-proto v0.6.3

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.3 (2021-08-24)
+### Changed
+- Bump MSRV to 1.54 ([#122])
+
+[#122]: https://github.com/cosmos/cosmos-rust/pull/122
+
 ## 0.6.2 (2021-08-24)
 ### Added
 - Protos for vesting accounts ([#119])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.6.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.3" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.2"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Changed
- Bump MSRV to 1.54 ([#122])

[#122]: https://github.com/cosmos/cosmos-rust/pull/122