### PR TITLE
cosmrs: `PublicKey` JSON serialization support

### DIFF
--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -15,6 +15,8 @@
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 
+pub use tendermint_proto as tendermint;
+
 /// The version (commit hash) of the Cosmos SDK used when generating this library.
 pub const COSMOS_SDK_VERSION: &str = include_str!("prost/COSMOS_SDK_COMMIT");
 

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -18,6 +18,8 @@ k256 = { version = "0.9", features = ["ecdsa", "sha256"] }
 prost = "0.7"
 prost-types = "0.7"
 rand_core = { version = "0.6", features = ["std"] }
+serde = { version = "1", features = ["serde_derive"] }
+serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tendermint = { version = "0.22", default-features = false, features = ["secp256k1"] }
 thiserror = "1"

--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -2,6 +2,7 @@
 
 use crate::{proto, Decimal, Error, Result};
 use eyre::WrapErr;
+use serde::{de, de::Error as _, ser, Deserialize, Serialize};
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -101,6 +102,20 @@ impl From<AccountId> for tendermint::account::Id {
 impl From<&AccountId> for tendermint::account::Id {
     fn from(id: &AccountId) -> tendermint::account::Id {
         tendermint::account::Id::new(id.to_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for AccountId {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for AccountId {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.bech32.serialize(serializer)
     }
 }
 


### PR DESCRIPTION
Adds support for the "Cosmos JSON" `PublicKey` serialization, e.g.:

    {"@type":"/cosmos.crypto.ed25519.PubKey","key":"sEEsVGkXvyewKLWMJbHVDRkBoerW0IIwmj1rHkabtHU="}

Encoding follows Protobub JSON conventions, with binary data encoded as standard (i.e. non-URL safe) Base64. However, note that it's structurally still a bit different from the Protobuf JSON encoding for public keys, and thus entails a custom solution.

Also note that there is unfortunately not yet a general solution for Protobuf JSON encoding for `prost::Message`:

https://github.com/tokio-rs/prost/issues/75