### PR TITLE
cosmos-sdk-proto: yank v0.12.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#220]: https://github.com/cosmos/cosmos-rust/pull/220
 
-## 0.12.0 (2022-05-02)
+## 0.12.0 (2022-05-02) [YANKED]
+
+NOTE: this release was yanked due to the clashing namespace bug ([#220])
+
 ### Changed
 - Bump tendermint-rs crates to v0.23.7 ([#215])
 - Bump `prost` to v0.10 ([#215])


### PR DESCRIPTION
v0.12.1 fixes #219, which is a major bug. See #220.