### PR TITLE
cosmos-sdk-proto: 2021 edition upgrade; include_str! docs

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -6,13 +6,14 @@ authors = [
     "Greg Szabo <greg@informal.systems>",
     "Tony Arcieri <tony@iqlusion.io>"
 ]
-edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmos-sdk-proto"
 description = "Protobuf stuct defintions for interacting Cosmos SDK powered blockchains"
-readme     = "README.md"
+readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
-keywords   = ["blockchain", "cosmos", "tendermint", "proto"]
+keywords = ["blockchain", "cosmos", "tendermint", "proto"]
+edition = "2018"
+rust-version = "1.56"
 
 [dependencies]
 prost = "0.9"

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -11,8 +11,8 @@ Rust crate for interacting with [Protobufs] defined by the [Cosmos SDK].
 The goal of this crate is to provide complete proto struct definitions for interacting
 with a Cosmos SDK blockchain.
 
-Currently this crate only provides a minority of the many total structs exported by
-proto files.
+Currently, this crate only provides a subset of the many total structs exported by
+Cosmos SDK proto files.
 
 Pull requests to expand coverage are welcome.
 

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -1,17 +1,9 @@
-//! The `cosmos-sdk-proto` crate provides access to the Cosmos SDK proto-defined structs.
-//! These are then re-exported in a module structure as close as possible to the proto files.
-//!
-//! The version strings are intentionally excluded, that way users may specify `cosmos-sdk` versions
-//! as a feature argument to this crate and not have to change their imports. For as much as that is
-//! worth considering that modules seem to show up and go away with every RC.
-//!
-//! TODO: actually implement features tag based compilation
-
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
     html_root_url = "https://docs.rs/cosmos-sdk-proto/0.7.1"
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 


### PR DESCRIPTION
- Changes `edition` attribute to 2021 in Cargo.toml
- Adds a `rust-version` attribute set to 1.56
- Uses the new `include_str!` feature to import README.md as the toplevel rustdoc documentation for the crate