### PR TITLE
cosmrs v0.3.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-10-28)
+### Added
+- Associated `Proto` type to `Msg` trait - formerly named `MsgType` ([#146])
+- `from_any`/`to_any` methods to `Msg` trait - formerly named `MsgType` ([#146])
+- `/cosmos.crypto.multisig.LegacyAminoPubKey` support ([#147])
+- `SignerPublicKey` enum for `SignerInfo::public_key` ([#147])
+
+### Changed
+- Bump tendermint-rs crates to v0.23 ([#144])
+- Bump prost crates to v0.9 ([#144])
+- Bump tonic to v0.6 ([#144])
+- MSRV 1.56 ([#144])
+- Renamed `tx::MsgType` trait to `tx::Msg` ([#146])
+- Renamed `MsgProto::from_msg`/`to_msg` to `from_any`/`to_any`([#146])
+- Bump `cosmos-sdk-proto` to v0.8 ([#149])
+
+### Removed
+- `tx::Msg` newtype for `prost_types::Any`. Use `Any` instead ([#146])
+
+[#144]: https://github.com/cosmos/cosmos-rust/pull/144
+[#146]: https://github.com/cosmos/cosmos-rust/pull/146
+[#147]: https://github.com/cosmos/cosmos-rust/pull/147
+[#149]: https://github.com/cosmos/cosmos-rust/pull/149
+
 ## 0.2.1 (2021-10-06)
 ### Added
 - `PublicKey` JSON serialization support ([#133])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/README.md
+++ b/cosmrs/README.md
@@ -1,4 +1,4 @@
-# CosmRS: Cosmos SDK for Rust
+# CosmRS: Cosmos Wallet and SDK for Rust
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -9,7 +9,24 @@
 Framework for building [Cosmos] blockchain applications in Rust, modeled off
 of the [Cosmos SDK for Golang].
 
-[Documentation][docs-link]
+## About
+
+This library is presently designed to serve as a *client* for interacting
+with the Golang implementation of the Cosmos SDK, providing things like wallet
+functionality such as transaction signing, and a builder/parser for Cosmos SDK
+formatted transaction messages.
+
+It does not implement server-side functionality (yet), such as hooks
+and message passing.
+
+## Features
+
+- [CosmWasm]: messages used by smart contracts written using CosmWasm
+- [Staking]: support for staking with validators
+- [Transactions]: build, sign, and/or parse Cosmos SDK transactions
+
+[Cosmos]: https://cosmos.network/
+[Cosmos SDK for Golang]: https://github.com/cosmos/cosmos-sdk
 
 ## Minimum Supported Rust Version
 
@@ -29,3 +46,6 @@ This crate is supported on Rust **1.56** or newer.
 [//]: # "general links"
 [Cosmos]: https://cosmos.network/
 [Cosmos SDK for Golang]: https://github.com/cosmos/cosmos-sdk
+[CosmWasm]: https://cosmwasm.com/
+[Staking]: https://docs.cosmos.network/master/modules/staking/
+[Transactions]: https://docs.cosmos.network/master/core/transactions.html

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -1,30 +1,9 @@
-//! # Cosmos SDK for Rust
-//!
-//! Framework for building [Cosmos] blockchain applications in Rust, modeled off
-//! of the [Cosmos SDK for Golang].
-//!
-//! ## About
-//!
-//! This library is presently designed to serve as a *client* for interacting
-//! with the Golang implementation of the Cosmos SDK.
-//!
-//! It does not implement server-side functionality (yet), such as hooks
-//! and message passing.
-//!
-//! ## Features
-//!
-//! - [CosmWasm][`cosmwasm`]: messages used by smart contracts written using CosmWasm
-//! - [Staking][`staking`]: support for staking with validators
-//! - [Transactions][`tx`]: build, sign, and/or parse Cosmos SDK transactions
-//!
-//! [Cosmos]: https://cosmos.network/
-//! [Cosmos SDK for Golang]: https://github.com/cosmos/cosmos-sdk
-
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmrs/0.2.1"
+    html_root_url = "https://docs.rs/cosmrs/0.3.0"
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 


### PR DESCRIPTION
### Added
- Associated `Proto` type to `Msg` trait - formerly named `MsgType` ([#146])
- `from_any`/`to_any` methods to `Msg` trait - formerly named `MsgType` ([#146])
- `/cosmos.crypto.multisig.LegacyAminoPubKey` support ([#147])
- `SignerPublicKey` enum for `SignerInfo::public_key` ([#147])

### Changed
- Bump tendermint-rs crates to v0.23 ([#144])
- Bump prost crates to v0.9 ([#144])
- Bump tonic to v0.6 ([#144])
- MSRV 1.56 ([#144])
- Renamed `tx::MsgType` trait to `tx::Msg` ([#146])
- Renamed `MsgProto::from_msg`/`to_msg` to `from_any`/`to_any`([#146])
- Bump `cosmos-sdk-proto` to v0.8 ([#149])

### Removed
- `tx::Msg` newtype for `prost_types::Any`. Use `Any` instead ([#146])

[#144]: https://github.com/cosmos/cosmos-rust/pull/144
[#146]: https://github.com/cosmos/cosmos-rust/pull/146
[#147]: https://github.com/cosmos/cosmos-rust/pull/147
[#149]: https://github.com/cosmos/cosmos-rust/pull/149