### PR TITLE
Bumped version of cosmos-sdk-proto in cosmos_sdk

### DIFF
--- a/cosmos-sdk-rs/Cargo.toml
+++ b/cosmos-sdk-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.6", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.6.3", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.12", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.9", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
cosmos_sdk still uses cosmos-sdk-proto v0.6