### PR TITLE
cosmrs v0.6.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-04-21)
+### Added
+- `TryFrom` impls for `tendermint` public key types ([#203])
+
+### Changed
+- Support variable-width `AccountId` using new Cosmos SDK rules ([#197], [#204])
+- Bump tendermint-rs crates to v0.23.6 ([#205])
+- Bump `cosmos-sdk-proto` to v0.11.0 ([#206])
+
+[#197]: https://github.com/cosmos/cosmos-rust/pull/197
+[#203]: https://github.com/cosmos/cosmos-rust/pull/203
+[#204]: https://github.com/cosmos/cosmos-rust/pull/204
+[#205]: https://github.com/cosmos/cosmos-rust/pull/205
+[#206]: https://github.com/cosmos/cosmos-rust/pull/206
+
 ## 0.5.1 (2022-03-14)
 ### Fixed
 - `Denom` parsing for IBC addresses ([#182])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png",
-    html_root_url = "https://docs.rs/cosmrs/0.5.1"
+    html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Added
- `TryFrom` impls for `tendermint` public key types ([#203])

### Changed
- Support variable-width `AccountId` using new Cosmos SDK rules ([#197], [#204])
- Bump tendermint-rs crates to v0.23.6 ([#205])
- Bump `cosmos-sdk-proto` to v0.11.0 ([#206])

[#197]: https://github.com/cosmos/cosmos-rust/pull/197
[#203]: https://github.com/cosmos/cosmos-rust/pull/203
[#204]: https://github.com/cosmos/cosmos-rust/pull/204
[#205]: https://github.com/cosmos/cosmos-rust/pull/205
[#206]: https://github.com/cosmos/cosmos-rust/pull/206