### PR TITLE
cosmos-sdk-proto v0.8.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-10-28)
+### Changed
+- Update to cosmos-sdk v0.44.1 and ibc-go v1.2.0 ([#138])
+- Bump tendermint-rs crates to v0.23; MSRV 1.56 ([#144])
+- 2021 edition upgrade ([#148])
+
+[#138]: https://github.com/cosmos/cosmos-rust/pull/138
+[#144]: https://github.com/cosmos/cosmos-rust/pull/144
+[#148]: https://github.com/cosmos/cosmos-rust/pull/148
+
 ## 0.7.0 (2021-09-27)
 ### Changed
 - Update `tendermint-proto` crate to v0.22 ([#128])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",
@@ -12,7 +12,7 @@ description = "Protobuf stuct defintions for interacting Cosmos SDK powered bloc
 readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords = ["blockchain", "cosmos", "tendermint", "proto"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 
 [dependencies]

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.7.1"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.8.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.8.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.8", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.12", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.9", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Update to cosmos-sdk v0.44.1 and ibc-go v1.2.0 ([#138])
- Bump tendermint-rs crates to v0.23; MSRV 1.56 ([#144])
- 2021 edition upgrade ([#148])

[#138]: https://github.com/cosmos/cosmos-rust/pull/138
[#144]: https://github.com/cosmos/cosmos-rust/pull/144
[#148]: https://github.com/cosmos/cosmos-rust/pull/148