### PR TITLE
cosmrs v0.4.1

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (2022-01-07)
+## 0.4.1 (2022-01-10)
+### Changed
+- Bump `cosmos-sdk-proto` to v0.4.1 ([#165])
+
+[#165]: https://github.com/cosmos/cosmos-rust/pull/165
+
+## 0.4.0 (2022-01-07) [YANKED]
 ### Changed
 - Bump `tendermint` to v0.23.3; `k256` to v0.10 ([#163])
 - Use `Vec<u8>` as the `Tx::signatures` type ([#164])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmrs/0.4.0"
+    html_root_url = "https://docs.rs/cosmrs/0.4.1"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Bump `cosmos-sdk-proto` to v0.4.1 ([#165])

[#165]: https://github.com/cosmos/cosmos-rust/pull/165