### PR TITLE
cosmos-sdk-protos: add `grpc-transport` feature

### DIFF
--- a/.github/workflows/cosmos-sdk-proto.yml
+++ b/.github/workflows/cosmos-sdk-proto.yml
@@ -35,7 +35,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --target ${{ matrix.target }} --no-default-features --release
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features grpc
 
   test:
     runs-on: ubuntu-latest

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -21,11 +21,12 @@ prost-types = "0.10"
 tendermint-proto = "=0.23.7"
 
 # Optional dependencies
-tonic = { version = "0.7", optional = true }
+tonic = { version = "0.7", optional = true, default-features = false, features = ["codegen", "prost"] }
 
 [features]
-default = ["grpc"]
+default = ["grpc-transport"]
 grpc = ["tonic"]
+grpc-transport = ["grpc", "tonic/transport"]
 cosmwasm = []
 
 [package.metadata.docs.rs]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
@@ -93,6 +93,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
@@ -30,201 +30,6 @@ pub struct GrantAuthorization {
     #[prost(message, optional, tag="4")]
     pub expiration: ::core::option::Option<::prost_types::Timestamp>,
 }
-/// QueryGrantsRequest is the request type for the Query/Grants RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGrantsRequest {
-    #[prost(string, tag="1")]
-    pub granter: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub grantee: ::prost::alloc::string::String,
-    /// Optional, msg_type_url, when set, will query only grants matching given msg type.
-    #[prost(string, tag="3")]
-    pub msg_type_url: ::prost::alloc::string::String,
-    /// pagination defines an pagination for the request.
-    #[prost(message, optional, tag="4")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
-}
-/// QueryGrantsResponse is the response type for the Query/Authorizations RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGrantsResponse {
-    /// authorizations is a list of grants granted for grantee by granter.
-    #[prost(message, repeated, tag="1")]
-    pub grants: ::prost::alloc::vec::Vec<Grant>,
-    /// pagination defines an pagination for the response.
-    #[prost(message, optional, tag="2")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
-}
-/// QueryGranterGrantsRequest is the request type for the Query/GranterGrants RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGranterGrantsRequest {
-    #[prost(string, tag="1")]
-    pub granter: ::prost::alloc::string::String,
-    /// pagination defines an pagination for the request.
-    #[prost(message, optional, tag="2")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
-}
-/// QueryGranterGrantsResponse is the response type for the Query/GranterGrants RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGranterGrantsResponse {
-    /// grants is a list of grants granted by the granter.
-    #[prost(message, repeated, tag="1")]
-    pub grants: ::prost::alloc::vec::Vec<GrantAuthorization>,
-    /// pagination defines an pagination for the response.
-    #[prost(message, optional, tag="2")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
-}
-/// QueryGranteeGrantsRequest is the request type for the Query/IssuedGrants RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGranteeGrantsRequest {
-    #[prost(string, tag="1")]
-    pub grantee: ::prost::alloc::string::String,
-    /// pagination defines an pagination for the request.
-    #[prost(message, optional, tag="2")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
-}
-/// QueryGranteeGrantsResponse is the response type for the Query/GranteeGrants RPC method.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryGranteeGrantsResponse {
-    /// grants is a list of grants granted to the grantee.
-    #[prost(message, repeated, tag="1")]
-    pub grants: ::prost::alloc::vec::Vec<GrantAuthorization>,
-    /// pagination defines an pagination for the response.
-    #[prost(message, optional, tag="2")]
-    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod query_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Query defines the gRPC querier service.
-    #[derive(Debug, Clone)]
-    pub struct QueryClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl QueryClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> QueryClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> QueryClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            QueryClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// Returns list of `Authorization`, granted to the grantee by the granter.
-        pub async fn grants(
-            &mut self,
-            request: impl tonic::IntoRequest<super::QueryGrantsRequest>,
-        ) -> Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.authz.v1beta1.Query/Grants",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// GranterGrants returns list of `GrantAuthorization`, granted by granter.
-        ///
-        /// Since: cosmos-sdk 0.45.2
-        pub async fn granter_grants(
-            &mut self,
-            request: impl tonic::IntoRequest<super::QueryGranterGrantsRequest>,
-        ) -> Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.authz.v1beta1.Query/GranterGrants",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// GranteeGrants returns a list of `GrantAuthorization` by grantee.
-        ///
-        /// Since: cosmos-sdk 0.45.2
-        pub async fn grantee_grants(
-            &mut self,
-            request: impl tonic::IntoRequest<super::QueryGranteeGrantsRequest>,
-        ) -> Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.authz.v1beta1.Query/GranteeGrants",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
 /// MsgGrant is a request type for Grant method. It declares authorization to the grantee
 /// on behalf of the granter with the provided expiration time.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -285,6 +90,8 @@ pub mod msg_client {
     pub struct MsgClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl MsgClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -409,11 +216,202 @@ pub mod msg_client {
         }
     }
 }
-/// GenesisState defines the authz module's genesis state.
+/// QueryGrantsRequest is the request type for the Query/Grants RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GenesisState {
+pub struct QueryGrantsRequest {
+    #[prost(string, tag="1")]
+    pub granter: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub grantee: ::prost::alloc::string::String,
+    /// Optional, msg_type_url, when set, will query only grants matching given msg type.
+    #[prost(string, tag="3")]
+    pub msg_type_url: ::prost::alloc::string::String,
+    /// pagination defines an pagination for the request.
+    #[prost(message, optional, tag="4")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryGrantsResponse is the response type for the Query/Authorizations RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryGrantsResponse {
+    /// authorizations is a list of grants granted for grantee by granter.
     #[prost(message, repeated, tag="1")]
-    pub authorization: ::prost::alloc::vec::Vec<GrantAuthorization>,
+    pub grants: ::prost::alloc::vec::Vec<Grant>,
+    /// pagination defines an pagination for the response.
+    #[prost(message, optional, tag="2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryGranterGrantsRequest is the request type for the Query/GranterGrants RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryGranterGrantsRequest {
+    #[prost(string, tag="1")]
+    pub granter: ::prost::alloc::string::String,
+    /// pagination defines an pagination for the request.
+    #[prost(message, optional, tag="2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryGranterGrantsResponse is the response type for the Query/GranterGrants RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryGranterGrantsResponse {
+    /// grants is a list of grants granted by the granter.
+    #[prost(message, repeated, tag="1")]
+    pub grants: ::prost::alloc::vec::Vec<GrantAuthorization>,
+    /// pagination defines an pagination for the response.
+    #[prost(message, optional, tag="2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryGranteeGrantsRequest is the request type for the Query/IssuedGrants RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryGranteeGrantsRequest {
+    #[prost(string, tag="1")]
+    pub grantee: ::prost::alloc::string::String,
+    /// pagination defines an pagination for the request.
+    #[prost(message, optional, tag="2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryGranteeGrantsResponse is the response type for the Query/GranteeGrants RPC method.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryGranteeGrantsResponse {
+    /// grants is a list of grants granted to the grantee.
+    #[prost(message, repeated, tag="1")]
+    pub grants: ::prost::alloc::vec::Vec<GrantAuthorization>,
+    /// pagination defines an pagination for the response.
+    #[prost(message, optional, tag="2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Query defines the gRPC querier service.
+    #[derive(Debug, Clone)]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl QueryClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QueryClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            QueryClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// Returns list of `Authorization`, granted to the grantee by the granter.
+        pub async fn grants(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryGrantsRequest>,
+        ) -> Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.authz.v1beta1.Query/Grants",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// GranterGrants returns list of `GrantAuthorization`, granted by granter.
+        ///
+        /// Since: cosmos-sdk 0.45.2
+        pub async fn granter_grants(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryGranterGrantsRequest>,
+        ) -> Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.authz.v1beta1.Query/GranterGrants",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// GranteeGrants returns a list of `GrantAuthorization` by grantee.
+        ///
+        /// Since: cosmos-sdk 0.45.2
+        pub async fn grantee_grants(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryGranteeGrantsRequest>,
+        ) -> Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.authz.v1beta1.Query/GranteeGrants",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
 }
 /// EventGrant is emitted on Msg/Grant
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -440,4 +438,10 @@ pub struct EventRevoke {
     /// Grantee account address
     #[prost(string, tag="4")]
     pub grantee: ::prost::alloc::string::String,
+}
+/// GenesisState defines the authz module's genesis state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisState {
+    #[prost(message, repeated, tag="1")]
+    pub authorization: ::prost::alloc::vec::Vec<GrantAuthorization>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
@@ -1,12 +1,3 @@
-/// SendAuthorization allows the grantee to spend up to spend_limit coins from
-/// the granter's account.
-///
-/// Since: cosmos-sdk 0.43
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SendAuthorization {
-    #[prost(message, repeated, tag="1")]
-    pub spend_limit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-}
 /// Params defines the parameters for the bank module.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
@@ -93,6 +84,143 @@ pub struct Metadata {
     /// Since: cosmos-sdk 0.43
     #[prost(string, tag="6")]
     pub symbol: ::prost::alloc::string::String,
+}
+/// MsgSend represents a message to send coins from one account to another.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSend {
+    #[prost(string, tag="1")]
+    pub from_address: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub to_address: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag="3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgSendResponse defines the Msg/Send response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSendResponse {
+}
+/// MsgMultiSend represents an arbitrary multi-in, multi-out send message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgMultiSend {
+    #[prost(message, repeated, tag="1")]
+    pub inputs: ::prost::alloc::vec::Vec<Input>,
+    #[prost(message, repeated, tag="2")]
+    pub outputs: ::prost::alloc::vec::Vec<Output>,
+}
+/// MsgMultiSendResponse defines the Msg/MultiSend response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgMultiSendResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the bank Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// Send defines a method for sending coins from one account to another account.
+        pub async fn send(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSend>,
+        ) -> Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.bank.v1beta1.Msg/Send",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// MultiSend defines a method for sending coins from some accounts to other accounts.
+        pub async fn multi_send(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgMultiSend>,
+        ) -> Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.bank.v1beta1.Msg/MultiSend",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
 }
 /// QueryBalanceRequest is the request type for the Query/Balance RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -245,6 +373,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -467,140 +597,14 @@ pub mod query_client {
         }
     }
 }
-/// MsgSend represents a message to send coins from one account to another.
+/// SendAuthorization allows the grantee to spend up to spend_limit coins from
+/// the granter's account.
+///
+/// Since: cosmos-sdk 0.43
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSend {
-    #[prost(string, tag="1")]
-    pub from_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub to_address: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="3")]
-    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-}
-/// MsgSendResponse defines the Msg/Send response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSendResponse {
-}
-/// MsgMultiSend represents an arbitrary multi-in, multi-out send message.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgMultiSend {
+pub struct SendAuthorization {
     #[prost(message, repeated, tag="1")]
-    pub inputs: ::prost::alloc::vec::Vec<Input>,
-    #[prost(message, repeated, tag="2")]
-    pub outputs: ::prost::alloc::vec::Vec<Output>,
-}
-/// MsgMultiSendResponse defines the Msg/MultiSend response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgMultiSendResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the bank Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// Send defines a method for sending coins from one account to another account.
-        pub async fn send(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgSend>,
-        ) -> Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.bank.v1beta1.Msg/Send",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// MultiSend defines a method for sending coins from some accounts to other accounts.
-        pub async fn multi_send(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgMultiSend>,
-        ) -> Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.bank.v1beta1.Msg/MultiSend",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
+    pub spend_limit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
 /// GenesisState defines the bank module's genesis state.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.rs
