### PR TITLE
Pin tendermint-rs deps to v0.23.1 for now

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 [dependencies]
 prost = "0.9"
 prost-types = "0.9"
-tendermint-proto = "0.23"
+tendermint-proto = "=0.23.1"
 
 # Optional dependencies
 tonic = { version = "0.6", optional = true }

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -22,12 +22,12 @@ rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.23", features = ["secp256k1"] }
+tendermint = { version = "=0.23.1", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
 bip32 = { version = "0.2", optional = true }
-tendermint-rpc = { version = "0.23", optional = true, features = ["http-client"] }
+tendermint-rpc = { version = "=0.23.1", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
As per the tendermint-rs versioning (https://github.com/informalsystems/tendermint-rs#versioning), we're now focusing on the v0.24.0 release for compatibility with Tendermint v0.35.x, so any further breaking changes to the v0.23.x series of tendermint-rs need to be released as patch versions.

This pins your tendermint-rs deps to v0.23.1 for now until we can ensure that v0.23.2 (https://github.com/informalsystems/tendermint-rs/pull/1043) does not break anything.