### PR TITLE
cosmos-sdk-proto v0.11.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-04-21)
+### Added
+- Missing modules from `ibc-go` ([#187])
+
+### Changed
+- Upgrade SDK version => v0.45.2, IBC => v3.0.0 ([#199])
+- Bump tendermint-rs crates to v0.23.6 ([#205])
+
+### Fixed
+- Export `authz` module ([#186])
+- Export `feegrant` module ([#198])
+
+[#186]: https://github.com/cosmos/cosmos-rust/pull/186
+[#187]: https://github.com/cosmos/cosmos-rust/pull/187
+[#198]: https://github.com/cosmos/cosmos-rust/pull/198
+[#199]: https://github.com/cosmos/cosmos-rust/pull/199
+[#205]: https://github.com/cosmos/cosmos-rust/pull/205
+
 ## 0.10.0 (2022-03-10)
 ### Added
 - `authz` and `feegrant` protos ([#177])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.10", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.11", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.13", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.10", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- Missing modules from `ibc-go` ([#187])

### Changed
- Upgrade SDK version => v0.45.2, IBC => v3.0.0 ([#199])
- Bump tendermint-rs crates to v0.23.6 ([#205])

### Fixed
- Export `authz` module ([#186])
- Export `feegrant` module ([#198])

[#186]: https://github.com/cosmos/cosmos-rust/pull/186
[#187]: https://github.com/cosmos/cosmos-rust/pull/187
[#198]: https://github.com/cosmos/cosmos-rust/pull/198
[#199]: https://github.com/cosmos/cosmos-rust/pull/199
[#205]: https://github.com/cosmos/cosmos-rust/pull/205