@@ -35,6 +35,8 @@ pub mod reflection_service_client {
     pub struct ReflectionServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl ReflectionServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.rs
@@ -237,6 +237,8 @@ pub mod reflection_service_client {
     pub struct ReflectionServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl ReflectionServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
@@ -141,6 +141,8 @@ pub mod service_client {
     pub struct ServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl ServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
@@ -23,6 +23,8 @@ pub mod msg_client {
     pub struct MsgClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl MsgClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
@@ -1,3 +1,220 @@
+/// MsgSetWithdrawAddress sets the withdraw address for
+/// a delegator (or validator self-delegation).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetWithdrawAddress {
+    #[prost(string, tag="1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub withdraw_address: ::prost::alloc::string::String,
+}
+/// MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetWithdrawAddressResponse {
+}
+/// MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
+/// from a single validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawDelegatorReward {
+    #[prost(string, tag="1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawDelegatorRewardResponse {
+}
+/// MsgWithdrawValidatorCommission withdraws the full commission to the validator
+/// address.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawValidatorCommission {
+    #[prost(string, tag="1")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgWithdrawValidatorCommissionResponse {
+}
+/// MsgFundCommunityPool allows an account to directly
+/// fund the community pool.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgFundCommunityPool {
+    #[prost(message, repeated, tag="1")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(string, tag="2")]
+    pub depositor: ::prost::alloc::string::String,
+}
+/// MsgFundCommunityPoolResponse defines the Msg/FundCommunityPool response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgFundCommunityPoolResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the distribution Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// SetWithdrawAddress defines a method to change the withdraw address
+        /// for a delegator (or validator self-delegation).
+        pub async fn set_withdraw_address(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSetWithdrawAddress>,
+        ) -> Result<
+                tonic::Response<super::MsgSetWithdrawAddressResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/SetWithdrawAddress",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// WithdrawDelegatorReward defines a method to withdraw rewards of delegator
+        /// from a single validator.
+        pub async fn withdraw_delegator_reward(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgWithdrawDelegatorReward>,
+        ) -> Result<
+                tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/WithdrawDelegatorReward",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// WithdrawValidatorCommission defines a method to withdraw the
+        /// full commission to the validator address.
+        pub async fn withdraw_validator_commission(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgWithdrawValidatorCommission>,
+        ) -> Result<
+                tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/WithdrawValidatorCommission",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// FundCommunityPool defines a method to allow an account to directly
+        /// fund the community pool.
+        pub async fn fund_community_pool(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgFundCommunityPool>,
+        ) -> Result<
+                tonic::Response<super::MsgFundCommunityPoolResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/FundCommunityPool",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// Params defines the set of params for the distribution module.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
@@ -293,6 +510,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -550,221 +769,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.distribution.v1beta1.Query/CommunityPool",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgSetWithdrawAddress sets the withdraw address for
-/// a delegator (or validator self-delegation).
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSetWithdrawAddress {
-    #[prost(string, tag="1")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub withdraw_address: ::prost::alloc::string::String,
-}
-/// MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSetWithdrawAddressResponse {
-}
-/// MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
-/// from a single validator.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgWithdrawDelegatorReward {
-    #[prost(string, tag="1")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub validator_address: ::prost::alloc::string::String,
-}
-/// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgWithdrawDelegatorRewardResponse {
-}
-/// MsgWithdrawValidatorCommission withdraws the full commission to the validator
-/// address.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgWithdrawValidatorCommission {
-    #[prost(string, tag="1")]
-    pub validator_address: ::prost::alloc::string::String,
-}
-/// MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgWithdrawValidatorCommissionResponse {
-}
-/// MsgFundCommunityPool allows an account to directly
-/// fund the community pool.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgFundCommunityPool {
-    #[prost(message, repeated, tag="1")]
-    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    #[prost(string, tag="2")]
-    pub depositor: ::prost::alloc::string::String,
-}
-/// MsgFundCommunityPoolResponse defines the Msg/FundCommunityPool response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgFundCommunityPoolResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the distribution Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// SetWithdrawAddress defines a method to change the withdraw address
-        /// for a delegator (or validator self-delegation).
-        pub async fn set_withdraw_address(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgSetWithdrawAddress>,
-        ) -> Result<
-                tonic::Response<super::MsgSetWithdrawAddressResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.distribution.v1beta1.Msg/SetWithdrawAddress",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// WithdrawDelegatorReward defines a method to withdraw rewards of delegator
-        /// from a single validator.
-        pub async fn withdraw_delegator_reward(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgWithdrawDelegatorReward>,
-        ) -> Result<
-                tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.distribution.v1beta1.Msg/WithdrawDelegatorReward",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// WithdrawValidatorCommission defines a method to withdraw the
-        /// full commission to the validator address.
-        pub async fn withdraw_validator_commission(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgWithdrawValidatorCommission>,
-        ) -> Result<
-                tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.distribution.v1beta1.Msg/WithdrawValidatorCommission",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// FundCommunityPool defines a method to allow an account to directly
-        /// fund the community pool.
-        pub async fn fund_community_pool(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgFundCommunityPool>,
-        ) -> Result<
-                tonic::Response<super::MsgFundCommunityPoolResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.distribution.v1beta1.Msg/FundCommunityPool",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
@@ -1,3 +1,111 @@
+/// MsgSubmitEvidence represents a message that supports submitting arbitrary
+/// Evidence of misbehavior such as equivocation or counterfactual signing.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitEvidence {
+    #[prost(string, tag="1")]
+    pub submitter: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub evidence: ::core::option::Option<::prost_types::Any>,
+}
+/// MsgSubmitEvidenceResponse defines the Msg/SubmitEvidence response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitEvidenceResponse {
+    /// hash defines the hash of the evidence.
+    #[prost(bytes="vec", tag="4")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the evidence Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// SubmitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or
+        /// counterfactual signing.
+        pub async fn submit_evidence(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSubmitEvidence>,
+        ) -> Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.evidence.v1beta1.Msg/SubmitEvidence",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// Equivocation implements the Evidence interface and defines evidence of double
 /// signing misbehavior.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -55,6 +163,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -148,112 +258,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.evidence.v1beta1.Query/AllEvidence",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgSubmitEvidence represents a message that supports submitting arbitrary
-/// Evidence of misbehavior such as equivocation or counterfactual signing.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitEvidence {
-    #[prost(string, tag="1")]
-    pub submitter: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub evidence: ::core::option::Option<::prost_types::Any>,
-}
-/// MsgSubmitEvidenceResponse defines the Msg/SubmitEvidence response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitEvidenceResponse {
-    /// hash defines the hash of the evidence.
-    #[prost(bytes="vec", tag="4")]
-    pub hash: ::prost::alloc::vec::Vec<u8>,
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the evidence Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// SubmitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or
-        /// counterfactual signing.
-        pub async fn submit_evidence(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgSubmitEvidence>,
-        ) -> Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.evidence.v1beta1.Msg/SubmitEvidence",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.rs
@@ -1,3 +1,148 @@
+/// MsgGrantAllowance adds permission for Grantee to spend up to Allowance
+/// of fees from the account of Granter.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgGrantAllowance {
+    /// granter is the address of the user granting an allowance of their funds.
+    #[prost(string, tag="1")]
+    pub granter: ::prost::alloc::string::String,
+    /// grantee is the address of the user being granted an allowance of another user's funds.
+    #[prost(string, tag="2")]
+    pub grantee: ::prost::alloc::string::String,
+    /// allowance can be any of basic and filtered fee allowance.
+    #[prost(message, optional, tag="3")]
+    pub allowance: ::core::option::Option<::prost_types::Any>,
+}
+/// MsgGrantAllowanceResponse defines the Msg/GrantAllowanceResponse response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgGrantAllowanceResponse {
+}
+/// MsgRevokeAllowance removes any existing Allowance from Granter to Grantee.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgRevokeAllowance {
+    /// granter is the address of the user granting an allowance of their funds.
+    #[prost(string, tag="1")]
+    pub granter: ::prost::alloc::string::String,
+    /// grantee is the address of the user being granted an allowance of another user's funds.
+    #[prost(string, tag="2")]
+    pub grantee: ::prost::alloc::string::String,
+}
+/// MsgRevokeAllowanceResponse defines the Msg/RevokeAllowanceResponse response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgRevokeAllowanceResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the feegrant msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// GrantAllowance grants fee allowance to the grantee on the granter's
+        /// account with the provided expiration time.
+        pub async fn grant_allowance(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgGrantAllowance>,
+        ) -> Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.feegrant.v1beta1.Msg/GrantAllowance",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// RevokeAllowance revokes any fee allowance of granter's account that
+        /// has been granted to the grantee.
+        pub async fn revoke_allowance(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgRevokeAllowance>,
+        ) -> Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.feegrant.v1beta1.Msg/RevokeAllowance",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// BasicAllowance implements Allowance with a one-time grant of tokens
 /// that optionally expires. The grantee can use up to SpendLimit to cover fees.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -105,6 +250,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -198,149 +345,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.feegrant.v1beta1.Query/Allowances",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgGrantAllowance adds permission for Grantee to spend up to Allowance
-/// of fees from the account of Granter.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgGrantAllowance {
-    /// granter is the address of the user granting an allowance of their funds.
-    #[prost(string, tag="1")]
-    pub granter: ::prost::alloc::string::String,
-    /// grantee is the address of the user being granted an allowance of another user's funds.
-    #[prost(string, tag="2")]
-    pub grantee: ::prost::alloc::string::String,
-    /// allowance can be any of basic and filtered fee allowance.
-    #[prost(message, optional, tag="3")]
-    pub allowance: ::core::option::Option<::prost_types::Any>,
-}
-/// MsgGrantAllowanceResponse defines the Msg/GrantAllowanceResponse response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgGrantAllowanceResponse {
-}
-/// MsgRevokeAllowance removes any existing Allowance from Granter to Grantee.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgRevokeAllowance {
-    /// granter is the address of the user granting an allowance of their funds.
-    #[prost(string, tag="1")]
-    pub granter: ::prost::alloc::string::String,
-    /// grantee is the address of the user being granted an allowance of another user's funds.
-    #[prost(string, tag="2")]
-    pub grantee: ::prost::alloc::string::String,
-}
-/// MsgRevokeAllowanceResponse defines the Msg/RevokeAllowanceResponse response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgRevokeAllowanceResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the feegrant msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// GrantAllowance grants fee allowance to the grantee on the granter's
-        /// account with the provided expiration time.
-        pub async fn grant_allowance(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgGrantAllowance>,
-        ) -> Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.feegrant.v1beta1.Msg/GrantAllowance",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// RevokeAllowance revokes any fee allowance of granter's account that
-        /// has been granted to the grantee.
-        pub async fn revoke_allowance(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgRevokeAllowance>,
-        ) -> Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.feegrant.v1beta1.Msg/RevokeAllowance",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
@@ -150,6 +150,222 @@ pub enum ProposalStatus {
     /// failed.
     Failed = 5,
 }
+/// MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
+/// proposal Content.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitProposal {
+    #[prost(message, optional, tag="1")]
+    pub content: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, repeated, tag="2")]
+    pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(string, tag="3")]
+    pub proposer: ::prost::alloc::string::String,
+}
+/// MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitProposalResponse {
+    #[prost(uint64, tag="1")]
+    pub proposal_id: u64,
+}
+/// MsgVote defines a message to cast a vote.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVote {
+    #[prost(uint64, tag="1")]
+    pub proposal_id: u64,
+    #[prost(string, tag="2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(enumeration="VoteOption", tag="3")]
+    pub option: i32,
+}
+/// MsgVoteResponse defines the Msg/Vote response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVoteResponse {
+}
+/// MsgVoteWeighted defines a message to cast a vote.
+///
+/// Since: cosmos-sdk 0.43
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVoteWeighted {
+    #[prost(uint64, tag="1")]
+    pub proposal_id: u64,
+    #[prost(string, tag="2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
+}
+/// MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
+///
+/// Since: cosmos-sdk 0.43
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgVoteWeightedResponse {
+}
+/// MsgDeposit defines a message to submit a deposit to an existing proposal.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDeposit {
+    #[prost(uint64, tag="1")]
+    pub proposal_id: u64,
+    #[prost(string, tag="2")]
+    pub depositor: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag="3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgDepositResponse defines the Msg/Deposit response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDepositResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the bank Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// SubmitProposal defines a method to create new proposal given a content.
+        pub async fn submit_proposal(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
+        ) -> Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.gov.v1beta1.Msg/SubmitProposal",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Vote defines a method to add a vote on a specific proposal.
+        pub async fn vote(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgVote>,
+        ) -> Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.gov.v1beta1.Msg/Vote",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// VoteWeighted defines a method to add a weighted vote on a specific proposal.
+        ///
+        /// Since: cosmos-sdk 0.43
+        pub async fn vote_weighted(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgVoteWeighted>,
+        ) -> Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.gov.v1beta1.Msg/VoteWeighted",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Deposit defines a method to add deposit on a specific proposal.
+        pub async fn deposit(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgDeposit>,
+        ) -> Result<tonic::Response<super::MsgDepositResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.gov.v1beta1.Msg/Deposit",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// QueryProposalRequest is the request type for the Query/Proposal RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryProposalRequest {
@@ -308,6 +524,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -521,220 +739,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.gov.v1beta1.Query/TallyResult",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
-/// proposal Content.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitProposal {
-    #[prost(message, optional, tag="1")]
-    pub content: ::core::option::Option<::prost_types::Any>,
-    #[prost(message, repeated, tag="2")]
-    pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    #[prost(string, tag="3")]
-    pub proposer: ::prost::alloc::string::String,
-}
-/// MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitProposalResponse {
-    #[prost(uint64, tag="1")]
-    pub proposal_id: u64,
-}
-/// MsgVote defines a message to cast a vote.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgVote {
-    #[prost(uint64, tag="1")]
-    pub proposal_id: u64,
-    #[prost(string, tag="2")]
-    pub voter: ::prost::alloc::string::String,
-    #[prost(enumeration="VoteOption", tag="3")]
-    pub option: i32,
-}
-/// MsgVoteResponse defines the Msg/Vote response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgVoteResponse {
-}
-/// MsgVoteWeighted defines a message to cast a vote.
-///
-/// Since: cosmos-sdk 0.43
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgVoteWeighted {
-    #[prost(uint64, tag="1")]
-    pub proposal_id: u64,
-    #[prost(string, tag="2")]
-    pub voter: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="3")]
-    pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
-}
-/// MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
-///
-/// Since: cosmos-sdk 0.43
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgVoteWeightedResponse {
-}
-/// MsgDeposit defines a message to submit a deposit to an existing proposal.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgDeposit {
-    #[prost(uint64, tag="1")]
-    pub proposal_id: u64,
-    #[prost(string, tag="2")]
-    pub depositor: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="3")]
-    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-}
-/// MsgDepositResponse defines the Msg/Deposit response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgDepositResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the bank Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// SubmitProposal defines a method to create new proposal given a content.
-        pub async fn submit_proposal(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
-        ) -> Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.gov.v1beta1.Msg/SubmitProposal",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Vote defines a method to add a vote on a specific proposal.
-        pub async fn vote(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgVote>,
-        ) -> Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.gov.v1beta1.Msg/Vote",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// VoteWeighted defines a method to add a weighted vote on a specific proposal.
-        ///
-        /// Since: cosmos-sdk 0.43
-        pub async fn vote_weighted(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgVoteWeighted>,
-        ) -> Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.gov.v1beta1.Msg/VoteWeighted",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Deposit defines a method to add deposit on a specific proposal.
-        pub async fn deposit(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgDeposit>,
-        ) -> Result<tonic::Response<super::MsgDepositResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.gov.v1beta1.Msg/Deposit",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
@@ -77,6 +77,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.rs
@@ -47,6 +47,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
@@ -1,3 +1,106 @@
+/// MsgUnjail defines the Msg/Unjail request type
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUnjail {
+    #[prost(string, tag="1")]
+    pub validator_addr: ::prost::alloc::string::String,
+}
+/// MsgUnjailResponse defines the Msg/Unjail response type
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUnjailResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the slashing Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// Unjail defines a method for unjailing a jailed validator, thus returning
+        /// them into the bonded validator set, so they can begin receiving provisions
+        /// and rewards again.
+        pub async fn unjail(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUnjail>,
+        ) -> Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.slashing.v1beta1.Msg/Unjail",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// ValidatorSigningInfo defines a validator's signing info for monitoring their
 /// liveness activity.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -92,6 +195,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -205,107 +310,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.slashing.v1beta1.Query/SigningInfos",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgUnjail defines the Msg/Unjail request type
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUnjail {
-    #[prost(string, tag="1")]
-    pub validator_addr: ::prost::alloc::string::String,
-}
-/// MsgUnjailResponse defines the Msg/Unjail response type
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUnjailResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the slashing Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// Unjail defines a method for unjailing a jailed validator, thus returning
-        /// them into the bonded validator set, so they can begin receiving provisions
-        /// and rewards again.
-        pub async fn unjail(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgUnjail>,
-        ) -> Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.slashing.v1beta1.Msg/Unjail",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
@@ -4,9 +4,9 @@
 /// (`n` is set by the staking module's `historical_entries` parameter).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistoricalInfo {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<::tendermint_proto::types::Header>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub valset: ::prost::alloc::vec::Vec<Validator>,
 }
 /// CommissionRates defines the initial commission rates to be used for creating
