### PR TITLE
cosmos-sdk-proto v0.12.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2022-05-02)
+### Changed
+- Bump tendermint-rs crates to v0.23.7 ([#215])
+- Bump `prost` to v0.10 ([#215])
+- Bump `tonic` to v0.7 ([#215])
+- Bump `COSMOS_SDK_REV` from v0.45.2 => v0.45.4 ([#215])
+
+[#215]: https://github.com/cosmos/cosmos-rust/pull/215
+
 ## 0.11.0 (2022-04-21)
 ### Added
 - Missing modules from `ibc-go` ([#187])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.12.0-pre"
+version = "0.12.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -23,7 +23,7 @@ Pull requests to expand coverage are welcome.
 This crate is supported on Rust **1.56** or newer.
 
 [//]: # "badges"
-[crate-image]: https://img.shields.io/crates/v/cosmos-sdk-proto.svg?logo=rust
+[crate-image]: https://buildstats.info/crate/cosmos-sdk-proto
 [crate-link]: https://crates.io/crates/cosmos-sdk-proto
 [docs-image]: https://docs.rs/cosmos-sdk-proto/badge.svg
 [docs-link]: https://docs.rs/cosmos-sdk-proto/

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.12.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.12", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.13", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.10", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Bump tendermint-rs crates to v0.23.7 ([#215])
- Bump `prost` to v0.10 ([#215])
- Bump `tonic` to v0.7 ([#215])
- Bump `COSMOS_SDK_REV` from v0.45.2 => v0.45.4 ([#215])

[#215]: https://github.com/cosmos/cosmos-rust/pull/215