### PR TITLE
cosmrs v0.2.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.0 (2021-09-27)
 ### Changed
-- Update `tendermint` crate to v0.22 ([#128])
+- Update `tendermint-proto` crate to v0.22 ([#128])
 - Bump `COSMOS_REV` to v0.44.0 ([#130])
 
 [#128]: https://github.com/cosmos/cosmos-rust/pull/128

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,5 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-09-27)
+### Changed
+- Make `Tx::find_by_hash` use the `/tx` endpoint ([#116])
+- Update `tendermint` crate to v0.22 ([#128])
+- Update `cosmos-sdk-proto` to v0.7 ([#129])
+
+[#116]: https://github.com/cosmos/cosmos-rust/pull/116
+[#128]: https://github.com/cosmos/cosmos-rust/pull/128
+[#129]: https://github.com/cosmos/cosmos-rust/pull/129
+
 ## 0.1.0 (2021-08-25)
 - Initial release under `cosmrs` name

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmrs/0.1.0"
+    html_root_url = "https://docs.rs/cosmrs/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]


### PR DESCRIPTION
### Changed
- Make `Tx::find_by_hash` use the `/tx` endpoint ([#116])
- Update `tendermint` crate to v0.22 ([#128])
- Update `cosmos-sdk-proto` to v0.7 ([#129])

[#116]: https://github.com/cosmos/cosmos-rust/pull/116
[#128]: https://github.com/cosmos/cosmos-rust/pull/128
[#129]: https://github.com/cosmos/cosmos-rust/pull/129