@@ -14,42 +14,42 @@ pub struct HistoricalInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRates {
     /// rate is the commission rate charged to delegators, as a fraction.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub rate: ::prost::alloc::string::String,
     /// max_rate defines the maximum commission rate which validator can ever charge, as a fraction.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub max_rate: ::prost::alloc::string::String,
     /// max_change_rate defines the maximum daily increase of the validator commission, as a fraction.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub max_change_rate: ::prost::alloc::string::String,
 }
 /// Commission defines commission parameters for a given validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commission {
     /// commission_rates defines the initial commission rates to be used for creating a validator.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub commission_rates: ::core::option::Option<CommissionRates>,
     /// update_time is the last time the commission rate was changed.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub update_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// Description defines a validator description.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Description {
     /// moniker defines a human-readable name for the validator.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub moniker: ::prost::alloc::string::String,
     /// identity defines an optional identity signature (ex. UPort or Keybase).
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub identity: ::prost::alloc::string::String,
     /// website defines an optional website link.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub website: ::prost::alloc::string::String,
     /// security_contact defines an optional email for security contact.
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub security_contact: ::prost::alloc::string::String,
     /// details define other optional details.
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub details: ::prost::alloc::string::String,
 }
 /// Validator defines a validator, together with the total amount of the
@@ -63,43 +63,43 @@ pub struct Description {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Validator {
     /// operator_address defines the address of the validator's operator; bech encoded in JSON.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub operator_address: ::prost::alloc::string::String,
     /// consensus_pubkey is the consensus public key of the validator, as a Protobuf Any.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub consensus_pubkey: ::core::option::Option<::prost_types::Any>,
     /// jailed defined whether the validator has been jailed from bonded status or not.
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub jailed: bool,
     /// status is the validator status (bonded/unbonding/unbonded).
-    #[prost(enumeration="BondStatus", tag="4")]
+    #[prost(enumeration = "BondStatus", tag = "4")]
     pub status: i32,
     /// tokens define the delegated tokens (incl. self-delegation).
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub tokens: ::prost::alloc::string::String,
     /// delegator_shares defines total shares issued to a validator's delegators.
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub delegator_shares: ::prost::alloc::string::String,
     /// description defines the description terms for the validator.
-    #[prost(message, optional, tag="7")]
+    #[prost(message, optional, tag = "7")]
     pub description: ::core::option::Option<Description>,
     /// unbonding_height defines, if unbonding, the height at which this validator has begun unbonding.
-    #[prost(int64, tag="8")]
+    #[prost(int64, tag = "8")]
     pub unbonding_height: i64,
     /// unbonding_time defines, if unbonding, the min time for the validator to complete unbonding.
-    #[prost(message, optional, tag="9")]
+    #[prost(message, optional, tag = "9")]
     pub unbonding_time: ::core::option::Option<::prost_types::Timestamp>,
     /// commission defines the commission parameters.
-    #[prost(message, optional, tag="10")]
+    #[prost(message, optional, tag = "10")]
     pub commission: ::core::option::Option<Commission>,
     /// min_self_delegation is the validator's self declared minimum self delegation.
-    #[prost(string, tag="11")]
+    #[prost(string, tag = "11")]
     pub min_self_delegation: ::prost::alloc::string::String,
 }
 /// ValAddresses defines a repeated set of validator addresses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValAddresses {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// DVPair is struct that just has a delegator-validator pair with no other data.
@@ -107,15 +107,15 @@ pub struct ValAddresses {
 /// be used to construct the key to getting an UnbondingDelegation from state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvPair {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_address: ::prost::alloc::string::String,
 }
 /// DVPairs defines an array of DVPair objects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvPairs {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub pairs: ::prost::alloc::vec::Vec<DvPair>,
 }
 /// DVVTriplet is struct that just has a delegator-validator-validator triplet
@@ -124,17 +124,17 @@ pub struct DvPairs {
 /// Redelegation from state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvvTriplet {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_src_address: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub validator_dst_address: ::prost::alloc::string::String,
 }
 /// DVVTriplets defines an array of DVVTriplet objects.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DvvTriplets {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub triplets: ::prost::alloc::vec::Vec<DvvTriplet>,
 }
 /// Delegation represents the bond with tokens held by an account. It is
@@ -143,13 +143,13 @@ pub struct DvvTriplets {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Delegation {
     /// delegator_address is the bech32-encoded address of the delegator.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_address: ::prost::alloc::string::String,
     /// validator_address is the bech32-encoded address of the validator.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_address: ::prost::alloc::string::String,
     /// shares define the delegation shares received.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub shares: ::prost::alloc::string::String,
 }
 /// UnbondingDelegation stores all of a single delegator's unbonding bonds
@@ -157,47 +157,47 @@ pub struct Delegation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnbondingDelegation {
     /// delegator_address is the bech32-encoded address of the delegator.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_address: ::prost::alloc::string::String,
     /// validator_address is the bech32-encoded address of the validator.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_address: ::prost::alloc::string::String,
     /// entries are the unbonding delegation entries.
     ///
     /// unbonding delegation entries
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub entries: ::prost::alloc::vec::Vec<UnbondingDelegationEntry>,
 }
 /// UnbondingDelegationEntry defines an unbonding object with relevant metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnbondingDelegationEntry {
     /// creation_height is the height which the unbonding took place.
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub creation_height: i64,
     /// completion_time is the unix time for unbonding completion.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
     /// initial_balance defines the tokens initially scheduled to receive at completion.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub initial_balance: ::prost::alloc::string::String,
     /// balance defines the tokens to receive at completion.
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub balance: ::prost::alloc::string::String,
 }
 /// RedelegationEntry defines a redelegation object with relevant metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RedelegationEntry {
     /// creation_height  defines the height which the redelegation took place.
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub creation_height: i64,
     /// completion_time defines the unix time for redelegation completion.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
     /// initial_balance defines the initial balance when redelegation started.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub initial_balance: ::prost::alloc::string::String,
     /// shares_dst is the amount of destination-validator shares created by redelegation.
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub shares_dst: ::prost::alloc::string::String,
 }
 /// Redelegation contains the list of a particular delegator's redelegating bonds
@@ -205,46 +205,46 @@ pub struct RedelegationEntry {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Redelegation {
     /// delegator_address is the bech32-encoded address of the delegator.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_address: ::prost::alloc::string::String,
     /// validator_src_address is the validator redelegation source operator address.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_src_address: ::prost::alloc::string::String,
     /// validator_dst_address is the validator redelegation destination operator address.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub validator_dst_address: ::prost::alloc::string::String,
     /// entries are the redelegation entries.
     ///
     /// redelegation entries
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub entries: ::prost::alloc::vec::Vec<RedelegationEntry>,
 }
 /// Params defines the parameters for the staking module.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
     /// unbonding_time is the time duration of unbonding.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub unbonding_time: ::core::option::Option<::prost_types::Duration>,
     /// max_validators is the maximum number of validators.
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub max_validators: u32,
     /// max_entries is the max entries for either unbonding delegation or redelegation (per pair/trio).
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub max_entries: u32,
     /// historical_entries is the number of historical entries to persist.
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub historical_entries: u32,
     /// bond_denom defines the bondable coin denomination.
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub bond_denom: ::prost::alloc::string::String,
 }
 /// DelegationResponse is equivalent to Delegation except that it contains a
 /// balance in addition to shares which is more suitable for client responses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub delegation: ::core::option::Option<Delegation>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub balance: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
 /// RedelegationEntryResponse is equivalent to a RedelegationEntry except that it
@@ -252,9 +252,9 @@ pub struct DelegationResponse {
 /// responses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RedelegationEntryResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub redelegation_entry: ::core::option::Option<RedelegationEntry>,
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub balance: ::prost::alloc::string::String,
 }
 /// RedelegationResponse is equivalent to a Redelegation except that its entries
@@ -262,18 +262,18 @@ pub struct RedelegationEntryResponse {
 /// responses.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RedelegationResponse {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub redelegation: ::core::option::Option<Redelegation>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub entries: ::prost::alloc::vec::Vec<RedelegationEntryResponse>,
 }
 /// Pool is used for tracking bonded and not-bonded token supply of the bond
 /// denomination.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Pool {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub not_bonded_tokens: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub bonded_tokens: ::prost::alloc::string::String,
 }
 /// BondStatus is the status of a validator.
@@ -289,89 +289,277 @@ pub enum BondStatus {
     /// BONDED defines a validator that is bonded.
     Bonded = 3,
 }
