### PR TITLE
cosmrs: fully variable-width `AccountId`

### DIFF
--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.5.1"
+version = "0.6.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/src/crypto/public_key.rs
+++ b/cosmrs/src/crypto/public_key.rs
@@ -35,7 +35,7 @@ impl PublicKey {
         match &self.0 {
             tendermint::PublicKey::Secp256k1(encoded_point) => {
                 let id = tendermint::account::Id::from(*encoded_point);
-                AccountId::new(prefix, id.as_bytes().try_into()?)
+                AccountId::new(prefix, id.as_bytes())
             }
             _ => Err(Error::Crypto.into()),
         }


### PR DESCRIPTION
This commit changes the constructor and `to_bytes` methods to fully support variable-width account IDs, as added in cosmos/cosmos-sdk#8363.

This is a breaking change.