### PR TITLE
cosmos-sdk-proto v0.7.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-09-27)
+### Changed
+- Update `tendermint` crate to v0.22 ([#128])
+- Bump `COSMOS_REV` to v0.44.0 ([#130])
+
+[#128]: https://github.com/cosmos/cosmos-rust/pull/128
+[#130]: https://github.com/cosmos/cosmos-rust/pull/130
+
 ## 0.6.3 (2021-08-24)
 ### Changed
 - Bump MSRV to 1.54 ([#122])
@@ -36,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.5.0 (2021-04-10)
 ### Changed
 - Add support for crypto proto and services ([#73])
-- Update tendermint crate ([#72])
+- Update `tendermint` crate ([#72])
 
 [#72]: https://github.com/cosmos/cosmos-rust/pull/72
 [#73]: https://github.com/cosmos/cosmos-rust/pull/73

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.6.3"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.7.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
@@ -201,8 +201,9 @@ pub mod cosmos {
     }
 }
 
-#[cfg(feature = "cosmwasm")]
 /// CosmWasm protobuf definitions.
+#[cfg(feature = "cosmwasm")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cosmwasm")))]
 pub mod cosmwasm {
     /// Messages and services handling CosmWasm.
     pub mod wasm {

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
 keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.7.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.7", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.12", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.9", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Update `tendermint` crate to v0.22 ([#128])

[#128]: https://github.com/cosmos/cosmos-rust/pull/128