-/// StakeAuthorization defines authorization for delegate/undelegate/redelegate.
-///
-/// Since: cosmos-sdk 0.43
+/// MsgCreateValidator defines a SDK message for creating a new validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StakeAuthorization {
-    /// max_tokens specifies the maximum amount of tokens can be delegate to a validator. If it is
-    /// empty, there is no spend limit and any amount of coins can be delegated.
-    #[prost(message, optional, tag="1")]
-    pub max_tokens: ::core::option::Option<super::super::base::v1beta1::Coin>,
-    /// authorization_type defines one of AuthorizationType.
-    #[prost(enumeration="AuthorizationType", tag="4")]
-    pub authorization_type: i32,
-    /// validators is the oneof that represents either allow_list or deny_list
-    #[prost(oneof="stake_authorization::IsStakeAuthorizationValidators", tags="2, 3")]
-    pub validators: ::core::option::Option<stake_authorization::IsStakeAuthorizationValidators>,
+pub struct MsgCreateValidator {
+    #[prost(message, optional, tag = "1")]
+    pub description: ::core::option::Option<Description>,
+    #[prost(message, optional, tag = "2")]
+    pub commission: ::core::option::Option<CommissionRates>,
+    #[prost(string, tag = "3")]
+    pub min_self_delegation: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "6")]
+    pub pubkey: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, optional, tag = "7")]
+    pub value: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
-/// Nested message and enum types in `StakeAuthorization`.
-pub mod stake_authorization {
-    /// StakeAuthorizationValidators defines list of validator addresses.
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct StakeAuthorizationValidators {
-        #[prost(string, repeated, tag="1")]
-        pub address: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    }
-    /// IsStakeAuthorizationValidators is the oneof that represents either allow_list or deny_list
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum IsStakeAuthorizationValidators {
-        /// allow_list specifies list of validator addresses to whom grantee can delegate tokens on behalf of granter's
-        /// account.
-        #[prost(message, tag="2")]
-        AllowList(StakeAuthorizationValidators),
-        /// deny_list specifies list of validator addresses to whom grantee can not delegate tokens.
-        #[prost(message, tag="3")]
-        DenyList(StakeAuthorizationValidators),
-    }
+/// MsgCreateValidatorResponse defines the Msg/CreateValidator response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateValidatorResponse {}
+/// MsgEditValidator defines a SDK message for editing an existing validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgEditValidator {
+    #[prost(message, optional, tag = "1")]
+    pub description: ::core::option::Option<Description>,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    /// We pass a reference to the new commission rate and min self delegation as
+    /// it's not mandatory to update. If not updated, the deserialized rate will be
+    /// zero with no way to distinguish if an update was intended.
+    /// REF: #2373
+    #[prost(string, tag = "3")]
+    pub commission_rate: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub min_self_delegation: ::prost::alloc::string::String,
 }
-/// AuthorizationType defines the type of staking module authorization type
-///
-/// Since: cosmos-sdk 0.43
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum AuthorizationType {
-    /// AUTHORIZATION_TYPE_UNSPECIFIED specifies an unknown authorization type
-    Unspecified = 0,
-    /// AUTHORIZATION_TYPE_DELEGATE defines an authorization type for Msg/Delegate
-    Delegate = 1,
-    /// AUTHORIZATION_TYPE_UNDELEGATE defines an authorization type for Msg/Undelegate
-    Undelegate = 2,
-    /// AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for Msg/BeginRedelegate
-    Redelegate = 3,
+/// MsgEditValidatorResponse defines the Msg/EditValidator response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgEditValidatorResponse {}
+/// MsgDelegate defines a SDK message for performing a delegation of coins
+/// from a delegator to a validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgDelegateResponse defines the Msg/Delegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgDelegateResponse {}
+/// MsgBeginRedelegate defines a SDK message for performing a redelegation
+/// of coins from a delegator and source validator to a destination validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgBeginRedelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_src_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub validator_dst_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "4")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgBeginRedelegateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// MsgUndelegate defines a SDK message for performing an undelegation from a
+/// delegate and a validator.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUndelegate {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgUndelegateResponse defines the Msg/Undelegate response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUndelegateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the staking Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// CreateValidator defines a method for creating a new validator.
+        pub async fn create_validator(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgCreateValidator>,
+        ) -> Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/CreateValidator");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// EditValidator defines a method for editing an existing validator.
+        pub async fn edit_validator(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgEditValidator>,
+        ) -> Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/EditValidator");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Delegate defines a method for performing a delegation of coins
+        /// from a delegator to a validator.
+        pub async fn delegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgDelegate>,
+        ) -> Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/Delegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// BeginRedelegate defines a method for performing a redelegation
+        /// of coins from a delegator and source validator to a destination validator.
+        pub async fn begin_redelegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgBeginRedelegate>,
+        ) -> Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/BeginRedelegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Undelegate defines a method for performing an undelegation from a
+        /// delegate and a validator.
+        pub async fn undelegate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUndelegate>,
+        ) -> Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/Undelegate");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
 }
 /// QueryValidatorsRequest is request type for Query/Validators RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorsRequest {
     /// status enables to query for validators matching a given status.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub status: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorsResponse is response type for the Query/Validators RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorsResponse {
     /// validators contains all the queried validators.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryValidatorRequest is response type for the Query/Validator RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorRequest {
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryValidatorResponse is response type for the Query/Validator RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorResponse {
     /// validator defines the the validator info.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub validator: ::core::option::Option<Validator>,
 }
 /// QueryValidatorDelegationsRequest is request type for the
@@ -379,20 +567,20 @@ pub struct QueryValidatorResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorDelegationsRequest {
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorDelegationsResponse is response type for the
 /// Query/ValidatorDelegations RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorDelegationsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub delegation_responses: ::prost::alloc::vec::Vec<DelegationResponse>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryValidatorUnbondingDelegationsRequest is required type for the
@@ -400,37 +588,37 @@ pub struct QueryValidatorDelegationsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorUnbondingDelegationsRequest {
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryValidatorUnbondingDelegationsResponse is response type for the
 /// Query/ValidatorUnbondingDelegations RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorUnbondingDelegationsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub unbonding_responses: ::prost::alloc::vec::Vec<UnbondingDelegation>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegationRequest is request type for the Query/Delegation RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegationRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegationResponse is response type for the Query/Delegation RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegationResponse {
     /// delegation_responses defines the delegation info of a delegation.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub delegation_response: ::core::option::Option<DelegationResponse>,
 }
 /// QueryUnbondingDelegationRequest is request type for the
@@ -438,10 +626,10 @@ pub struct QueryDelegationResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryUnbondingDelegationRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegationResponse is response type for the Query/UnbondingDelegation
@@ -449,7 +637,7 @@ pub struct QueryUnbondingDelegationRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryUnbondingDelegationResponse {
     /// unbond defines the unbonding information of a delegation.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub unbond: ::core::option::Option<UnbondingDelegation>,
 }
 /// QueryDelegatorDelegationsRequest is request type for the
@@ -457,10 +645,10 @@ pub struct QueryUnbondingDelegationResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorDelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryDelegatorDelegationsResponse is response type for the
@@ -468,10 +656,10 @@ pub struct QueryDelegatorDelegationsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorDelegationsResponse {
     /// delegation_responses defines all the delegations' info of a delegator.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub delegation_responses: ::prost::alloc::vec::Vec<DelegationResponse>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorUnbondingDelegationsRequest is request type for the
@@ -479,20 +667,20 @@ pub struct QueryDelegatorDelegationsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorUnbondingDelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryUnbondingDelegatorDelegationsResponse is response type for the
 /// Query/UnbondingDelegatorDelegations RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorUnbondingDelegationsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub unbonding_responses: ::prost::alloc::vec::Vec<UnbondingDelegation>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryRedelegationsRequest is request type for the Query/Redelegations RPC
@@ -500,26 +688,26 @@ pub struct QueryDelegatorUnbondingDelegationsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryRedelegationsRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// src_validator_addr defines the validator address to redelegate from.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub src_validator_addr: ::prost::alloc::string::String,
     /// dst_validator_addr defines the validator address to redelegate to.
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub dst_validator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryRedelegationsResponse is response type for the Query/Redelegations RPC
 /// method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryRedelegationsResponse {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub redelegation_responses: ::prost::alloc::vec::Vec<RedelegationResponse>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorValidatorsRequest is request type for the
@@ -527,10 +715,10 @@ pub struct QueryRedelegationsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorValidatorsRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// pagination defines an optional pagination for the request.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
 /// QueryDelegatorValidatorsResponse is response type for the
@@ -538,10 +726,10 @@ pub struct QueryDelegatorValidatorsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorValidatorsResponse {
     /// validators defines the the validators' info of a delegator.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// pagination defines the pagination in the response.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
 /// QueryDelegatorValidatorRequest is request type for the
@@ -549,10 +737,10 @@ pub struct QueryDelegatorValidatorsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorValidatorRequest {
     /// delegator_addr defines the delegator address to query for.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub delegator_addr: ::prost::alloc::string::String,
     /// validator_addr defines the validator address to query for.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub validator_addr: ::prost::alloc::string::String,
 }
 /// QueryDelegatorValidatorResponse response type for the
@@ -560,7 +748,7 @@ pub struct QueryDelegatorValidatorRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDelegatorValidatorResponse {
     /// validator defines the the validator info.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub validator: ::core::option::Option<Validator>,
 }
 /// QueryHistoricalInfoRequest is request type for the Query/HistoricalInfo RPC
@@ -568,7 +756,7 @@ pub struct QueryDelegatorValidatorResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryHistoricalInfoRequest {
     /// height defines at which height to query the historical info.
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub height: i64,
 }
 /// QueryHistoricalInfoResponse is response type for the Query/HistoricalInfo RPC
@@ -576,29 +764,27 @@ pub struct QueryHistoricalInfoRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryHistoricalInfoResponse {
     /// hist defines the historical info at the given height.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub hist: ::core::option::Option<HistoricalInfo>,
 }
 /// QueryPoolRequest is request type for the Query/Pool RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryPoolRequest {
-}
+pub struct QueryPoolRequest {}
 /// QueryPoolResponse is response type for the Query/Pool RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPoolResponse {
     /// pool defines the pool info.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub pool: ::core::option::Option<Pool>,
 }
 /// QueryParamsRequest is request type for the Query/Params RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryParamsRequest {
-}
+pub struct QueryParamsRequest {}
 /// QueryParamsResponse is response type for the Query/Params RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsResponse {
     /// params holds all the parameters of this module.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
 }
 /// Generated client implementations.
@@ -612,6 +798,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -647,9 +835,8 @@ pub mod query_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -673,19 +860,15 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorsRequest>,
         ) -> Result<tonic::Response<super::QueryValidatorsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Validators",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Validators");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Validator queries validator info for given validator address.
@@ -693,38 +876,29 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorRequest>,
         ) -> Result<tonic::Response<super::QueryValidatorResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Validator",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Validator");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// ValidatorDelegations queries delegate info for given validator.
         pub async fn validator_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorDelegationsRequest>,
-        ) -> Result<
-                tonic::Response<super::QueryValidatorDelegationsResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::QueryValidatorDelegationsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/ValidatorDelegations",
@@ -734,22 +908,15 @@ pub mod query_client {
         /// ValidatorUnbondingDelegations queries unbonding delegations of a validator.
         pub async fn validator_unbonding_delegations(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::QueryValidatorUnbondingDelegationsRequest,
-            >,
-        ) -> Result<
-                tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::QueryValidatorUnbondingDelegationsRequest>,
+        ) -> Result<tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/ValidatorUnbondingDelegations",
@@ -761,19 +928,15 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationRequest>,
         ) -> Result<tonic::Response<super::QueryDelegationResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Delegation",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Delegation");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// UnbondingDelegation queries unbonding info for given validator delegator
@@ -781,19 +944,14 @@ pub mod query_client {
         pub async fn unbonding_delegation(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUnbondingDelegationRequest>,
-        ) -> Result<
-                tonic::Response<super::QueryUnbondingDelegationResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::QueryUnbondingDelegationResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/UnbondingDelegation",
@@ -804,19 +962,14 @@ pub mod query_client {
         pub async fn delegator_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorDelegationsRequest>,
-        ) -> Result<
-                tonic::Response<super::QueryDelegatorDelegationsResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::QueryDelegatorDelegationsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/DelegatorDelegations",
@@ -827,22 +980,15 @@ pub mod query_client {
         /// delegator address.
         pub async fn delegator_unbonding_delegations(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::QueryDelegatorUnbondingDelegationsRequest,
-            >,
-        ) -> Result<
-                tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::QueryDelegatorUnbondingDelegationsRequest>,
+        ) -> Result<tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/DelegatorUnbondingDelegations",
@@ -854,19 +1000,15 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryRedelegationsRequest>,
         ) -> Result<tonic::Response<super::QueryRedelegationsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Redelegations",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Redelegations");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// DelegatorValidators queries all validators info for given delegator
@@ -874,19 +1016,14 @@ pub mod query_client {
         pub async fn delegator_validators(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
-        ) -> Result<
-                tonic::Response<super::QueryDelegatorValidatorsResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::QueryDelegatorValidatorsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/DelegatorValidators",
@@ -898,19 +1035,14 @@ pub mod query_client {
         pub async fn delegator_validator(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorRequest>,
-        ) -> Result<
-                tonic::Response<super::QueryDelegatorValidatorResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::QueryDelegatorValidatorResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/DelegatorValidator",
@@ -922,15 +1054,12 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryHistoricalInfoRequest>,
         ) -> Result<tonic::Response<super::QueryHistoricalInfoResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cosmos.staking.v1beta1.Query/HistoricalInfo",
@@ -942,19 +1071,14 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPoolRequest>,
         ) -> Result<tonic::Response<super::QueryPoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Pool",
-            );
+            let path = http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Pool");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Parameters queries the staking parameters.
@@ -962,324 +1086,108 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
         ) -> Result<tonic::Response<super::QueryParamsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Query/Params",
