### PR TITLE
cosmrs: better error message on `AccountId` Bech32 decode failure

### DIFF
--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -82,7 +82,7 @@ impl FromStr for AccountId {
     type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
-        let (hrp, bytes) = bech32::decode(s).wrap_err("failed to decode bech32")?;
+        let (hrp, bytes) = bech32::decode(s).wrap_err(format!("invalid bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)
     }
 }
@@ -204,7 +204,14 @@ impl FromStr for Denom {
 
 #[cfg(test)]
 mod tests {
-    use super::Denom;
+    use super::{AccountId, Denom};
+
+    #[test]
+    fn account_id() {
+        let _id = "juno1cma4czt2jnydvrvz3lrc9jvcmhpjxtds95s3c6"
+            .parse::<AccountId>()
+            .unwrap();
+    }
 
     #[test]
     fn denom_from_str() {

--- a/cosmrs/src/tx.rs
+++ b/cosmrs/src/tx.rs
@@ -183,6 +183,7 @@ impl TryFrom<&[u8]> for Tx {
         proto::cosmos::tx::v1beta1::Tx::decode(bytes)?.try_into()
     }
 }
+
 impl TryFrom<proto::cosmos::tx::v1beta1::Tx> for Tx {
     type Error = ErrorReport;
 


### PR DESCRIPTION
Includes the Bech32 string that failed to decode in the error message.

Also adds a basic test for `AccountId` parsing.