### PR TITLE
cosmrs v0.6.1

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2022-04-21)
+## 0.6.1 (2022-04-28)
+### Fixed
+- Better error message on `AccountId` Bech32 decode failure ([#209])
+- `tx::Fee` parsing with empty address fields ([#210])
+
+[#209]: https://github.com/cosmos/cosmos-rust/pull/209
+[#210]: https://github.com/cosmos/cosmos-rust/pull/210
+
+## 0.6.0 (2022-04-22)
 ### Added
 - `TryFrom` impls for `tendermint` public key types ([#203])
 

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Fixed
- Better error message on `AccountId` Bech32 decode failure ([#209])
- `tx::Fee` parsing with empty address fields ([#210])

[#209]: https://github.com/cosmos/cosmos-rust/pull/209
[#210]: https://github.com/cosmos/cosmos-rust/pull/210