-            );
+            let path = http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Query/Params");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
-/// MsgCreateValidator defines a SDK message for creating a new validator.
+/// StakeAuthorization defines authorization for delegate/undelegate/redelegate.
+///
+/// Since: cosmos-sdk 0.43
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgCreateValidator {
-    #[prost(message, optional, tag="1")]
-    pub description: ::core::option::Option<Description>,
-    #[prost(message, optional, tag="2")]
-    pub commission: ::core::option::Option<CommissionRates>,
-    #[prost(string, tag="3")]
-    pub min_self_delegation: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="5")]
-    pub validator_address: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="6")]
-    pub pubkey: ::core::option::Option<::prost_types::Any>,
-    #[prost(message, optional, tag="7")]
-    pub value: ::core::option::Option<super::super::base::v1beta1::Coin>,
+pub struct StakeAuthorization {
+    /// max_tokens specifies the maximum amount of tokens can be delegate to a validator. If it is
+    /// empty, there is no spend limit and any amount of coins can be delegated.
+    #[prost(message, optional, tag = "1")]
+    pub max_tokens: ::core::option::Option<super::super::base::v1beta1::Coin>,
+    /// authorization_type defines one of AuthorizationType.
+    #[prost(enumeration = "AuthorizationType", tag = "4")]
+    pub authorization_type: i32,
+    /// validators is the oneof that represents either allow_list or deny_list
+    #[prost(
+        oneof = "stake_authorization::IsStakeAuthorizationValidators",
+        tags = "2, 3"
+    )]
+    pub validators: ::core::option::Option<stake_authorization::IsStakeAuthorizationValidators>,
 }
-/// MsgCreateValidatorResponse defines the Msg/CreateValidator response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgCreateValidatorResponse {
-}
-/// MsgEditValidator defines a SDK message for editing an existing validator.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgEditValidator {
-    #[prost(message, optional, tag="1")]
-    pub description: ::core::option::Option<Description>,
-    #[prost(string, tag="2")]
-    pub validator_address: ::prost::alloc::string::String,
-    /// We pass a reference to the new commission rate and min self delegation as
-    /// it's not mandatory to update. If not updated, the deserialized rate will be
-    /// zero with no way to distinguish if an update was intended.
-    /// REF: #2373
-    #[prost(string, tag="3")]
-    pub commission_rate: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
-    pub min_self_delegation: ::prost::alloc::string::String,
-}
-/// MsgEditValidatorResponse defines the Msg/EditValidator response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgEditValidatorResponse {
-}
-/// MsgDelegate defines a SDK message for performing a delegation of coins
-/// from a delegator to a validator.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgDelegate {
-    #[prost(string, tag="1")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub validator_address: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="3")]
-    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
-}
-/// MsgDelegateResponse defines the Msg/Delegate response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgDelegateResponse {
-}
-/// MsgBeginRedelegate defines a SDK message for performing a redelegation
-/// of coins from a delegator and source validator to a destination validator.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgBeginRedelegate {
-    #[prost(string, tag="1")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub validator_src_address: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
-    pub validator_dst_address: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="4")]
-    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
-}
-/// MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgBeginRedelegateResponse {
-    #[prost(message, optional, tag="1")]
-    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
-}
-/// MsgUndelegate defines a SDK message for performing an undelegation from a
-/// delegate and a validator.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUndelegate {
-    #[prost(string, tag="1")]
-    pub delegator_address: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub validator_address: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="3")]
-    pub amount: ::core::option::Option<super::super::base::v1beta1::Coin>,
-}
-/// MsgUndelegateResponse defines the Msg/Undelegate response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUndelegateResponse {
-    #[prost(message, optional, tag="1")]
-    pub completion_time: ::core::option::Option<::prost_types::Timestamp>,
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the staking Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
+/// Nested message and enum types in `StakeAuthorization`.
+pub mod stake_authorization {
+    /// Validators defines list of validator addresses.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct StakeAuthorizationValidators {
+        #[prost(string, repeated, tag = "1")]
+        pub address: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
+    /// validators is the oneof that represents either allow_list or deny_list
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum IsStakeAuthorizationValidators {
+        /// allow_list specifies list of validator addresses to whom grantee can delegate tokens on behalf of granter's
+        /// account.
+        #[prost(message, tag = "2")]
+        AllowList(StakeAuthorizationValidators),
+        /// deny_list specifies list of validator addresses to whom grantee can not delegate tokens.
+        #[prost(message, tag = "3")]
+        DenyList(StakeAuthorizationValidators),
     }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// CreateValidator defines a method for creating a new validator.
-        pub async fn create_validator(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgCreateValidator>,
-        ) -> Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Msg/CreateValidator",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// EditValidator defines a method for editing an existing validator.
-        pub async fn edit_validator(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgEditValidator>,
-        ) -> Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Msg/EditValidator",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Delegate defines a method for performing a delegation of coins
-        /// from a delegator to a validator.
-        pub async fn delegate(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgDelegate>,
-        ) -> Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Msg/Delegate",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// BeginRedelegate defines a method for performing a redelegation
-        /// of coins from a delegator and source validator to a destination validator.
-        pub async fn begin_redelegate(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgBeginRedelegate>,
-        ) -> Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Msg/BeginRedelegate",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Undelegate defines a method for performing an undelegation from a
-        /// delegate and a validator.
-        pub async fn undelegate(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgUndelegate>,
-        ) -> Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/cosmos.staking.v1beta1.Msg/Undelegate",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
+}
+/// AuthorizationType defines the type of staking module authorization type
+///
+/// Since: cosmos-sdk 0.43
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum AuthorizationType {
+    /// AUTHORIZATION_TYPE_UNSPECIFIED specifies an unknown authorization type
+    Unspecified = 0,
+    /// AUTHORIZATION_TYPE_DELEGATE defines an authorization type for Msg/Delegate
+    Delegate = 1,
+    /// AUTHORIZATION_TYPE_UNDELEGATE defines an authorization type for Msg/Undelegate
+    Undelegate = 2,
+    /// AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for Msg/BeginRedelegate
+    Redelegate = 3,
 }
 /// GenesisState defines the staking module's genesis state.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
     /// params defines all the paramaters of related to deposit.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// last_total_power tracks the total amounts of bonded tokens recorded during
     /// the previous end block.
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub last_total_power: ::prost::alloc::vec::Vec<u8>,
     /// last_validator_powers is a special index that provides a historical list
     /// of the last-block's bonded validators.
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub last_validator_powers: ::prost::alloc::vec::Vec<LastValidatorPower>,
     /// delegations defines the validator set at genesis.
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub validators: ::prost::alloc::vec::Vec<Validator>,
     /// delegations defines the delegations active at genesis.
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub delegations: ::prost::alloc::vec::Vec<Delegation>,
     /// unbonding_delegations defines the unbonding delegations active at genesis.
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub unbonding_delegations: ::prost::alloc::vec::Vec<UnbondingDelegation>,
     /// redelegations defines the redelegations active at genesis.
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub redelegations: ::prost::alloc::vec::Vec<Redelegation>,
-    #[prost(bool, tag="8")]
+    #[prost(bool, tag = "8")]
     pub exported: bool,
 }
 /// LastValidatorPower required for validator set update logic.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LastValidatorPower {
     /// address is the address of the validator.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub address: ::prost::alloc::string::String,
     /// power defines the power of the validator.
-    #[prost(int64, tag="2")]
+    #[prost(int64, tag = "2")]
     pub power: i64,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
@@ -344,6 +344,8 @@ pub mod service_client {
     pub struct ServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl ServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
@@ -142,6 +142,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.rs
@@ -1,64 +1,3 @@
-/// BaseVestingAccount implements the VestingAccount interface. It contains all
-/// the necessary fields needed for any vesting account implementation.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct BaseVestingAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_account: ::core::option::Option<super::super::auth::v1beta1::BaseAccount>,
-    #[prost(message, repeated, tag="2")]
-    pub original_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    #[prost(message, repeated, tag="3")]
-    pub delegated_free: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    #[prost(message, repeated, tag="4")]
-    pub delegated_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    #[prost(int64, tag="5")]
-    pub end_time: i64,
-}
-/// ContinuousVestingAccount implements the VestingAccount interface. It
-/// continuously vests by unlocking coins linearly with respect to time.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ContinuousVestingAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
-    #[prost(int64, tag="2")]
-    pub start_time: i64,
-}
-/// DelayedVestingAccount implements the VestingAccount interface. It vests all
-/// coins after a specific time, but non prior. In other words, it keeps them
-/// locked until a specified time.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DelayedVestingAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
-}
-/// Period defines a length of time and amount of coins that will vest.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Period {
-    #[prost(int64, tag="1")]
-    pub length: i64,
-    #[prost(message, repeated, tag="2")]
-    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-}
-/// PeriodicVestingAccount implements the VestingAccount interface. It
-/// periodically vests by unlocking coins during each specified period.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PeriodicVestingAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
-    #[prost(int64, tag="2")]
-    pub start_time: i64,
-    #[prost(message, repeated, tag="3")]
-    pub vesting_periods: ::prost::alloc::vec::Vec<Period>,
-}
-/// PermanentLockedAccount implements the VestingAccount interface. It does
-/// not ever release coins, locking them indefinitely. Coins in this account can
-/// still be used for delegating and for governance votes even while locked.
-///
-/// Since: cosmos-sdk 0.43
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PermanentLockedAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
-}
 /// MsgCreateVestingAccount defines a message that enables creating a vesting
 /// account.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,6 +28,8 @@ pub mod msg_client {
     pub struct MsgClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl MsgClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -170,4 +111,65 @@ pub mod msg_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
+}
+/// BaseVestingAccount implements the VestingAccount interface. It contains all
+/// the necessary fields needed for any vesting account implementation.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BaseVestingAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_account: ::core::option::Option<super::super::auth::v1beta1::BaseAccount>,
+    #[prost(message, repeated, tag="2")]
+    pub original_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, repeated, tag="3")]
+    pub delegated_free: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, repeated, tag="4")]
+    pub delegated_vesting: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(int64, tag="5")]
+    pub end_time: i64,
+}
+/// ContinuousVestingAccount implements the VestingAccount interface. It
+/// continuously vests by unlocking coins linearly with respect to time.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContinuousVestingAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+    #[prost(int64, tag="2")]
+    pub start_time: i64,
+}
+/// DelayedVestingAccount implements the VestingAccount interface. It vests all
+/// coins after a specific time, but non prior. In other words, it keeps them
+/// locked until a specified time.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DelayedVestingAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+}
+/// Period defines a length of time and amount of coins that will vest.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Period {
+    #[prost(int64, tag="1")]
+    pub length: i64,
+    #[prost(message, repeated, tag="2")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// PeriodicVestingAccount implements the VestingAccount interface. It
+/// periodically vests by unlocking coins during each specified period.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PeriodicVestingAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
+    #[prost(int64, tag="2")]
+    pub start_time: i64,
+    #[prost(message, repeated, tag="3")]
+    pub vesting_periods: ::prost::alloc::vec::Vec<Period>,
+}
+/// PermanentLockedAccount implements the VestingAccount interface. It does
+/// not ever release coins, locking them indefinitely. Coins in this account can
+/// still be used for delegating and for governance votes even while locked.
+///
+/// Since: cosmos-sdk 0.43
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PermanentLockedAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_vesting_account: ::core::option::Option<BaseVestingAccount>,
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
@@ -28,6 +28,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
@@ -31,6 +31,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
@@ -1,3 +1,37 @@
+/// An InterchainAccount is defined as a BaseAccount & the address of the account owner on the controller chain
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InterchainAccount {
+    #[prost(message, optional, tag="1")]
+    pub base_account: ::core::option::Option<super::super::super::super::cosmos::auth::v1beta1::BaseAccount>,
+    #[prost(string, tag="2")]
+    pub account_owner: ::prost::alloc::string::String,
+}
+/// InterchainAccountPacketData is comprised of a raw transaction, type of transaction and optional memo field.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InterchainAccountPacketData {
+    #[prost(enumeration="Type", tag="1")]
+    pub r#type: i32,
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag="3")]
+    pub memo: ::prost::alloc::string::String,
+}
+/// CosmosTx contains a list of sdk.Msg's. It should be used when sending transactions to an SDK host chain.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CosmosTx {
+    #[prost(message, repeated, tag="1")]
+    pub messages: ::prost::alloc::vec::Vec<::prost_types::Any>,
+}
+/// Type defines a classification of message issued from a controller chain to its associated interchain accounts
+/// host
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Type {
+    /// Default zero value enumeration
+    Unspecified = 0,
+    /// Execute a transaction on an interchain accounts host chain
+    ExecuteTx = 1,
+}
 /// Metadata defines a set of protocol specific data encoded into the ICS27 channel version bytestring
 /// See ICS004: <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning>
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -73,38 +107,4 @@ pub struct RegisteredInterchainAccount {
     pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag="3")]
     pub account_address: ::prost::alloc::string::String,
