### PR TITLE
cosmrs: add sealed `ParseOptional` trait; fix `Fee` parsing

### DIFF
--- a/cosmrs/src/cosmwasm.rs
+++ b/cosmrs/src/cosmwasm.rs
@@ -4,7 +4,9 @@
 //! - Protocol Docs: <https://github.com/CosmWasm/wasmd/blob/master/docs/proto/proto.md>
 
 pub use crate::proto::cosmwasm::wasm::v1::AccessType;
-use crate::{proto, tx::Msg, AccountId, Coin, Error, ErrorReport, Result};
+use crate::{
+    prost_ext::ParseOptional, proto, tx::Msg, AccountId, Coin, Error, ErrorReport, Result,
+};
 
 /// AccessConfig access control type.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -129,21 +131,11 @@ impl TryFrom<proto::cosmwasm::wasm::v1::MsgInstantiateContract> for MsgInstantia
     fn try_from(
         proto: proto::cosmwasm::wasm::v1::MsgInstantiateContract,
     ) -> Result<MsgInstantiateContract> {
-        let label = if proto.label.is_empty() {
-            None
-        } else {
-            Some(proto.label)
-        };
-        let admin = if proto.admin.is_empty() {
-            None
-        } else {
-            Some(proto.admin.parse())
-        };
         Ok(MsgInstantiateContract {
             sender: proto.sender.parse()?,
-            admin: admin.transpose()?,
+            admin: proto.admin.parse_optional()?,
             code_id: proto.code_id,
-            label,
+            label: proto.label.parse_optional()?,
             msg: proto.msg,
             funds: proto
                 .funds

--- a/cosmrs/src/prost_ext.rs
+++ b/cosmrs/src/prost_ext.rs
@@ -1,6 +1,7 @@
 //! Prost extension traits
 
 use crate::Result;
+use std::str::FromStr;
 
 /// Extension trait for prost messages.
 // TODO(tarcieri): decide if this trait should really be sealed or if it should be public
@@ -19,3 +20,20 @@ where
         Ok(bytes)
     }
 }
+
+/// Extension traits for optionally parsing non-empty strings.
+///
+/// This is a common pattern in Cosmos SDK protobufs.
+pub trait ParseOptional: AsRef<str> {
+    /// Parse optional field.
+    fn parse_optional<T: FromStr>(&self) -> Result<Option<T>, T::Err> {
+        if self.as_ref().is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(self.as_ref().parse()?))
+        }
+    }
+}
+
+impl ParseOptional for str {}
+impl ParseOptional for String {}

--- a/cosmrs/src/tx/fee.rs
+++ b/cosmrs/src/tx/fee.rs
@@ -1,7 +1,7 @@
 //! Transaction fees
 
 use super::Gas;
-use crate::{proto, AccountId, Coin, ErrorReport, Result};
+use crate::{prost_ext::ParseOptional, proto, AccountId, Coin, ErrorReport, Result};
 
 /// Fee includes the amount of coins paid in fees and the maximum gas to be
 /// used by the transaction.
@@ -66,22 +66,11 @@ impl TryFrom<&proto::cosmos::tx::v1beta1::Fee> for Fee {
             .map(TryFrom::try_from)
             .collect::<Result<_, _>>()?;
 
-        let gas_limit = proto.gas_limit.into();
-        let mut accounts = [None, None];
-
-        for (index, id) in [&proto.payer, &proto.granter].iter().enumerate() {
-            if id.is_empty() {
-                accounts[index] = None;
-            } else {
-                accounts[index] = Some(proto.payer.parse()?)
-            }
-        }
-
         Ok(Fee {
             amount,
-            gas_limit,
-            payer: accounts[0].take(),
-            granter: accounts[1].take(),
+            gas_limit: proto.gas_limit.into(),
+            payer: proto.payer.parse_optional()?,
+            granter: proto.granter.parse_optional()?,
         })
     }
 }


### PR DESCRIPTION
Adds an extension trait to `String`/`str` for handling a common Cosmos SDK pattern: treating a string field as optional if it's empty, or otherwise parsing it to a particular type.

This pattern existed in the `cosmwasm` and `fee` modules, with similar boilerplate to handle it. As it were, the code in the `Fee` module was buggy.

This redundant code can be replaced with this simple extension trait.