### PR TITLE
cosmrs v0.7.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2022-05-02)
+### Changed
+- Bump tendermint-rs crates to v0.23.7 ([#215])
+- Bump `prost` to v0.10 ([#215])
+- Bump `tonic` to v0.7 ([#215])
+- Bump `cosmos-sdk-proto` to v0.12.0 ([#217])
+
+[#215]: https://github.com/cosmos/cosmos-rust/pull/215
+[#217]: https://github.com/cosmos/cosmos-rust/pull/217
+
 ## 0.6.1 (2022-04-28)
 ### Fixed
 - Better error message on `AccountId` Bech32 decode failure ([#209])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump tendermint-rs crates to v0.23.7 ([#215])
- Bump `prost` to v0.10 ([#215])
- Bump `tonic` to v0.7 ([#215])
- Bump `cosmos-sdk-proto` to v0.12.0 ([#217])

[#215]: https://github.com/cosmos/cosmos-rust/pull/215
[#217]: https://github.com/cosmos/cosmos-rust/pull/217