-}
-/// InterchainAccountPacketData is comprised of a raw transaction, type of transaction and optional memo field.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InterchainAccountPacketData {
-    #[prost(enumeration="Type", tag="1")]
-    pub r#type: i32,
-    #[prost(bytes="vec", tag="2")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
-    #[prost(string, tag="3")]
-    pub memo: ::prost::alloc::string::String,
-}
-/// CosmosTx contains a list of sdk.Msg's. It should be used when sending transactions to an SDK host chain.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CosmosTx {
-    #[prost(message, repeated, tag="1")]
-    pub messages: ::prost::alloc::vec::Vec<::prost_types::Any>,
-}
-/// Type defines a classification of message issued from a controller chain to its associated interchain accounts
-/// host
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum Type {
-    /// Default zero value enumeration
-    Unspecified = 0,
-    /// Execute a transaction on an interchain accounts host chain
-    ExecuteTx = 1,
-}
-/// An InterchainAccount is defined as a BaseAccount & the address of the account owner on the controller chain
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InterchainAccount {
-    #[prost(message, optional, tag="1")]
-    pub base_account: ::core::option::Option<super::super::super::super::cosmos::auth::v1beta1::BaseAccount>,
-    #[prost(string, tag="2")]
-    pub account_owner: ::prost::alloc::string::String,
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
@@ -1,3 +1,127 @@
+/// MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between
+/// ICS20 enabled chains. See ICS Spec here:
+/// <https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures>
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTransfer {
+    /// the port on which the packet will be sent
+    #[prost(string, tag="1")]
+    pub source_port: ::prost::alloc::string::String,
+    /// the channel by which the packet will be sent
+    #[prost(string, tag="2")]
+    pub source_channel: ::prost::alloc::string::String,
+    /// the tokens to be transferred
+    #[prost(message, optional, tag="3")]
+    pub token: ::core::option::Option<super::super::super::super::cosmos::base::v1beta1::Coin>,
+    /// the sender address
+    #[prost(string, tag="4")]
+    pub sender: ::prost::alloc::string::String,
+    /// the recipient address on the destination chain
+    #[prost(string, tag="5")]
+    pub receiver: ::prost::alloc::string::String,
+    /// Timeout height relative to the current block height.
+    /// The timeout is disabled when set to 0.
+    #[prost(message, optional, tag="6")]
+    pub timeout_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
+    /// Timeout timestamp in absolute nanoseconds since unix epoch.
+    /// The timeout is disabled when set to 0.
+    #[prost(uint64, tag="7")]
+    pub timeout_timestamp: u64,
+}
+/// MsgTransferResponse defines the Msg/Transfer response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTransferResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the ibc/transfer Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// Transfer defines a rpc handler method for MsgTransfer.
+        pub async fn transfer(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgTransfer>,
+        ) -> Result<tonic::Response<super::MsgTransferResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.applications.transfer.v1.Msg/Transfer",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// DenomTrace contains the base denomination for ICS20 fungible tokens and the
 /// source tracing information path.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -98,6 +222,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -231,128 +357,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/ibc.applications.transfer.v1.Query/DenomHash",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between
-/// ICS20 enabled chains. See ICS Spec here:
-/// <https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures>
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTransfer {
-    /// the port on which the packet will be sent
-    #[prost(string, tag="1")]
-    pub source_port: ::prost::alloc::string::String,
-    /// the channel by which the packet will be sent
-    #[prost(string, tag="2")]
-    pub source_channel: ::prost::alloc::string::String,
-    /// the tokens to be transferred
-    #[prost(message, optional, tag="3")]
-    pub token: ::core::option::Option<super::super::super::super::cosmos::base::v1beta1::Coin>,
-    /// the sender address
-    #[prost(string, tag="4")]
-    pub sender: ::prost::alloc::string::String,
-    /// the recipient address on the destination chain
-    #[prost(string, tag="5")]
-    pub receiver: ::prost::alloc::string::String,
-    /// Timeout height relative to the current block height.
-    /// The timeout is disabled when set to 0.
-    #[prost(message, optional, tag="6")]
-    pub timeout_height: ::core::option::Option<super::super::super::core::client::v1::Height>,
-    /// Timeout timestamp in absolute nanoseconds since unix epoch.
-    /// The timeout is disabled when set to 0.
-    #[prost(uint64, tag="7")]
-    pub timeout_timestamp: u64,
-}
-/// MsgTransferResponse defines the Msg/Transfer response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTransferResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the ibc/transfer Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// Transfer defines a rpc handler method for MsgTransfer.
-        pub async fn transfer(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgTransfer>,
-        ) -> Result<tonic::Response<super::MsgTransferResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.applications.transfer.v1.Msg/Transfer",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
@@ -160,6 +160,497 @@ pub enum Order {
     /// packets are delivered exactly in the order which they were sent
     Ordered = 2,
 }
+/// MsgChannelOpenInit defines an sdk.Msg to initialize a channel handshake. It
+/// is called by a relayer on Chain A.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenInit {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub channel: ::core::option::Option<Channel>,
+    #[prost(string, tag="3")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelOpenInitResponse defines the Msg/ChannelOpenInit response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenInitResponse {
+    #[prost(string, tag="1")]
+    pub channel_id: ::prost::alloc::string::String,
+}
+/// MsgChannelOpenInit defines a msg sent by a Relayer to try to open a channel
+/// on Chain B. The version field within the Channel field has been deprecated. Its
+/// value will be ignored by core IBC.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenTry {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    /// in the case of crossing hello's, when both chains call OpenInit, we need
+    /// the channel identifier of the previous channel in state INIT
+    #[prost(string, tag="2")]
+    pub previous_channel_id: ::prost::alloc::string::String,
+    /// NOTE: the version field within the channel has been deprecated. Its value will be ignored by core IBC.
+    #[prost(message, optional, tag="3")]
+    pub channel: ::core::option::Option<Channel>,
+    #[prost(string, tag="4")]
+    pub counterparty_version: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="5")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="6")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="7")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelOpenTryResponse defines the Msg/ChannelOpenTry response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenTryResponse {
+}
+/// MsgChannelOpenAck defines a msg sent by a Relayer to Chain A to acknowledge
+/// the change of channel state to TRYOPEN on Chain B.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenAck {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub counterparty_channel_id: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub counterparty_version: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="5")]
+    pub proof_try: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="6")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="7")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelOpenAckResponse defines the Msg/ChannelOpenAck response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenAckResponse {
+}
+/// MsgChannelOpenConfirm defines a msg sent by a Relayer to Chain B to
+/// acknowledge the change of channel state to OPEN on Chain A.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenConfirm {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="3")]
+    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="4")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="5")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response
+/// type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelOpenConfirmResponse {
+}
+/// MsgChannelCloseInit defines a msg sent by a Relayer to Chain A
+/// to close a channel with Chain B.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelCloseInit {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelCloseInitResponse defines the Msg/ChannelCloseInit response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelCloseInitResponse {
+}
+/// MsgChannelCloseConfirm defines a msg sent by a Relayer to Chain B
+/// to acknowledge the change of channel state to CLOSED on Chain A.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelCloseConfirm {
+    #[prost(string, tag="1")]
+    pub port_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub channel_id: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="3")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="4")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="5")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response
+/// type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgChannelCloseConfirmResponse {
+}
+/// MsgRecvPacket receives incoming IBC packet
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgRecvPacket {
+    #[prost(message, optional, tag="1")]
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes="vec", tag="2")]
+    pub proof_commitment: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="3")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="4")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgRecvPacketResponse defines the Msg/RecvPacket response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgRecvPacketResponse {
+    #[prost(enumeration="ResponseResultType", tag="1")]
+    pub result: i32,
+}
+/// MsgTimeout receives timed-out packet
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTimeout {
+    #[prost(message, optional, tag="1")]
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes="vec", tag="2")]
+    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="3")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(uint64, tag="4")]
+    pub next_sequence_recv: u64,
+    #[prost(string, tag="5")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgTimeoutResponse defines the Msg/Timeout response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTimeoutResponse {
+    #[prost(enumeration="ResponseResultType", tag="1")]
+    pub result: i32,
+}
+/// MsgTimeoutOnClose timed-out packet upon counterparty channel closure.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTimeoutOnClose {
+    #[prost(message, optional, tag="1")]
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes="vec", tag="2")]
+    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub proof_close: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="4")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(uint64, tag="5")]
+    pub next_sequence_recv: u64,
+    #[prost(string, tag="6")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgTimeoutOnCloseResponse defines the Msg/TimeoutOnClose response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgTimeoutOnCloseResponse {
+    #[prost(enumeration="ResponseResultType", tag="1")]
+    pub result: i32,
+}
+/// MsgAcknowledgement receives incoming IBC acknowledgement
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgAcknowledgement {
+    #[prost(message, optional, tag="1")]
+    pub packet: ::core::option::Option<Packet>,
+    #[prost(bytes="vec", tag="2")]
+    pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub proof_acked: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="4")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="5")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgAcknowledgementResponse defines the Msg/Acknowledgement response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgAcknowledgementResponse {
+    #[prost(enumeration="ResponseResultType", tag="1")]
+    pub result: i32,
+}
+/// ResponseResultType defines the possible outcomes of the execution of a message
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ResponseResultType {
+    /// Default zero value enumeration
+    ResponseResultUnspecified = 0,
+    /// The message did not call the IBC application callbacks (because, for example, the packet had already been relayed)
+    ResponseResultNoop = 1,
+    /// The message was executed successfully
+    ResponseResultSuccess = 2,
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the ibc/channel Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// ChannelOpenInit defines a rpc handler method for MsgChannelOpenInit.
+        pub async fn channel_open_init(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelOpenInit>,
+        ) -> Result<tonic::Response<super::MsgChannelOpenInitResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelOpenInit",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ChannelOpenTry defines a rpc handler method for MsgChannelOpenTry.
+        pub async fn channel_open_try(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelOpenTry>,
+        ) -> Result<tonic::Response<super::MsgChannelOpenTryResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelOpenTry",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ChannelOpenAck defines a rpc handler method for MsgChannelOpenAck.
+        pub async fn channel_open_ack(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelOpenAck>,
+        ) -> Result<tonic::Response<super::MsgChannelOpenAckResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelOpenAck",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ChannelOpenConfirm defines a rpc handler method for MsgChannelOpenConfirm.
+        pub async fn channel_open_confirm(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelOpenConfirm>,
+        ) -> Result<
+                tonic::Response<super::MsgChannelOpenConfirmResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelOpenConfirm",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ChannelCloseInit defines a rpc handler method for MsgChannelCloseInit.
+        pub async fn channel_close_init(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelCloseInit>,
+        ) -> Result<tonic::Response<super::MsgChannelCloseInitResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelCloseInit",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ChannelCloseConfirm defines a rpc handler method for
+        /// MsgChannelCloseConfirm.
+        pub async fn channel_close_confirm(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgChannelCloseConfirm>,
+        ) -> Result<
+                tonic::Response<super::MsgChannelCloseConfirmResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/ChannelCloseConfirm",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// RecvPacket defines a rpc handler method for MsgRecvPacket.
+        pub async fn recv_packet(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgRecvPacket>,
+        ) -> Result<tonic::Response<super::MsgRecvPacketResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/RecvPacket",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Timeout defines a rpc handler method for MsgTimeout.
+        pub async fn timeout(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgTimeout>,
+        ) -> Result<tonic::Response<super::MsgTimeoutResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/Timeout",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// TimeoutOnClose defines a rpc handler method for MsgTimeoutOnClose.
+        pub async fn timeout_on_close(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgTimeoutOnClose>,
+        ) -> Result<tonic::Response<super::MsgTimeoutOnCloseResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/TimeoutOnClose",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Acknowledgement defines a rpc handler method for MsgAcknowledgement.
+        pub async fn acknowledgement(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgAcknowledgement>,
+        ) -> Result<tonic::Response<super::MsgAcknowledgementResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.channel.v1.Msg/Acknowledgement",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// QueryChannelRequest is the request type for the Query/Channel RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryChannelRequest {
@@ -519,6 +1010,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -867,495 +1360,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/ibc.core.channel.v1.Query/NextSequenceReceive",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgChannelOpenInit defines an sdk.Msg to initialize a channel handshake. It
-/// is called by a relayer on Chain A.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenInit {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub channel: ::core::option::Option<Channel>,
-    #[prost(string, tag="3")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelOpenInitResponse defines the Msg/ChannelOpenInit response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenInitResponse {
-    #[prost(string, tag="1")]
-    pub channel_id: ::prost::alloc::string::String,
-}
-/// MsgChannelOpenInit defines a msg sent by a Relayer to try to open a channel
-/// on Chain B. The version field within the Channel field has been deprecated. Its
-/// value will be ignored by core IBC.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenTry {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    /// in the case of crossing hello's, when both chains call OpenInit, we need
-    /// the channel identifier of the previous channel in state INIT
-    #[prost(string, tag="2")]
-    pub previous_channel_id: ::prost::alloc::string::String,
-    /// NOTE: the version field within the channel has been deprecated. Its value will be ignored by core IBC.
-    #[prost(message, optional, tag="3")]
-    pub channel: ::core::option::Option<Channel>,
-    #[prost(string, tag="4")]
-    pub counterparty_version: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="5")]
-    pub proof_init: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="6")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="7")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelOpenTryResponse defines the Msg/ChannelOpenTry response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenTryResponse {
-}
-/// MsgChannelOpenAck defines a msg sent by a Relayer to Chain A to acknowledge
-/// the change of channel state to TRYOPEN on Chain B.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenAck {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub channel_id: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
-    pub counterparty_channel_id: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
-    pub counterparty_version: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="5")]
-    pub proof_try: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="6")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="7")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelOpenAckResponse defines the Msg/ChannelOpenAck response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenAckResponse {
-}
-/// MsgChannelOpenConfirm defines a msg sent by a Relayer to Chain B to
-/// acknowledge the change of channel state to OPEN on Chain A.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenConfirm {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub channel_id: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="3")]
-    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="5")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response
-/// type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelOpenConfirmResponse {
-}
-/// MsgChannelCloseInit defines a msg sent by a Relayer to Chain A
-/// to close a channel with Chain B.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelCloseInit {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub channel_id: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelCloseInitResponse defines the Msg/ChannelCloseInit response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelCloseInitResponse {
-}
-/// MsgChannelCloseConfirm defines a msg sent by a Relayer to Chain B
-/// to acknowledge the change of channel state to CLOSED on Chain A.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelCloseConfirm {
-    #[prost(string, tag="1")]
-    pub port_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub channel_id: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="3")]
-    pub proof_init: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="5")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response
-/// type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgChannelCloseConfirmResponse {
-}
-/// MsgRecvPacket receives incoming IBC packet
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgRecvPacket {
-    #[prost(message, optional, tag="1")]
-    pub packet: ::core::option::Option<Packet>,
-    #[prost(bytes="vec", tag="2")]
-    pub proof_commitment: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="3")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="4")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgRecvPacketResponse defines the Msg/RecvPacket response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgRecvPacketResponse {
-    #[prost(enumeration="ResponseResultType", tag="1")]
-    pub result: i32,
-}
-/// MsgTimeout receives timed-out packet
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTimeout {
-    #[prost(message, optional, tag="1")]
-    pub packet: ::core::option::Option<Packet>,
-    #[prost(bytes="vec", tag="2")]
-    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="3")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(uint64, tag="4")]
-    pub next_sequence_recv: u64,
-    #[prost(string, tag="5")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgTimeoutResponse defines the Msg/Timeout response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTimeoutResponse {
-    #[prost(enumeration="ResponseResultType", tag="1")]
-    pub result: i32,
-}
-/// MsgTimeoutOnClose timed-out packet upon counterparty channel closure.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTimeoutOnClose {
-    #[prost(message, optional, tag="1")]
-    pub packet: ::core::option::Option<Packet>,
-    #[prost(bytes="vec", tag="2")]
-    pub proof_unreceived: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="3")]
-    pub proof_close: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(uint64, tag="5")]
-    pub next_sequence_recv: u64,
-    #[prost(string, tag="6")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgTimeoutOnCloseResponse defines the Msg/TimeoutOnClose response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgTimeoutOnCloseResponse {
-    #[prost(enumeration="ResponseResultType", tag="1")]
-    pub result: i32,
-}
-/// MsgAcknowledgement receives incoming IBC acknowledgement
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgAcknowledgement {
-    #[prost(message, optional, tag="1")]
-    pub packet: ::core::option::Option<Packet>,
-    #[prost(bytes="vec", tag="2")]
-    pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="3")]
-    pub proof_acked: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="5")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgAcknowledgementResponse defines the Msg/Acknowledgement response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgAcknowledgementResponse {
-    #[prost(enumeration="ResponseResultType", tag="1")]
-    pub result: i32,
-}
-/// ResponseResultType defines the possible outcomes of the execution of a message
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum ResponseResultType {
-    /// Default zero value enumeration
-    ResponseResultUnspecified = 0,
-    /// The message did not call the IBC application callbacks (because, for example, the packet had already been relayed)
-    ResponseResultNoop = 1,
-    /// The message was executed successfully
-    ResponseResultSuccess = 2,
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the ibc/channel Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// ChannelOpenInit defines a rpc handler method for MsgChannelOpenInit.
-        pub async fn channel_open_init(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelOpenInit>,
-        ) -> Result<tonic::Response<super::MsgChannelOpenInitResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelOpenInit",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ChannelOpenTry defines a rpc handler method for MsgChannelOpenTry.
-        pub async fn channel_open_try(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelOpenTry>,
-        ) -> Result<tonic::Response<super::MsgChannelOpenTryResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelOpenTry",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ChannelOpenAck defines a rpc handler method for MsgChannelOpenAck.
-        pub async fn channel_open_ack(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelOpenAck>,
-        ) -> Result<tonic::Response<super::MsgChannelOpenAckResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelOpenAck",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ChannelOpenConfirm defines a rpc handler method for MsgChannelOpenConfirm.
-        pub async fn channel_open_confirm(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelOpenConfirm>,
-        ) -> Result<
-                tonic::Response<super::MsgChannelOpenConfirmResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelOpenConfirm",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ChannelCloseInit defines a rpc handler method for MsgChannelCloseInit.
-        pub async fn channel_close_init(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelCloseInit>,
-        ) -> Result<tonic::Response<super::MsgChannelCloseInitResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelCloseInit",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ChannelCloseConfirm defines a rpc handler method for
-        /// MsgChannelCloseConfirm.
-        pub async fn channel_close_confirm(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgChannelCloseConfirm>,
-        ) -> Result<
-                tonic::Response<super::MsgChannelCloseConfirmResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/ChannelCloseConfirm",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// RecvPacket defines a rpc handler method for MsgRecvPacket.
-        pub async fn recv_packet(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgRecvPacket>,
-        ) -> Result<tonic::Response<super::MsgRecvPacketResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/RecvPacket",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Timeout defines a rpc handler method for MsgTimeout.
-        pub async fn timeout(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgTimeout>,
-        ) -> Result<tonic::Response<super::MsgTimeoutResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/Timeout",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// TimeoutOnClose defines a rpc handler method for MsgTimeoutOnClose.
-        pub async fn timeout_on_close(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgTimeoutOnClose>,
-        ) -> Result<tonic::Response<super::MsgTimeoutOnCloseResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/TimeoutOnClose",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// Acknowledgement defines a rpc handler method for MsgAcknowledgement.
-        pub async fn acknowledgement(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgAcknowledgement>,
-        ) -> Result<tonic::Response<super::MsgAcknowledgementResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.channel.v1.Msg/Acknowledgement",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
@@ -96,6 +96,243 @@ pub struct Params {
     #[prost(string, repeated, tag="1")]
     pub allowed_clients: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// MsgCreateClient defines a message to create an IBC client
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateClient {
+    /// light client state
+    #[prost(message, optional, tag="1")]
+    pub client_state: ::core::option::Option<::prost_types::Any>,
+    /// consensus state associated with the client that corresponds to a given
+    /// height.
+    #[prost(message, optional, tag="2")]
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
+    /// signer address
+    #[prost(string, tag="3")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgCreateClientResponse defines the Msg/CreateClient response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCreateClientResponse {
+}
+/// MsgUpdateClient defines an sdk.Msg to update a IBC client state using
+/// the given header.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateClient {
+    /// client unique identifier
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    /// header to update the light client
+    #[prost(message, optional, tag="2")]
+    pub header: ::core::option::Option<::prost_types::Any>,
+    /// signer address
+    #[prost(string, tag="3")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgUpdateClientResponse defines the Msg/UpdateClient response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateClientResponse {
+}
+/// MsgUpgradeClient defines an sdk.Msg to upgrade an IBC client to a new client
+/// state
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpgradeClient {
+    /// client unique identifier
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    /// upgraded client state
+    #[prost(message, optional, tag="2")]
+    pub client_state: ::core::option::Option<::prost_types::Any>,
+    /// upgraded consensus state, only contains enough information to serve as a
+    /// basis of trust in update logic
+    #[prost(message, optional, tag="3")]
+    pub consensus_state: ::core::option::Option<::prost_types::Any>,
+    /// proof that old chain committed to new client
+    #[prost(bytes="vec", tag="4")]
+    pub proof_upgrade_client: ::prost::alloc::vec::Vec<u8>,
+    /// proof that old chain committed to new consensus state
+    #[prost(bytes="vec", tag="5")]
+    pub proof_upgrade_consensus_state: ::prost::alloc::vec::Vec<u8>,
+    /// signer address
+    #[prost(string, tag="6")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgUpgradeClientResponse defines the Msg/UpgradeClient response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpgradeClientResponse {
+}
+/// MsgSubmitMisbehaviour defines an sdk.Msg type that submits Evidence for
+/// light client misbehaviour.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitMisbehaviour {
+    /// client unique identifier
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    /// misbehaviour used for freezing the light client
+    #[prost(message, optional, tag="2")]
+    pub misbehaviour: ::core::option::Option<::prost_types::Any>,
+    /// signer address
+    #[prost(string, tag="3")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response
+/// type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSubmitMisbehaviourResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the ibc/client Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// CreateClient defines a rpc handler method for MsgCreateClient.
+        pub async fn create_client(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgCreateClient>,
+        ) -> Result<tonic::Response<super::MsgCreateClientResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.client.v1.Msg/CreateClient",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// UpdateClient defines a rpc handler method for MsgUpdateClient.
+        pub async fn update_client(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateClient>,
+        ) -> Result<tonic::Response<super::MsgUpdateClientResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.client.v1.Msg/UpdateClient",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// UpgradeClient defines a rpc handler method for MsgUpgradeClient.
+        pub async fn upgrade_client(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpgradeClient>,
+        ) -> Result<tonic::Response<super::MsgUpgradeClientResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.client.v1.Msg/UpgradeClient",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// SubmitMisbehaviour defines a rpc handler method for MsgSubmitMisbehaviour.
+        pub async fn submit_misbehaviour(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSubmitMisbehaviour>,
+        ) -> Result<
+                tonic::Response<super::MsgSubmitMisbehaviourResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.client.v1.Msg/SubmitMisbehaviour",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// QueryClientStateRequest is the request type for the Query/ClientState RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -258,6 +495,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -482,241 +721,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/ibc.core.client.v1.Query/UpgradedConsensusState",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgCreateClient defines a message to create an IBC client
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgCreateClient {
-    /// light client state
-    #[prost(message, optional, tag="1")]
-    pub client_state: ::core::option::Option<::prost_types::Any>,
-    /// consensus state associated with the client that corresponds to a given
-    /// height.
-    #[prost(message, optional, tag="2")]
-    pub consensus_state: ::core::option::Option<::prost_types::Any>,
-    /// signer address
-    #[prost(string, tag="3")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgCreateClientResponse defines the Msg/CreateClient response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgCreateClientResponse {
-}
-/// MsgUpdateClient defines an sdk.Msg to update a IBC client state using
-/// the given header.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUpdateClient {
-    /// client unique identifier
-    #[prost(string, tag="1")]
-    pub client_id: ::prost::alloc::string::String,
-    /// header to update the light client
-    #[prost(message, optional, tag="2")]
-    pub header: ::core::option::Option<::prost_types::Any>,
-    /// signer address
-    #[prost(string, tag="3")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgUpdateClientResponse defines the Msg/UpdateClient response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUpdateClientResponse {
-}
-/// MsgUpgradeClient defines an sdk.Msg to upgrade an IBC client to a new client
-/// state
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUpgradeClient {
-    /// client unique identifier
-    #[prost(string, tag="1")]
-    pub client_id: ::prost::alloc::string::String,
-    /// upgraded client state
-    #[prost(message, optional, tag="2")]
-    pub client_state: ::core::option::Option<::prost_types::Any>,
-    /// upgraded consensus state, only contains enough information to serve as a
-    /// basis of trust in update logic
-    #[prost(message, optional, tag="3")]
-    pub consensus_state: ::core::option::Option<::prost_types::Any>,
-    /// proof that old chain committed to new client
-    #[prost(bytes="vec", tag="4")]
-    pub proof_upgrade_client: ::prost::alloc::vec::Vec<u8>,
-    /// proof that old chain committed to new consensus state
-    #[prost(bytes="vec", tag="5")]
-    pub proof_upgrade_consensus_state: ::prost::alloc::vec::Vec<u8>,
-    /// signer address
-    #[prost(string, tag="6")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgUpgradeClientResponse defines the Msg/UpgradeClient response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUpgradeClientResponse {
-}
-/// MsgSubmitMisbehaviour defines an sdk.Msg type that submits Evidence for
-/// light client misbehaviour.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitMisbehaviour {
-    /// client unique identifier
-    #[prost(string, tag="1")]
-    pub client_id: ::prost::alloc::string::String,
-    /// misbehaviour used for freezing the light client
-    #[prost(message, optional, tag="2")]
-    pub misbehaviour: ::core::option::Option<::prost_types::Any>,
-    /// signer address
-    #[prost(string, tag="3")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response
-/// type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgSubmitMisbehaviourResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the ibc/client Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// CreateClient defines a rpc handler method for MsgCreateClient.
-        pub async fn create_client(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgCreateClient>,
-        ) -> Result<tonic::Response<super::MsgCreateClientResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.client.v1.Msg/CreateClient",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// UpdateClient defines a rpc handler method for MsgUpdateClient.
-        pub async fn update_client(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgUpdateClient>,
-        ) -> Result<tonic::Response<super::MsgUpdateClientResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.client.v1.Msg/UpdateClient",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// UpgradeClient defines a rpc handler method for MsgUpgradeClient.
-        pub async fn upgrade_client(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgUpgradeClient>,
-        ) -> Result<tonic::Response<super::MsgUpgradeClientResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.client.v1.Msg/UpgradeClient",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// SubmitMisbehaviour defines a rpc handler method for MsgSubmitMisbehaviour.
-        pub async fn submit_misbehaviour(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgSubmitMisbehaviour>,
-        ) -> Result<
-                tonic::Response<super::MsgSubmitMisbehaviourResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.client.v1.Msg/SubmitMisbehaviour",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
@@ -117,6 +117,281 @@ pub enum State {
     /// A connection end has completed the handshake.
     Open = 3,
 }
