### PR TITLE
cosmos-sdk-proto v0.10.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2022-03-10)
+### Added
+- `authz` and `feegrant` protos ([#177])
+
+### Changed
+- Update SDK version => v0.45.1, IBC => v2.0.3, wasmd => v0.23.0 ([#177])
+- Bump `tendermint-proto` to v0.23.5 ([#178])
+
+[#177]: https://github.com/cosmos/cosmos-rust/pull/177
+[#178]: https://github.com/cosmos/cosmos-rust/pull/178
+
 ## 0.9.0 (2022-01-10)
 ### Changed
 - Update wasmd compatibility to 0.21 ([#158])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmos-sdk-proto/0.9.0"
+    html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.9", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.10", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.13", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.10", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- `authz` and `feegrant` protos ([#177])

### Changed
- Update SDK version => v0.45.1, IBC => v2.0.3, wasmd => v0.23.0 ([#177])
- Bump `tendermint-proto` to v0.23.5 ([#178])

[#177]: https://github.com/cosmos/cosmos-rust/pull/177
[#178]: https://github.com/cosmos/cosmos-rust/pull/178