### PR TITLE
cosmos-sdk-proto v0.9.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-01-10)
+### Changed
+- Update wasmd compatibility to 0.21 ([#158])
+- Bump `tendermint-proto` to v0.23.3 ([#163])
+
+[#158]: https://github.com/cosmos/cosmos-rust/pull/158
+[#163]: https://github.com/cosmos/cosmos-rust/pull/163
+
 ## 0.8.0 (2021-10-28)
 ### Changed
 - Update to cosmos-sdk v0.44.1 and ibc-go v1.2.0 ([#138])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.8.0"
+    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.9.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.8", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.9", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.13", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.10", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Update wasmd compatibility to 0.21 ([#158])
- Bump `tendermint-proto` to v0.23.3 ([#163])

[#158]: https://github.com/cosmos/cosmos-rust/pull/158
[#163]: https://github.com/cosmos/cosmos-rust/pull/163