+/// MsgConnectionOpenInit defines the msg sent by an account on Chain A to
+/// initialize a connection with Chain B.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenInit {
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub counterparty: ::core::option::Option<Counterparty>,
+    #[prost(message, optional, tag="3")]
+    pub version: ::core::option::Option<Version>,
+    #[prost(uint64, tag="4")]
+    pub delay_period: u64,
+    #[prost(string, tag="5")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response
+/// type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenInitResponse {
+}
+/// MsgConnectionOpenTry defines a msg sent by a Relayer to try to open a
+/// connection on Chain B.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenTry {
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    /// in the case of crossing hello's, when both chains call OpenInit, we need
+    /// the connection identifier of the previous connection in state INIT
+    #[prost(string, tag="2")]
+    pub previous_connection_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub client_state: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, optional, tag="4")]
+    pub counterparty: ::core::option::Option<Counterparty>,
+    #[prost(uint64, tag="5")]
+    pub delay_period: u64,
+    #[prost(message, repeated, tag="6")]
+    pub counterparty_versions: ::prost::alloc::vec::Vec<Version>,
+    #[prost(message, optional, tag="7")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    /// proof of the initialization the connection on Chain A: `UNITIALIZED ->
+    /// INIT`
+    #[prost(bytes="vec", tag="8")]
+    pub proof_init: ::prost::alloc::vec::Vec<u8>,
+    /// proof of client state included in message
+    #[prost(bytes="vec", tag="9")]
+    pub proof_client: ::prost::alloc::vec::Vec<u8>,
+    /// proof of client consensus state
+    #[prost(bytes="vec", tag="10")]
+    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="11")]
+    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="12")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgConnectionOpenTryResponse defines the Msg/ConnectionOpenTry response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenTryResponse {
+}
+/// MsgConnectionOpenAck defines a msg sent by a Relayer to Chain A to
+/// acknowledge the change of connection state to TRYOPEN on Chain B.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenAck {
+    #[prost(string, tag="1")]
+    pub connection_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub counterparty_connection_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub version: ::core::option::Option<Version>,
+    #[prost(message, optional, tag="4")]
+    pub client_state: ::core::option::Option<::prost_types::Any>,
+    #[prost(message, optional, tag="5")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    /// proof of the initialization the connection on Chain B: `UNITIALIZED ->
+    /// TRYOPEN`
+    #[prost(bytes="vec", tag="6")]
+    pub proof_try: ::prost::alloc::vec::Vec<u8>,
+    /// proof of client state included in message
+    #[prost(bytes="vec", tag="7")]
+    pub proof_client: ::prost::alloc::vec::Vec<u8>,
+    /// proof of client consensus state
+    #[prost(bytes="vec", tag="8")]
+    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="9")]
+    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="10")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgConnectionOpenAckResponse defines the Msg/ConnectionOpenAck response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenAckResponse {
+}
+/// MsgConnectionOpenConfirm defines a msg sent by a Relayer to Chain B to
+/// acknowledge the change of connection state to OPEN on Chain A.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenConfirm {
+    #[prost(string, tag="1")]
+    pub connection_id: ::prost::alloc::string::String,
+    /// proof for the change of the connection state on Chain A: `INIT -> OPEN`
+    #[prost(bytes="vec", tag="2")]
+    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="3")]
+    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+    #[prost(string, tag="4")]
+    pub signer: ::prost::alloc::string::String,
+}
+/// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm
+/// response type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgConnectionOpenConfirmResponse {
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Msg defines the ibc/connection Msg service.
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        /// ConnectionOpenInit defines a rpc handler method for MsgConnectionOpenInit.
+        pub async fn connection_open_init(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgConnectionOpenInit>,
+        ) -> Result<
+                tonic::Response<super::MsgConnectionOpenInitResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.connection.v1.Msg/ConnectionOpenInit",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ConnectionOpenTry defines a rpc handler method for MsgConnectionOpenTry.
+        pub async fn connection_open_try(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgConnectionOpenTry>,
+        ) -> Result<
+                tonic::Response<super::MsgConnectionOpenTryResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.connection.v1.Msg/ConnectionOpenTry",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ConnectionOpenAck defines a rpc handler method for MsgConnectionOpenAck.
+        pub async fn connection_open_ack(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgConnectionOpenAck>,
+        ) -> Result<
+                tonic::Response<super::MsgConnectionOpenAckResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.connection.v1.Msg/ConnectionOpenAck",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// ConnectionOpenConfirm defines a rpc handler method for
+        /// MsgConnectionOpenConfirm.
+        pub async fn connection_open_confirm(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgConnectionOpenConfirm>,
+        ) -> Result<
+                tonic::Response<super::MsgConnectionOpenConfirmResponse>,
+                tonic::Status,
+            > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ibc.core.connection.v1.Msg/ConnectionOpenConfirm",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
 /// QueryConnectionRequest is the request type for the Query/Connection RPC
 /// method
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -245,6 +520,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -410,279 +687,6 @@ pub mod query_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/ibc.core.connection.v1.Query/ConnectionConsensusState",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-}
-/// MsgConnectionOpenInit defines the msg sent by an account on Chain A to
-/// initialize a connection with Chain B.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenInit {
-    #[prost(string, tag="1")]
-    pub client_id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub counterparty: ::core::option::Option<Counterparty>,
-    #[prost(message, optional, tag="3")]
-    pub version: ::core::option::Option<Version>,
-    #[prost(uint64, tag="4")]
-    pub delay_period: u64,
-    #[prost(string, tag="5")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response
-/// type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenInitResponse {
-}
-/// MsgConnectionOpenTry defines a msg sent by a Relayer to try to open a
-/// connection on Chain B.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenTry {
-    #[prost(string, tag="1")]
-    pub client_id: ::prost::alloc::string::String,
-    /// in the case of crossing hello's, when both chains call OpenInit, we need
-    /// the connection identifier of the previous connection in state INIT
-    #[prost(string, tag="2")]
-    pub previous_connection_id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="3")]
-    pub client_state: ::core::option::Option<::prost_types::Any>,
-    #[prost(message, optional, tag="4")]
-    pub counterparty: ::core::option::Option<Counterparty>,
-    #[prost(uint64, tag="5")]
-    pub delay_period: u64,
-    #[prost(message, repeated, tag="6")]
-    pub counterparty_versions: ::prost::alloc::vec::Vec<Version>,
-    #[prost(message, optional, tag="7")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    /// proof of the initialization the connection on Chain A: `UNITIALIZED ->
-    /// INIT`
-    #[prost(bytes="vec", tag="8")]
-    pub proof_init: ::prost::alloc::vec::Vec<u8>,
-    /// proof of client state included in message
-    #[prost(bytes="vec", tag="9")]
-    pub proof_client: ::prost::alloc::vec::Vec<u8>,
-    /// proof of client consensus state
-    #[prost(bytes="vec", tag="10")]
-    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="11")]
-    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="12")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgConnectionOpenTryResponse defines the Msg/ConnectionOpenTry response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenTryResponse {
-}
-/// MsgConnectionOpenAck defines a msg sent by a Relayer to Chain A to
-/// acknowledge the change of connection state to TRYOPEN on Chain B.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenAck {
-    #[prost(string, tag="1")]
-    pub connection_id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub counterparty_connection_id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="3")]
-    pub version: ::core::option::Option<Version>,
-    #[prost(message, optional, tag="4")]
-    pub client_state: ::core::option::Option<::prost_types::Any>,
-    #[prost(message, optional, tag="5")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    /// proof of the initialization the connection on Chain B: `UNITIALIZED ->
-    /// TRYOPEN`
-    #[prost(bytes="vec", tag="6")]
-    pub proof_try: ::prost::alloc::vec::Vec<u8>,
-    /// proof of client state included in message
-    #[prost(bytes="vec", tag="7")]
-    pub proof_client: ::prost::alloc::vec::Vec<u8>,
-    /// proof of client consensus state
-    #[prost(bytes="vec", tag="8")]
-    pub proof_consensus: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="9")]
-    pub consensus_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="10")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgConnectionOpenAckResponse defines the Msg/ConnectionOpenAck response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenAckResponse {
-}
-/// MsgConnectionOpenConfirm defines a msg sent by a Relayer to Chain B to
-/// acknowledge the change of connection state to OPEN on Chain A.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenConfirm {
-    #[prost(string, tag="1")]
-    pub connection_id: ::prost::alloc::string::String,
-    /// proof for the change of the connection state on Chain A: `INIT -> OPEN`
-    #[prost(bytes="vec", tag="2")]
-    pub proof_ack: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="3")]
-    pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
-    #[prost(string, tag="4")]
-    pub signer: ::prost::alloc::string::String,
-}
-/// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm
-/// response type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgConnectionOpenConfirmResponse {
-}
-/// Generated client implementations.
-#[cfg(feature = "grpc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
-pub mod msg_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Msg defines the ibc/connection Msg service.
-    #[derive(Debug, Clone)]
-    pub struct MsgClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MsgClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MsgClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MsgClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            MsgClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with `gzip`.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
-            self
-        }
-        /// Enable decompressing responses with `gzip`.
-        #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
-            self
-        }
-        /// ConnectionOpenInit defines a rpc handler method for MsgConnectionOpenInit.
-        pub async fn connection_open_init(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgConnectionOpenInit>,
-        ) -> Result<
-                tonic::Response<super::MsgConnectionOpenInitResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.connection.v1.Msg/ConnectionOpenInit",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ConnectionOpenTry defines a rpc handler method for MsgConnectionOpenTry.
-        pub async fn connection_open_try(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgConnectionOpenTry>,
-        ) -> Result<
-                tonic::Response<super::MsgConnectionOpenTryResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.connection.v1.Msg/ConnectionOpenTry",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ConnectionOpenAck defines a rpc handler method for MsgConnectionOpenAck.
-        pub async fn connection_open_ack(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgConnectionOpenAck>,
-        ) -> Result<
-                tonic::Response<super::MsgConnectionOpenAckResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.connection.v1.Msg/ConnectionOpenAck",
-            );
-            self.inner.unary(request.into_request(), path, codec).await
-        }
-        /// ConnectionOpenConfirm defines a rpc handler method for
-        /// MsgConnectionOpenConfirm.
-        pub async fn connection_open_confirm(
-            &mut self,
-            request: impl tonic::IntoRequest<super::MsgConnectionOpenConfirm>,
-        ) -> Result<
-                tonic::Response<super::MsgConnectionOpenConfirmResponse>,
-                tonic::Status,
-            > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ibc.core.connection.v1.Msg/ConnectionOpenConfirm",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.rs
@@ -314,6 +314,8 @@ pub mod query_client {
     pub struct QueryClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl QueryClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
@@ -710,6 +712,8 @@ pub mod msg_client {
     pub struct MsgClient<T> {
         inner: tonic::client::Grpc<T>,
     }
+    #[cfg(feature = "grpc-transport")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
     impl MsgClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>


### PR DESCRIPTION
Closes #226

Adds an on-by-default `grpc-transport` feature which enables the corresponding `transport` feature in `tonic`. The main use case is supporting gRPC in WASM environments.

To make this work with generated code, the generated protos are patched to feature-gate the `tonic::transport`-dependent code.