### PR TITLE
cosmrs: refactor `Msg*` traits

### DIFF
--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -2,13 +2,14 @@
 name = "cosmrs"
 version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
-edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
 description = "Transaction builder and signer for Cosmos-based blockchains"
-readme     = "README.md"
+readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "encoding"]
-keywords   = ["blockchain", "cosmos", "tendermint", "transaction"]
+keywords = ["blockchain", "cosmos", "tendermint", "transaction"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 cosmos-sdk-proto = { version = "=0.8.0-pre", default-features = false, path = "../cosmos-sdk-proto" }

--- a/cosmrs/src/bank.rs
+++ b/cosmrs/src/bank.rs
@@ -2,12 +2,7 @@
 //!
 //! <https://docs.cosmos.network/master/modules/bank/>
 
-use crate::{
-    proto,
-    tx::{Msg, MsgType},
-    AccountId, Coin, Result,
-};
-use std::convert::{TryFrom, TryInto};
+use crate::{proto, tx::Msg, AccountId, Coin, ErrorReport, Result};
 
 /// MsgSend represents a message to send coins from one account to another.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -22,18 +17,12 @@ pub struct MsgSend {
     pub amount: Vec<Coin>,
 }
 
-impl MsgType for MsgSend {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::bank::v1beta1::MsgSend::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::bank::v1beta1::MsgSend::from(self).to_msg()
-    }
+impl Msg for MsgSend {
+    type Proto = proto::cosmos::bank::v1beta1::MsgSend;
 }
 
 impl TryFrom<proto::cosmos::bank::v1beta1::MsgSend> for MsgSend {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::bank::v1beta1::MsgSend) -> Result<MsgSend> {
         MsgSend::try_from(&proto)
@@ -41,7 +30,7 @@ impl TryFrom<proto::cosmos::bank::v1beta1::MsgSend> for MsgSend {
 }
 
 impl TryFrom<&proto::cosmos::bank::v1beta1::MsgSend> for MsgSend {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmos::bank::v1beta1::MsgSend) -> Result<MsgSend> {
         Ok(MsgSend {

--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -1,13 +1,9 @@
 //! Base functionality.
 
-use crate::{proto, Decimal, Error, Result};
+use crate::{proto, Decimal, Error, ErrorReport, Result};
 use eyre::WrapErr;
 use serde::{de, de::Error as _, ser, Deserialize, Serialize};
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    str::FromStr,
-};
+use std::{fmt, str::FromStr};
 use subtle_encoding::bech32;
 
 /// Account identifiers
@@ -71,7 +67,7 @@ impl fmt::Display for AccountId {
 }
 
 impl FromStr for AccountId {
-    type Err = eyre::Report;
+    type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
         let (hrp, bytes) = bech32::decode(s).wrap_err("failed to decode bech32")?;
@@ -130,7 +126,7 @@ pub struct Coin {
 }
 
 impl TryFrom<proto::cosmos::base::v1beta1::Coin> for Coin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::base::v1beta1::Coin) -> Result<Coin> {
         Coin::try_from(&proto)
@@ -138,7 +134,7 @@ impl TryFrom<proto::cosmos::base::v1beta1::Coin> for Coin {
 }
 
 impl TryFrom<&proto::cosmos::base::v1beta1::Coin> for Coin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmos::base::v1beta1::Coin) -> Result<Coin> {
         Ok(Coin {
@@ -180,7 +176,7 @@ impl fmt::Display for Denom {
 }
 
 impl FromStr for Denom {
-    type Err = eyre::Report;
+    type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
         // TODO(tarcieri): ensure this is the proper validation for a denom name

--- a/cosmrs/src/cosmwasm.rs
+++ b/cosmrs/src/cosmwasm.rs
@@ -4,12 +4,7 @@
 //! - Protocol Docs: <https://github.com/CosmWasm/wasmd/blob/master/docs/proto/proto.md>
 
 pub use crate::proto::cosmwasm::wasm::v1beta1::AccessType;
-use crate::{
-    proto,
-    tx::{Msg, MsgType},
-    AccountId, Coin, Error, Result,
-};
-use std::convert::{TryFrom, TryInto};
+use crate::{proto, tx::Msg, AccountId, Coin, Error, ErrorReport, Result};
 
 /// AccessConfig access control type.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -22,7 +17,7 @@ pub struct AccessConfig {
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::AccessConfig> for AccessConfig {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmwasm::wasm::v1beta1::AccessConfig) -> Result<AccessConfig> {
         AccessConfig::try_from(&proto)
@@ -30,7 +25,7 @@ impl TryFrom<proto::cosmwasm::wasm::v1beta1::AccessConfig> for AccessConfig {
 }
 
 impl TryFrom<&proto::cosmwasm::wasm::v1beta1::AccessConfig> for AccessConfig {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmwasm::wasm::v1beta1::AccessConfig) -> Result<AccessConfig> {
         Ok(AccessConfig {
@@ -79,18 +74,12 @@ pub struct MsgStoreCode {
     pub instantiate_permission: Option<AccessConfig>,
 }
 
-impl MsgType for MsgStoreCode {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgStoreCode::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgStoreCode::from(self.clone()).to_msg()
-    }
+impl Msg for MsgStoreCode {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgStoreCode;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgStoreCode> for MsgStoreCode {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmwasm::wasm::v1beta1::MsgStoreCode) -> Result<MsgStoreCode> {
         let source = if proto.source.is_empty() {
@@ -153,19 +142,12 @@ pub struct MsgInstantiateContract {
     pub funds: Vec<Coin>,
 }
 
-impl MsgType for MsgInstantiateContract {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgInstantiateContract::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgInstantiateContract::from(self.clone()).to_msg()
-    }
+impl Msg for MsgInstantiateContract {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgInstantiateContract;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgInstantiateContract> for MsgInstantiateContract {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmwasm::wasm::v1beta1::MsgInstantiateContract,
@@ -224,19 +206,12 @@ pub struct MsgExecuteContract {
     pub funds: Vec<Coin>,
 }
 
-impl MsgType for MsgExecuteContract {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgExecuteContract::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgExecuteContract::from(self.clone()).to_msg()
-    }
+impl Msg for MsgExecuteContract {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgExecuteContract;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgExecuteContract> for MsgExecuteContract {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmwasm::wasm::v1beta1::MsgExecuteContract,
@@ -281,19 +256,12 @@ pub struct MsgMigrateContract {
     pub migrate_msg: Vec<u8>,
 }
 
-impl MsgType for MsgMigrateContract {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgMigrateContract::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgMigrateContract::from(self.clone()).to_msg()
-    }
+impl Msg for MsgMigrateContract {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgMigrateContract;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgMigrateContract> for MsgMigrateContract {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmwasm::wasm::v1beta1::MsgMigrateContract,
@@ -331,18 +299,12 @@ pub struct MsgUpdateAdmin {
     pub contract: AccountId,
 }
 
-impl MsgType for MsgUpdateAdmin {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin::from(self).to_msg()
-    }
+impl Msg for MsgUpdateAdmin {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin> for MsgUpdateAdmin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin) -> Result<MsgUpdateAdmin> {
         MsgUpdateAdmin::try_from(&proto)
@@ -350,7 +312,7 @@ impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin> for MsgUpdateAdmin 
 }
 
 impl TryFrom<&proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin> for MsgUpdateAdmin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmwasm::wasm::v1beta1::MsgUpdateAdmin) -> Result<MsgUpdateAdmin> {
         Ok(MsgUpdateAdmin {
@@ -387,18 +349,12 @@ pub struct MsgClearAdmin {
     pub contract: AccountId,
 }
 
-impl MsgType for MsgClearAdmin {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmwasm::wasm::v1beta1::MsgClearAdmin::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmwasm::wasm::v1beta1::MsgClearAdmin::from(self).to_msg()
-    }
+impl Msg for MsgClearAdmin {
+    type Proto = proto::cosmwasm::wasm::v1beta1::MsgClearAdmin;
 }
 
 impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgClearAdmin> for MsgClearAdmin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmwasm::wasm::v1beta1::MsgClearAdmin) -> Result<MsgClearAdmin> {
         MsgClearAdmin::try_from(&proto)
@@ -406,7 +362,7 @@ impl TryFrom<proto::cosmwasm::wasm::v1beta1::MsgClearAdmin> for MsgClearAdmin {
 }
 
 impl TryFrom<&proto::cosmwasm::wasm::v1beta1::MsgClearAdmin> for MsgClearAdmin {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmwasm::wasm::v1beta1::MsgClearAdmin) -> Result<MsgClearAdmin> {
         Ok(MsgClearAdmin {

--- a/cosmrs/src/crypto/public_key.rs
+++ b/cosmrs/src/crypto/public_key.rs
@@ -1,14 +1,11 @@
 //! Public keys
 
-use crate::{prost_ext::MessageExt, proto, AccountId, Error, Result};
+use crate::{prost_ext::MessageExt, proto, AccountId, Error, ErrorReport, Result};
 use eyre::WrapErr;
 use prost::Message;
 use prost_types::Any;
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::{TryFrom, TryInto},
-    str::FromStr,
-};
+use std::str::FromStr;
 use subtle_encoding::base64;
 
 /// Protobuf [`Any`] type URL for Ed25519 public keys
@@ -93,7 +90,7 @@ impl From<&k256::ecdsa::VerifyingKey> for PublicKey {
 }
 
 impl TryFrom<Any> for PublicKey {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(any: Any) -> Result<PublicKey> {
         PublicKey::try_from(&any)
@@ -101,7 +98,7 @@ impl TryFrom<Any> for PublicKey {
 }
 
 impl TryFrom<&Any> for PublicKey {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(any: &Any) -> Result<PublicKey> {
         let tm_key = match any.type_url.as_str() {
@@ -144,7 +141,7 @@ impl From<PublicKey> for tendermint::PublicKey {
 }
 
 impl FromStr for PublicKey {
-    type Err = eyre::Report;
+    type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
         Self::from_json(s)
@@ -185,7 +182,7 @@ impl From<&PublicKey> for PublicKeyJson {
 }
 
 impl TryFrom<PublicKeyJson> for PublicKey {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(json: PublicKeyJson) -> Result<PublicKey> {
         PublicKey::try_from(&json)
@@ -193,7 +190,7 @@ impl TryFrom<PublicKeyJson> for PublicKey {
 }
 
 impl TryFrom<&PublicKeyJson> for PublicKey {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(json: &PublicKeyJson) -> Result<PublicKey> {
         let pk_bytes = base64::decode(&json.key)?;

--- a/cosmrs/src/crypto/secp256k1/signing_key.rs
+++ b/cosmrs/src/crypto/secp256k1/signing_key.rs
@@ -1,10 +1,11 @@
 //! Transaction signing key
 
-use crate::crypto::{secp256k1::Signature, PublicKey};
-use eyre::Result;
+use crate::{
+    crypto::{secp256k1::Signature, PublicKey},
+    ErrorReport, Result,
+};
 use k256::ecdsa::VerifyingKey;
 use rand_core::OsRng;
-use std::convert::TryFrom;
 
 /// ECDSA/secp256k1 signing key (i.e. private key)
 ///
@@ -73,7 +74,7 @@ impl From<Box<dyn EcdsaSigner>> for SigningKey {
 }
 
 impl TryFrom<&[u8]> for SigningKey {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
         Self::from_bytes(bytes)

--- a/cosmrs/src/decimal.rs
+++ b/cosmrs/src/decimal.rs
@@ -2,7 +2,7 @@
 //!
 //! [1]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types#Dec
 
-use crate::Result;
+use crate::{ErrorReport, Result};
 use std::{
     fmt,
     ops::{Add, AddAssign},
@@ -16,7 +16,7 @@ use std::{
 pub struct Decimal(u64);
 
 impl FromStr for Decimal {
-    type Err = eyre::Report;
+    type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
         Ok(s.parse().map(Self)?)

--- a/cosmrs/src/distribution.rs
+++ b/cosmrs/src/distribution.rs
@@ -2,12 +2,7 @@
 //!
 //! <https://docs.cosmos.network/master/modules/distribution/>
 
-use crate::{
-    proto,
-    tx::{Msg, MsgType},
-    AccountId, Coin, Result,
-};
-use std::convert::{TryFrom, TryInto};
+use crate::{proto, tx::Msg, AccountId, Coin, ErrorReport, Result};
 
 /// MsgSetWithdrawAddress represents a message to set a withdraw address for staking rewards.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -19,21 +14,14 @@ pub struct MsgSetWithdrawAddress {
     pub withdraw_address: AccountId,
 }
 
-impl MsgType for MsgSetWithdrawAddress {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress::from(self).to_msg()
-    }
+impl Msg for MsgSetWithdrawAddress {
+    type Proto = proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress;
 }
 
 impl TryFrom<proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress>
     for MsgSetWithdrawAddress
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress,
@@ -45,7 +33,7 @@ impl TryFrom<proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress>
 impl TryFrom<&proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress>
     for MsgSetWithdrawAddress
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: &proto::cosmos::distribution::v1beta1::MsgSetWithdrawAddress,
@@ -86,21 +74,14 @@ pub struct MsgWithdrawDelegatorReward {
     pub validator_address: AccountId,
 }
 
-impl MsgType for MsgWithdrawDelegatorReward {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward::from(self).to_msg()
-    }
+impl Msg for MsgWithdrawDelegatorReward {
+    type Proto = proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward;
 }
 
 impl TryFrom<proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward>
     for MsgWithdrawDelegatorReward
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward,
@@ -112,7 +93,7 @@ impl TryFrom<proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward>
 impl TryFrom<&proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward>
     for MsgWithdrawDelegatorReward
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: &proto::cosmos::distribution::v1beta1::MsgWithdrawDelegatorReward,
@@ -154,21 +135,14 @@ pub struct MsgWithdrawValidatorCommission {
     pub validator_address: AccountId,
 }
 
-impl MsgType for MsgWithdrawValidatorCommission {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission::from(self).to_msg()
-    }
+impl Msg for MsgWithdrawValidatorCommission {
+    type Proto = proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission;
 }
 
 impl TryFrom<proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission>
     for MsgWithdrawValidatorCommission
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission,
@@ -180,7 +154,7 @@ impl TryFrom<proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommissio
 impl TryFrom<&proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission>
     for MsgWithdrawValidatorCommission
 {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: &proto::cosmos::distribution::v1beta1::MsgWithdrawValidatorCommission,
@@ -223,19 +197,12 @@ pub struct MsgFundCommunityPool {
     pub amount: Vec<Coin>,
 }
 
-impl MsgType for MsgFundCommunityPool {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::distribution::v1beta1::MsgFundCommunityPool::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::distribution::v1beta1::MsgFundCommunityPool::from(self).to_msg()
-    }
+impl Msg for MsgFundCommunityPool {
+    type Proto = proto::cosmos::distribution::v1beta1::MsgFundCommunityPool;
 }
 
 impl TryFrom<proto::cosmos::distribution::v1beta1::MsgFundCommunityPool> for MsgFundCommunityPool {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmos::distribution::v1beta1::MsgFundCommunityPool,
@@ -245,7 +212,7 @@ impl TryFrom<proto::cosmos::distribution::v1beta1::MsgFundCommunityPool> for Msg
 }
 
 impl TryFrom<&proto::cosmos::distribution::v1beta1::MsgFundCommunityPool> for MsgFundCommunityPool {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: &proto::cosmos::distribution::v1beta1::MsgFundCommunityPool,

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -54,6 +54,8 @@ pub use crate::{
 };
 
 pub use cosmos_sdk_proto as proto;
+pub use eyre::Report as ErrorReport;
+pub use prost_types::Any;
 pub use tendermint;
 
 #[cfg(feature = "bip32")]

--- a/cosmrs/src/staking.rs
+++ b/cosmrs/src/staking.rs
@@ -2,12 +2,7 @@
 //!
 //! <https://docs.cosmos.network/master/modules/staking/>
 
-use crate::{
-    proto,
-    tx::{Msg, MsgType},
-    AccountId, Coin, Error, Result,
-};
-use std::convert::{TryFrom, TryInto};
+use crate::{proto, tx::Msg, AccountId, Coin, Error, ErrorReport, Result};
 
 /// MsgDelegate represents a message to delegate coins to a validator.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -22,18 +17,12 @@ pub struct MsgDelegate {
     pub amount: Coin,
 }
 
-impl MsgType for MsgDelegate {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::staking::v1beta1::MsgDelegate::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::staking::v1beta1::MsgDelegate::from(self).to_msg()
-    }
+impl Msg for MsgDelegate {
+    type Proto = proto::cosmos::staking::v1beta1::MsgDelegate;
 }
 
 impl TryFrom<proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
         MsgDelegate::try_from(&proto)
@@ -41,7 +30,7 @@ impl TryFrom<proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
 }
 
 impl TryFrom<&proto::cosmos::staking::v1beta1::MsgDelegate> for MsgDelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgDelegate) -> Result<MsgDelegate> {
         let amount = proto
@@ -94,18 +83,12 @@ pub struct MsgUndelegate {
     pub amount: Option<Coin>,
 }
 
-impl MsgType for MsgUndelegate {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::staking::v1beta1::MsgUndelegate::from_msg(msg).and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::staking::v1beta1::MsgUndelegate::from(self).to_msg()
-    }
+impl Msg for MsgUndelegate {
+    type Proto = proto::cosmos::staking::v1beta1::MsgUndelegate;
 }
 
 impl TryFrom<proto::cosmos::staking::v1beta1::MsgUndelegate> for MsgUndelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::staking::v1beta1::MsgUndelegate) -> Result<MsgUndelegate> {
         MsgUndelegate::try_from(&proto)
@@ -113,7 +96,7 @@ impl TryFrom<proto::cosmos::staking::v1beta1::MsgUndelegate> for MsgUndelegate {
 }
 
 impl TryFrom<&proto::cosmos::staking::v1beta1::MsgUndelegate> for MsgUndelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmos::staking::v1beta1::MsgUndelegate) -> Result<MsgUndelegate> {
         let amount = if let Some(amount) = &proto.amount {
@@ -171,19 +154,12 @@ pub struct MsgBeginRedelegate {
     pub amount: Option<Coin>,
 }
 
-impl MsgType for MsgBeginRedelegate {
-    fn from_msg(msg: &Msg) -> Result<Self> {
-        proto::cosmos::staking::v1beta1::MsgBeginRedelegate::from_msg(msg)
-            .and_then(TryInto::try_into)
-    }
-
-    fn to_msg(&self) -> Result<Msg> {
-        proto::cosmos::staking::v1beta1::MsgBeginRedelegate::from(self).to_msg()
-    }
+impl Msg for MsgBeginRedelegate {
+    type Proto = proto::cosmos::staking::v1beta1::MsgBeginRedelegate;
 }
 
 impl TryFrom<proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginRedelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: proto::cosmos::staking::v1beta1::MsgBeginRedelegate,
@@ -193,7 +169,7 @@ impl TryFrom<proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginRe
 }
 
 impl TryFrom<&proto::cosmos::staking::v1beta1::MsgBeginRedelegate> for MsgBeginRedelegate {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(
         proto: &proto::cosmos::staking::v1beta1::MsgBeginRedelegate,

--- a/cosmrs/src/tx.rs
+++ b/cosmrs/src/tx.rs
@@ -26,7 +26,7 @@
 //! use cosmrs::{
 //!     bank::MsgSend,
 //!     crypto::secp256k1,
-//!     tx::{self, Fee, MsgType, SignDoc, SignerInfo, Tx},
+//!     tx::{self, Fee, Msg, SignDoc, SignerInfo, Tx},
 //!     AccountId, Coin
 //! };
 //!
@@ -68,7 +68,7 @@
 //! let memo = "example memo";
 //!
 //! // Create transaction body from the MsgSend, memo, and timeout height.
-//! let tx_body = tx::Body::new(vec![msg_send.to_msg()?], memo, timeout_height);
+//! let tx_body = tx::Body::new(vec![msg_send.to_any()?], memo, timeout_height);
 //!
 //! // Create signer info from public key and sequence number.
 //! // This uses a standard "direct" signature from a single signer.
@@ -117,17 +117,16 @@ pub use self::{
     body::Body,
     fee::Fee,
     mode_info::ModeInfo,
-    msg::{Msg, MsgProto, MsgType},
+    msg::{Msg, MsgProto},
     raw::Raw,
     sign_doc::SignDoc,
     signer_info::SignerInfo,
 };
-pub use crate::proto::cosmos::tx::signing::v1beta1::SignMode;
+pub use crate::{proto::cosmos::tx::signing::v1beta1::SignMode, ErrorReport};
 pub use tendermint::abci::{transaction::Hash, Gas};
 
 use crate::{crypto::secp256k1, proto, Error, Result};
 use prost::Message;
-use std::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "rpc")]
 use crate::rpc;
@@ -172,14 +171,14 @@ impl Tx {
 }
 
 impl TryFrom<&[u8]> for Tx {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(bytes: &[u8]) -> Result<Tx> {
         proto::cosmos::tx::v1beta1::Tx::decode(bytes)?.try_into()
     }
 }
 impl TryFrom<proto::cosmos::tx::v1beta1::Tx> for Tx {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::Tx) -> Result<Tx> {
         Ok(Tx {

--- a/cosmrs/src/tx/auth_info.rs
+++ b/cosmrs/src/tx/auth_info.rs
@@ -1,8 +1,7 @@
 //! Auth info.
 
 use super::{Fee, SignerInfo};
-use crate::{prost_ext::MessageExt, proto, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use crate::{prost_ext::MessageExt, proto, Error, ErrorReport, Result};
 
 /// [`AuthInfo`] describes the fee and signer modes that are used to sign a transaction.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -35,7 +34,7 @@ impl AuthInfo {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::AuthInfo> for AuthInfo {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::AuthInfo) -> Result<AuthInfo> {
         Ok(AuthInfo {

--- a/cosmrs/src/tx/body.rs
+++ b/cosmrs/src/tx/body.rs
@@ -1,9 +1,7 @@
 //! Transaction bodies.
 
-use super::Msg;
-use crate::{prost_ext::MessageExt, proto, Result};
+use crate::{prost_ext::MessageExt, proto, ErrorReport, Result};
 use prost_types::Any;
-use std::convert::{TryFrom, TryInto};
 use tendermint::block;
 
 /// [`Body`] of a transaction that all signers sign over.
@@ -19,7 +17,7 @@ pub struct Body {
     /// By convention, the first required signer (usually from the first message)
     /// is referred to as the primary signer and pays the fee for the whole
     /// transaction.
-    pub messages: Vec<Msg>,
+    pub messages: Vec<Any>,
 
     /// `memo` is any arbitrary memo to be added to the transaction.
     pub memo: String,
@@ -47,7 +45,7 @@ impl Body {
         timeout_height: impl Into<block::Height>,
     ) -> Self
     where
-        I: IntoIterator<Item = Msg>,
+        I: IntoIterator<Item = Any>,
     {
         Body {
             messages: messages.into_iter().map(Into::into).collect(),
@@ -82,7 +80,7 @@ impl From<Body> for proto::cosmos::tx::v1beta1::TxBody {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::TxBody> for Body {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::TxBody) -> Result<Body> {
         Ok(Body {

--- a/cosmrs/src/tx/fee.rs
+++ b/cosmrs/src/tx/fee.rs
@@ -1,8 +1,7 @@
 //! Transaction fees
 
 use super::Gas;
-use crate::{proto, AccountId, Coin, Result};
-use std::convert::TryFrom;
+use crate::{proto, AccountId, Coin, ErrorReport, Result};
 
 /// Fee includes the amount of coins paid in fees and the maximum gas to be
 /// used by the transaction.
@@ -50,7 +49,7 @@ impl Fee {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::Fee> for Fee {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::Fee) -> Result<Fee> {
         Fee::try_from(&proto)
@@ -58,7 +57,7 @@ impl TryFrom<proto::cosmos::tx::v1beta1::Fee> for Fee {
 }
 
 impl TryFrom<&proto::cosmos::tx::v1beta1::Fee> for Fee {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmos::tx::v1beta1::Fee) -> Result<Fee> {
         let amount = proto

--- a/cosmrs/src/tx/mode_info.rs
+++ b/cosmrs/src/tx/mode_info.rs
@@ -1,8 +1,7 @@
 //! Mode info.
 
 use super::SignMode;
-use crate::{crypto::CompactBitArray, proto, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use crate::{crypto::CompactBitArray, proto, Error, ErrorReport, Result};
 
 /// [`ModeInfo`] describes the signing mode of a single or nested multisig signer.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -22,7 +21,7 @@ impl ModeInfo {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::ModeInfo> for ModeInfo {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::ModeInfo) -> Result<ModeInfo> {
         match proto.sum {
@@ -112,7 +111,7 @@ pub struct Multi {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::mode_info::Multi> for Multi {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::mode_info::Multi) -> Result<Multi> {
         Ok(Multi {

--- a/cosmrs/src/tx/signer_info.rs
+++ b/cosmrs/src/tx/signer_info.rs
@@ -1,8 +1,7 @@
 //! Signer info.
 
 use super::{AuthInfo, Fee, ModeInfo, SequenceNumber, SignMode};
-use crate::{crypto::PublicKey, proto, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use crate::{crypto::PublicKey, proto, Error, ErrorReport, Result};
 
 /// [`SignerInfo`] describes the public key and signing mode of a single top-level signer.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,7 +46,7 @@ impl SignerInfo {
 }
 
 impl TryFrom<proto::cosmos::tx::v1beta1::SignerInfo> for SignerInfo {
-    type Error = eyre::Report;
+    type Error = ErrorReport;
 
     fn try_from(proto: proto::cosmos::tx::v1beta1::SignerInfo) -> Result<SignerInfo> {
         Ok(SignerInfo {

--- a/cosmrs/tests/integration.rs
+++ b/cosmrs/tests/integration.rs
@@ -8,7 +8,7 @@ use cosmrs::{
     bank::MsgSend,
     crypto::secp256k1,
     dev, rpc,
-    tx::{self, AccountNumber, Fee, MsgType, SignDoc, SignerInfo},
+    tx::{self, AccountNumber, Fee, Msg, SignDoc, SignerInfo},
     Coin,
 };
 use std::{panic, str};
@@ -53,7 +53,7 @@ fn msg_send() {
         to_address: recipient_account_id,
         amount: vec![amount.clone()],
     }
-    .to_msg()
+    .to_any()
     .unwrap();
 
     let chain_id = CHAIN_ID.parse().unwrap();


### PR DESCRIPTION
- Removes the former `Msg` newtype for `Any`; uses the `Any` type explicitly. The `Msg` newtype was providing little value and obscuring access to the `type_url`.
- Renames `from_msg` and `to_msg` methods to `from_any` and `to_any`.
- Renames the `MsgType` trait to `Msg`. This trait now has an associated `Proto` type bounded on `MsgProto`. This alows for default impls of `from_any`/`to_any`/`into_any` methods which replace the previous blanket impl of `MsgType` for `MsgProto`.

Altogether these changes simplify the API and eliminate some redundant
boilerplate impling the former `MsgType` trait.