### PR TITLE
cosmrs v0.5.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-03-10)
+### Changed
+- Bump `tendermint-proto` to v0.23.5 ([#178])
+- Bump `cosmos-sdk-proto` to v0.10.0 ([#180])
+
+### Removed
+- `Option` from field amount of `MsgUndelegate` and `MsgBeginRedelegate` ([#175])
+
+[#175]: https://github.com/cosmos/cosmos-rust/pull/175
+[#178]: https://github.com/cosmos/cosmos-rust/pull/178
+[#180]: https://github.com/cosmos/cosmos-rust/pull/180
+
 ## 0.4.1 (2022-01-10)
 ### Changed
 - Bump `cosmos-sdk-proto` to v0.4.1 ([#165])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmrs/0.4.1"
+    html_root_url = "https://docs.rs/cosmrs/0.5.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Bump `tendermint-proto` to v0.23.5 ([#178])
- Bump `cosmos-sdk-proto` to v0.10.0 ([#180])

### Removed
- `Option` from field amount of `MsgUndelegate` and `MsgBeginRedelegate` ([#175])

[#175]: https://github.com/cosmos/cosmos-rust/pull/175
[#178]: https://github.com/cosmos/cosmos-rust/pull/178
[#180]: https://github.com/cosmos/cosmos-rust/pull/180