### PR TITLE
Additional protobuf-equivalent types

### DIFF
--- a/cosmrs/src/abci.rs
+++ b/cosmrs/src/abci.rs
@@ -83,7 +83,7 @@ impl From<TxMsgData> for proto::cosmos::base::abci::v1beta1::TxMsgData {
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
-struct GasInfo {
+pub struct GasInfo {
     /// GasWanted is the maximum units of work we allow this tx to perform.
     pub gas_wanted: Gas,
 

--- a/cosmrs/src/abci.rs
+++ b/cosmrs/src/abci.rs
@@ -1,0 +1,89 @@
+//! Abci-related functionality
+
+use crate::tx::Msg;
+use crate::{proto, ErrorReport, Result};
+use prost::Message;
+use prost_types::Any;
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgData {
+    pub msg_type: String,
+    pub data: Vec<u8>,
+}
+
+impl MsgData {
+    // MsgData has the same structure as `Any` and is actually treated as such,
+    // so abuse this fact to attempt to decode it into the corresponding proto type.
+    pub fn try_decode<M: Msg>(&self) -> Result<M> {
+        let as_any = Any {
+            type_url: self.msg_type.clone(),
+            value: self.data.clone(),
+        };
+        
+        M::from_any(&as_any)
+    }
+}
+
+impl Msg for MsgData {
+    type Proto = proto::cosmos::base::abci::v1beta1::MsgData;
+}
+
+impl TryFrom<proto::cosmos::base::abci::v1beta1::MsgData> for MsgData {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::base::abci::v1beta1::MsgData) -> Result<MsgData> {
+        Ok(MsgData {
+            msg_type: proto.msg_type,
+            data: proto.data,
+        })
+    }
+}
+
+impl From<MsgData> for proto::cosmos::base::abci::v1beta1::MsgData {
+    fn from(msg_data: MsgData) -> Self {
+        proto::cosmos::base::abci::v1beta1::MsgData {
+            msg_type: msg_data.msg_type,
+            data: msg_data.data,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct TxMsgData {
+    pub data: Vec<MsgData>,
+}
+
+impl<'a> TryFrom<&'a [u8]> for TxMsgData {
+    type Error = ErrorReport;
+
+    fn try_from(value: &'a [u8]) -> Result<TxMsgData> {
+        let proto = proto::cosmos::base::abci::v1beta1::TxMsgData::decode(value)?;
+        proto.try_into()
+    }
+}
+
+impl Msg for TxMsgData {
+    type Proto = proto::cosmos::base::abci::v1beta1::TxMsgData;
+}
+
+impl TryFrom<proto::cosmos::base::abci::v1beta1::TxMsgData> for TxMsgData {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::base::abci::v1beta1::TxMsgData) -> Result<TxMsgData> {
+        Ok(TxMsgData {
+            data: proto
+                .data
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl From<TxMsgData> for proto::cosmos::base::abci::v1beta1::TxMsgData {
+    fn from(tx_msg_data: TxMsgData) -> Self {
+        proto::cosmos::base::abci::v1beta1::TxMsgData {
+            data: tx_msg_data.data.into_iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/cosmrs/src/abci.rs
+++ b/cosmrs/src/abci.rs
@@ -3,6 +3,8 @@
 use crate::tx::Msg;
 use crate::{proto, ErrorReport, Result};
 use prost::Message;
+use serde::{Deserialize, Serialize};
+use tendermint::abci::Gas;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MsgData {
@@ -76,6 +78,35 @@ impl From<TxMsgData> for proto::cosmos::base::abci::v1beta1::TxMsgData {
     fn from(tx_msg_data: TxMsgData) -> Self {
         proto::cosmos::base::abci::v1beta1::TxMsgData {
             data: tx_msg_data.data.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
+struct GasInfo {
+    /// GasWanted is the maximum units of work we allow this tx to perform.
+    pub gas_wanted: Gas,
+
+    /// GasUsed is the amount of gas actually consumed.
+    pub gas_used: Gas,
+}
+
+impl TryFrom<proto::cosmos::base::abci::v1beta1::GasInfo> for GasInfo {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::base::abci::v1beta1::GasInfo) -> Result<GasInfo> {
+        Ok(GasInfo {
+            gas_wanted: Gas::from(proto.gas_wanted),
+            gas_used: Gas::from(proto.gas_used),
+        })
+    }
+}
+
+impl From<GasInfo> for proto::cosmos::base::abci::v1beta1::GasInfo {
+    fn from(info: GasInfo) -> Self {
+        proto::cosmos::base::abci::v1beta1::GasInfo {
+            gas_wanted: info.gas_wanted.value(),
+            gas_used: info.gas_wanted.value(),
         }
     }
 }

--- a/cosmrs/src/auth.rs
+++ b/cosmrs/src/auth.rs
@@ -1,0 +1,72 @@
+//! Auth functionality.
+
+use crate::crypto::PublicKey;
+use crate::tx::{AccountNumber, SequenceNumber};
+use crate::Result;
+use crate::{proto, AccountId, ErrorReport};
+
+/// BaseAccount defines a base account type. It contains all the necessary fields
+/// for basic account functionality. Any custom account type should extend this
+/// type for additional functionality (e.g. vesting).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BaseAccount {
+    /// Bech32 account address
+    pub address: AccountId,
+    pub pubkey: Option<PublicKey>,
+    pub account_number: AccountNumber,
+    pub sequence: SequenceNumber,
+}
+
+impl TryFrom<proto::cosmos::auth::v1beta1::BaseAccount> for BaseAccount {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::auth::v1beta1::BaseAccount) -> Result<BaseAccount> {
+        Ok(BaseAccount {
+            address: proto.address.parse()?,
+            pubkey: proto.pub_key.map(PublicKey::try_from).transpose()?,
+            account_number: proto.account_number,
+            sequence: proto.sequence,
+        })
+    }
+}
+
+impl From<BaseAccount> for proto::cosmos::auth::v1beta1::BaseAccount {
+    fn from(account: BaseAccount) -> proto::cosmos::auth::v1beta1::BaseAccount {
+        proto::cosmos::auth::v1beta1::BaseAccount {
+            address: account.address.to_string(),
+            pub_key: account.pubkey.map(Into::into),
+            account_number: account.account_number,
+            sequence: account.sequence,
+        }
+    }
+}
+
+/// ModuleAccount defines an account for modules that holds coins on a pool.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModuleAccount {
+    pub base_account: Option<BaseAccount>,
+    pub name: String,
+    pub permissions: Vec<String>,
+}
+
+impl TryFrom<proto::cosmos::auth::v1beta1::ModuleAccount> for ModuleAccount {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::auth::v1beta1::ModuleAccount) -> Result<ModuleAccount> {
+        Ok(ModuleAccount {
+            base_account: proto.base_account.map(TryFrom::try_from).transpose()?,
+            name: proto.name,
+            permissions: proto.permissions,
+        })
+    }
+}
+
+impl From<ModuleAccount> for proto::cosmos::auth::v1beta1::ModuleAccount {
+    fn from(account: ModuleAccount) -> proto::cosmos::auth::v1beta1::ModuleAccount {
+        proto::cosmos::auth::v1beta1::ModuleAccount {
+            base_account: account.base_account.map(Into::into),
+            name: account.name,
+            permissions: account.permissions,
+        }
+    }
+}

--- a/cosmrs/src/auth.rs
+++ b/cosmrs/src/auth.rs
@@ -10,10 +10,17 @@ use crate::{proto, AccountId, ErrorReport};
 /// type for additional functionality (e.g. vesting).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BaseAccount {
-    /// Bech32 account address
+    /// Bech32 [`AccountId`] of this account.
     pub address: AccountId,
+
+    /// Optional [`PublicKey`] associated with this account.
     pub pubkey: Option<PublicKey>,
+
+    /// `account_number` is the account number of the account in state
     pub account_number: AccountNumber,
+
+    /// Sequence of the account, which describes the number of committed transactions signed by a
+    /// given address.
     pub sequence: SequenceNumber,
 }
 
@@ -44,8 +51,13 @@ impl From<BaseAccount> for proto::cosmos::auth::v1beta1::BaseAccount {
 /// ModuleAccount defines an account for modules that holds coins on a pool.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModuleAccount {
+    /// [`BaseAccount`] specification of this module account.
     pub base_account: Option<BaseAccount>,
+
+    /// Name of the module.
     pub name: String,
+
+    /// Permissions associated with this module account.
     pub permissions: Vec<String>,
 }
 

--- a/cosmrs/src/cosmwasm.rs
+++ b/cosmrs/src/cosmwasm.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use cosmos_sdk_proto::cosmwasm::wasm::v1::ContractCodeHistoryOperationType;
 
+/// The ID of a particular contract code assigned by the chain.
 pub type ContractCodeId = u64;
 
 /// AccessConfig access control type.
@@ -198,6 +199,7 @@ impl From<MsgInstantiateContract> for proto::cosmwasm::wasm::v1::MsgInstantiateC
 pub struct MsgInstantiateContractResponse {
     /// Address is the bech32 address of the new contract instance.
     pub address: AccountId,
+
     /// Data contains base64-encoded bytes to returned from the contract
     pub data: Vec<u8>,
 }
@@ -538,11 +540,13 @@ impl From<MsgClearAdminResponse> for proto::cosmwasm::wasm::v1::MsgClearAdminRes
     }
 }
 
+/// CodeInfoResponse contains code meta data from CodeInfo
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct CodeInfoResponse {
+    /// CodeId of the stored contract code.
     pub code_id: ContractCodeId,
 
-    /// Bech32 account address
+    /// Bech32 [`AccountId`] of the creator of this smart contract.
     pub creator: AccountId,
 
     /// sha256 hash of the code stored
@@ -571,11 +575,13 @@ impl From<CodeInfoResponse> for proto::cosmwasm::wasm::v1::CodeInfoResponse {
     }
 }
 
+/// QueryCodeResponse is the response type for the Query/Code RPC method.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct QueryCodeResponse {
+    /// If available, the associated code ID metadata.
     pub code_info: Option<CodeInfoResponse>,
 
-    /// The original wasm bytes
+    /// The original wasm bytes.
     pub data: Vec<u8>,
 }
 
@@ -599,13 +605,28 @@ impl From<QueryCodeResponse> for proto::cosmwasm::wasm::v1::QueryCodeResponse {
     }
 }
 
+/// ContractInfo stores a WASM contract instance
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ContractInfo {
+    /// Reference to the stored Wasm code.
     code_id: ContractCodeId,
+
+    /// Creator address who initially instantiated the contract.
     creator: AccountId,
+
+    /// Admin is an optional address that can execute migrations.
     admin: Option<AccountId>,
+
+    /// Label is optional metadata to be stored with a contract instance.
     label: String,
+
+    /// Created Tx position when the contract was instantiated.
+    // Note that this data should kept internal and not be exposed via query results.
+    // Just use for sorting.
     created: Option<AbsoluteTxPosition>,
+
+    /// The IBC port ID assigned to this contract by wasmd.
+    /// This is set for all IBC contracts (https://github.com/CosmWasm/wasmd/blob/v0.16.0/x/wasm/keeper/keeper.go#L299-L306).
     ibc_port_id: String,
 }
 
@@ -641,12 +662,19 @@ impl From<ContractInfo> for proto::cosmwasm::wasm::v1::ContractInfo {
     }
 }
 
+/// ContractCodeHistoryEntry metadata to a contract.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ContractCodeHistoryEntry {
-    /// The source of this history entry
+    /// The source of this history entry.
     pub operation: ContractCodeHistoryOperationType,
+
+    /// Reference to the stored Wasm code.
     pub code_id: ContractCodeId,
+
+    /// Updated Tx position when the operation was executed.
     pub updated: Option<AbsoluteTxPosition>,
+
+    /// Raw message returned by a wasm contract.
     pub msg: Vec<u8>,
 }
 

--- a/cosmrs/src/cosmwasm.rs
+++ b/cosmrs/src/cosmwasm.rs
@@ -98,6 +98,37 @@ impl From<MsgStoreCode> for proto::cosmwasm::wasm::v1::MsgStoreCode {
     }
 }
 
+/// MsgStoreCodeResponse returns store result data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgStoreCodeResponse {
+    /// CodeID is the reference to the stored WASM code
+    pub code_id: u64,
+}
+
+impl Msg for MsgStoreCodeResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgStoreCodeResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgStoreCodeResponse> for MsgStoreCodeResponse {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmwasm::wasm::v1::MsgStoreCodeResponse,
+    ) -> Result<MsgStoreCodeResponse> {
+        Ok(MsgStoreCodeResponse {
+            code_id: proto.code_id,
+        })
+    }
+}
+
+impl From<MsgStoreCodeResponse> for proto::cosmwasm::wasm::v1::MsgStoreCodeResponse {
+    fn from(msg: MsgStoreCodeResponse) -> proto::cosmwasm::wasm::v1::MsgStoreCodeResponse {
+        proto::cosmwasm::wasm::v1::MsgStoreCodeResponse {
+            code_id: msg.code_id,
+        }
+    }
+}
+
 /// MsgInstantiateContract create a new smart contract instance for the given
 /// code id.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -159,6 +190,47 @@ impl From<MsgInstantiateContract> for proto::cosmwasm::wasm::v1::MsgInstantiateC
     }
 }
 
+/// MsgInstantiateContractResponse return instantiation result data
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgInstantiateContractResponse {
+    /// Address is the bech32 address of the new contract instance.
+    pub address: AccountId,
+    /// Data contains base64-encoded bytes to returned from the contract
+    pub data: Vec<u8>,
+}
+
+impl Msg for MsgInstantiateContractResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse>
+    for MsgInstantiateContractResponse
+{
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse,
+    ) -> Result<MsgInstantiateContractResponse> {
+        Ok(MsgInstantiateContractResponse {
+            address: proto.address.parse()?,
+            data: proto.data,
+        })
+    }
+}
+
+impl From<MsgInstantiateContractResponse>
+    for proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse
+{
+    fn from(
+        msg: MsgInstantiateContractResponse,
+    ) -> proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse {
+        proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse {
+            address: msg.address.to_string(),
+            data: msg.data,
+        }
+    }
+}
+
 /// MsgExecuteContract submits the given message data to a smart contract
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MsgExecuteContract {
@@ -209,6 +281,35 @@ impl From<MsgExecuteContract> for proto::cosmwasm::wasm::v1::MsgExecuteContract 
     }
 }
 
+/// MsgExecuteContractResponse returns execution result data.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgExecuteContractResponse {
+    /// Data contains base64-encoded bytes to returned from the contract
+    pub data: Vec<u8>,
+}
+
+impl Msg for MsgExecuteContractResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgExecuteContractResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgExecuteContractResponse> for MsgExecuteContractResponse {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmwasm::wasm::v1::MsgExecuteContractResponse,
+    ) -> Result<MsgExecuteContractResponse> {
+        Ok(MsgExecuteContractResponse { data: proto.data })
+    }
+}
+
+impl From<MsgExecuteContractResponse> for proto::cosmwasm::wasm::v1::MsgExecuteContractResponse {
+    fn from(
+        msg: MsgExecuteContractResponse,
+    ) -> proto::cosmwasm::wasm::v1::MsgExecuteContractResponse {
+        proto::cosmwasm::wasm::v1::MsgExecuteContractResponse { data: msg.data }
+    }
+}
+
 /// MsgMigrateContract runs a code upgrade/ downgrade for a smart contract
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MsgMigrateContract {
@@ -252,6 +353,36 @@ impl From<MsgMigrateContract> for proto::cosmwasm::wasm::v1::MsgMigrateContract 
             code_id: msg.code_id,
             msg: msg.msg,
         }
+    }
+}
+
+/// MsgMigrateContractResponse returns contract migration result data.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgMigrateContractResponse {
+    /// Data contains same raw bytes returned as data from the wasm contract.
+    /// (May be empty)
+    pub data: Vec<u8>,
+}
+
+impl Msg for MsgMigrateContractResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgMigrateContractResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgMigrateContractResponse> for MsgMigrateContractResponse {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmwasm::wasm::v1::MsgMigrateContractResponse,
+    ) -> Result<MsgMigrateContractResponse> {
+        Ok(MsgMigrateContractResponse { data: proto.data })
+    }
+}
+
+impl From<MsgMigrateContractResponse> for proto::cosmwasm::wasm::v1::MsgMigrateContractResponse {
+    fn from(
+        msg: MsgMigrateContractResponse,
+    ) -> proto::cosmwasm::wasm::v1::MsgMigrateContractResponse {
+        proto::cosmwasm::wasm::v1::MsgMigrateContractResponse { data: msg.data }
     }
 }
 
@@ -308,6 +439,30 @@ impl From<&MsgUpdateAdmin> for proto::cosmwasm::wasm::v1::MsgUpdateAdmin {
     }
 }
 
+/// MsgUpdateAdminResponse returns empty data
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgUpdateAdminResponse {}
+
+impl Msg for MsgUpdateAdminResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse> for MsgUpdateAdminResponse {
+    type Error = ErrorReport;
+
+    fn try_from(
+        _proto: proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse,
+    ) -> Result<MsgUpdateAdminResponse> {
+        Ok(MsgUpdateAdminResponse {})
+    }
+}
+
+impl From<MsgUpdateAdminResponse> for proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse {
+    fn from(_msg: MsgUpdateAdminResponse) -> proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse {
+        proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse {}
+    }
+}
+
 /// MsgClearAdmin removes any admin stored for a smart contract
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MsgClearAdmin {
@@ -353,5 +508,29 @@ impl From<&MsgClearAdmin> for proto::cosmwasm::wasm::v1::MsgClearAdmin {
             sender: msg.sender.to_string(),
             contract: msg.contract.to_string(),
         }
+    }
+}
+
+/// MsgClearAdminResponse returns empty data
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MsgClearAdminResponse {}
+
+impl Msg for MsgClearAdminResponse {
+    type Proto = proto::cosmwasm::wasm::v1::MsgClearAdminResponse;
+}
+
+impl TryFrom<proto::cosmwasm::wasm::v1::MsgClearAdminResponse> for MsgClearAdminResponse {
+    type Error = ErrorReport;
+
+    fn try_from(
+        _proto: proto::cosmwasm::wasm::v1::MsgClearAdminResponse,
+    ) -> Result<MsgClearAdminResponse> {
+        Ok(MsgClearAdminResponse {})
+    }
+}
+
+impl From<MsgClearAdminResponse> for proto::cosmwasm::wasm::v1::MsgClearAdminResponse {
+    fn from(_msg: MsgClearAdminResponse) -> proto::cosmwasm::wasm::v1::MsgClearAdminResponse {
+        proto::cosmwasm::wasm::v1::MsgClearAdminResponse {}
     }
 }

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -18,11 +18,13 @@
 )]
 
 pub mod abci;
+pub mod auth;
 pub mod bank;
 pub mod crypto;
 pub mod distribution;
 pub mod staking;
 pub mod tx;
+pub mod vesting;
 
 #[cfg(feature = "cosmwasm")]
 pub mod cosmwasm;

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -17,6 +17,7 @@
     unused_import_braces
 )]
 
+pub mod abci;
 pub mod bank;
 pub mod crypto;
 pub mod distribution;

--- a/cosmrs/src/tx/msg.rs
+++ b/cosmrs/src/tx/msg.rs
@@ -93,6 +93,14 @@ impl MsgProto for proto::cosmos::staking::v1beta1::MsgBeginRedelegate {
     const TYPE_URL: &'static str = "/cosmos.staking.v1beta1.MsgBeginRedelegate";
 }
 
+impl MsgProto for proto::cosmos::base::abci::v1beta1::MsgData {
+    const TYPE_URL: &'static str = "/cosmos.base.v1beta1.abci.MsgData";
+}
+
+impl MsgProto for proto::cosmos::base::abci::v1beta1::TxMsgData {
+    const TYPE_URL: &'static str = "/cosmos.base.v1beta1.abci.TxMsgData";
+}
+
 #[cfg(feature = "cosmwasm")]
 impl MsgProto for proto::cosmwasm::wasm::v1::MsgStoreCode {
     const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgStoreCode";

--- a/cosmrs/src/tx/msg.rs
+++ b/cosmrs/src/tx/msg.rs
@@ -122,3 +122,33 @@ impl MsgProto for proto::cosmwasm::wasm::v1::MsgUpdateAdmin {
 impl MsgProto for proto::cosmwasm::wasm::v1::MsgClearAdmin {
     const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgClearAdmin";
 }
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgStoreCodeResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgStoreCodeResponse";
+}
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgInstantiateContractResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgInstantiateContractResponse";
+}
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgExecuteContractResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgExecuteContractResponse";
+}
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgMigrateContractResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgMigrateContractResponse";
+}
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgUpdateAdminResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgUpdateAdminResponse";
+}
+
+#[cfg(feature = "cosmwasm")]
+impl MsgProto for proto::cosmwasm::wasm::v1::MsgClearAdminResponse {
+    const TYPE_URL: &'static str = "/cosmwasm.wasm.v1.MsgClearAdminResponse";
+}

--- a/cosmrs/src/vesting.rs
+++ b/cosmrs/src/vesting.rs
@@ -1,0 +1,236 @@
+//! Vesting-related types
+
+use crate::auth::BaseAccount;
+use crate::Result;
+use crate::{proto, Coin, ErrorReport};
+
+/// BaseVestingAccount implements the VestingAccount interface. It contains all
+/// the necessary fields needed for any vesting account implementation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BaseVestingAccount {
+    pub base_account: Option<BaseAccount>,
+    pub original_vesting: Vec<Coin>,
+    pub delegated_free: Vec<Coin>,
+    pub delegated_vesting: Vec<Coin>,
+    pub end_time: i64,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::BaseVestingAccount> for BaseVestingAccount {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmos::vesting::v1beta1::BaseVestingAccount,
+    ) -> Result<BaseVestingAccount> {
+        Ok(BaseVestingAccount {
+            base_account: proto.base_account.map(TryFrom::try_from).transpose()?,
+            original_vesting: proto
+                .original_vesting
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+            delegated_free: proto
+                .delegated_free
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+            delegated_vesting: proto
+                .delegated_vesting
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+            end_time: proto.end_time,
+        })
+    }
+}
+
+impl From<BaseVestingAccount> for proto::cosmos::vesting::v1beta1::BaseVestingAccount {
+    fn from(account: BaseVestingAccount) -> Self {
+        proto::cosmos::vesting::v1beta1::BaseVestingAccount {
+            base_account: account.base_account.map(Into::into),
+            original_vesting: account
+                .original_vesting
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            delegated_free: account.delegated_free.into_iter().map(Into::into).collect(),
+            delegated_vesting: account
+                .delegated_vesting
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            end_time: account.end_time,
+        }
+    }
+}
+
+/// ContinuousVestingAccount implements the VestingAccount interface. It
+/// continuously vests by unlocking coins linearly with respect to time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContinuousVestingAccount {
+    pub base_vesting_account: Option<BaseVestingAccount>,
+    pub start_time: i64,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::ContinuousVestingAccount>
+    for ContinuousVestingAccount
+{
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmos::vesting::v1beta1::ContinuousVestingAccount,
+    ) -> Result<ContinuousVestingAccount> {
+        Ok(ContinuousVestingAccount {
+            base_vesting_account: proto
+                .base_vesting_account
+                .map(TryFrom::try_from)
+                .transpose()?,
+            start_time: proto.start_time,
+        })
+    }
+}
+
+impl From<ContinuousVestingAccount> for proto::cosmos::vesting::v1beta1::ContinuousVestingAccount {
+    fn from(account: ContinuousVestingAccount) -> Self {
+        proto::cosmos::vesting::v1beta1::ContinuousVestingAccount {
+            base_vesting_account: account.base_vesting_account.map(Into::into),
+            start_time: 0,
+        }
+    }
+}
+
+/// DelayedVestingAccount implements the VestingAccount interface. It vests all
+/// coins after a specific time, but non prior. In other words, it keeps them
+/// locked until a specified time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayedVestingAccount {
+    pub base_vesting_account: Option<BaseVestingAccount>,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::DelayedVestingAccount> for DelayedVestingAccount {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmos::vesting::v1beta1::DelayedVestingAccount,
+    ) -> Result<DelayedVestingAccount> {
+        Ok(DelayedVestingAccount {
+            base_vesting_account: proto
+                .base_vesting_account
+                .map(TryFrom::try_from)
+                .transpose()?,
+        })
+    }
+}
+
+impl From<DelayedVestingAccount> for proto::cosmos::vesting::v1beta1::DelayedVestingAccount {
+    fn from(account: DelayedVestingAccount) -> Self {
+        proto::cosmos::vesting::v1beta1::DelayedVestingAccount {
+            base_vesting_account: account.base_vesting_account.map(Into::into),
+        }
+    }
+}
+
+/// Period defines a length of time and amount of coins that will vest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Period {
+    pub length: i64,
+    pub amount: Vec<Coin>,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::Period> for Period {
+    type Error = ErrorReport;
+
+    fn try_from(proto: proto::cosmos::vesting::v1beta1::Period) -> Result<Period> {
+        Ok(Period {
+            length: proto.length,
+            amount: proto
+                .amount
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl From<Period> for proto::cosmos::vesting::v1beta1::Period {
+    fn from(period: Period) -> Self {
+        proto::cosmos::vesting::v1beta1::Period {
+            length: period.length,
+            amount: period.amount.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// PeriodicVestingAccount implements the VestingAccount interface. It
+/// periodically vests by unlocking coins during each specified period.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeriodicVestingAccount {
+    pub base_vesting_account: Option<BaseVestingAccount>,
+    pub start_time: i64,
+    pub vesting_periods: Vec<Period>,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::PeriodicVestingAccount> for PeriodicVestingAccount {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmos::vesting::v1beta1::PeriodicVestingAccount,
+    ) -> Result<PeriodicVestingAccount> {
+        Ok(PeriodicVestingAccount {
+            base_vesting_account: proto
+                .base_vesting_account
+                .map(TryFrom::try_from)
+                .transpose()?,
+            start_time: proto.start_time,
+            vesting_periods: proto
+                .vesting_periods
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl From<PeriodicVestingAccount> for proto::cosmos::vesting::v1beta1::PeriodicVestingAccount {
+    fn from(account: PeriodicVestingAccount) -> Self {
+        proto::cosmos::vesting::v1beta1::PeriodicVestingAccount {
+            base_vesting_account: account.base_vesting_account.map(Into::into),
+            start_time: account.start_time,
+            vesting_periods: account
+                .vesting_periods
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        }
+    }
+}
+
+/// PermanentLockedAccount implements the VestingAccount interface. It does
+/// not ever release coins, locking them indefinitely. Coins in this account can
+/// still be used for delegating and for governance votes even while locked.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PermanentLockedAccount {
+    pub base_vesting_account: Option<BaseVestingAccount>,
+}
+
+impl TryFrom<proto::cosmos::vesting::v1beta1::PermanentLockedAccount> for PermanentLockedAccount {
+    type Error = ErrorReport;
+
+    fn try_from(
+        proto: proto::cosmos::vesting::v1beta1::PermanentLockedAccount,
+    ) -> Result<PermanentLockedAccount> {
+        Ok(PermanentLockedAccount {
+            base_vesting_account: proto
+                .base_vesting_account
+                .map(TryFrom::try_from)
+                .transpose()?,
+        })
+    }
+}
+
+impl From<PermanentLockedAccount> for proto::cosmos::vesting::v1beta1::PermanentLockedAccount {
+    fn from(account: PermanentLockedAccount) -> Self {
+        proto::cosmos::vesting::v1beta1::PermanentLockedAccount {
+            base_vesting_account: account.base_vesting_account.map(Into::into),
+        }
+    }
+}

--- a/cosmrs/src/vesting.rs
+++ b/cosmrs/src/vesting.rs
@@ -8,10 +8,22 @@ use crate::{proto, Coin, ErrorReport};
 /// the necessary fields needed for any vesting account implementation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BaseVestingAccount {
+    /// [`BaseAccount`] specification of this vesting account.
     pub base_account: Option<BaseAccount>,
+
+    /// The amount of coins (per denomination) that are initially part of a vesting account.
+    /// These coins are set at genesis.
     pub original_vesting: Vec<Coin>,
+
+    /// The tracked amount of coins (per denomination) that are delegated from a vesting account
+    /// that have been fully vested at time of delegation.
     pub delegated_free: Vec<Coin>,
+
+    /// The tracked amount of coins (per denomination) that are delegated from a vesting account
+    /// that were vesting at time of delegation.
     pub delegated_vesting: Vec<Coin>,
+
+    /// The BFT time at which a vesting account is fully vested
     pub end_time: i64,
 }
 
@@ -67,7 +79,10 @@ impl From<BaseVestingAccount> for proto::cosmos::vesting::v1beta1::BaseVestingAc
 /// continuously vests by unlocking coins linearly with respect to time.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContinuousVestingAccount {
+    /// Base vesting account specification required for this vesting implementation.
     pub base_vesting_account: Option<BaseVestingAccount>,
+
+    /// The BFT time at which a vesting account starts to vest.
     pub start_time: i64,
 }
 
@@ -103,6 +118,7 @@ impl From<ContinuousVestingAccount> for proto::cosmos::vesting::v1beta1::Continu
 /// locked until a specified time.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelayedVestingAccount {
+    /// Base vesting account specification required for this vesting implementation.
     pub base_vesting_account: Option<BaseVestingAccount>,
 }
 
@@ -132,7 +148,10 @@ impl From<DelayedVestingAccount> for proto::cosmos::vesting::v1beta1::DelayedVes
 /// Period defines a length of time and amount of coins that will vest.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Period {
+    /// Length of this vesting period in seconds.
     pub length: i64,
+
+    /// The amount of coins (per denomination) that will vest upon this period finishing.
     pub amount: Vec<Coin>,
 }
 
@@ -164,8 +183,14 @@ impl From<Period> for proto::cosmos::vesting::v1beta1::Period {
 /// periodically vests by unlocking coins during each specified period.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PeriodicVestingAccount {
+    /// Base vesting account specification required for this vesting implementation.
     pub base_vesting_account: Option<BaseVestingAccount>,
+
+    /// The BFT time at which a vesting account starts to vest.
     pub start_time: i64,
+
+    /// Vesting [`Period`]s associated with this account. Periods are sequential,
+    /// in that the duration of a period only starts at the end of the previous period.
     pub vesting_periods: Vec<Period>,
 }
 
@@ -209,6 +234,7 @@ impl From<PeriodicVestingAccount> for proto::cosmos::vesting::v1beta1::PeriodicV
 /// still be used for delegating and for governance votes even while locked.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PermanentLockedAccount {
+    /// Base vesting account specification required for this vesting implementation.
     pub base_vesting_account: Option<BaseVestingAccount>,
 }
 


### PR DESCRIPTION
Hi!

I've added additional concrete types for things we already had defined in protobuf files, in particular `Response` types for various `cosmwasm` requests. But also for `MsgData` and `TxMsgData` from `abci`, for which I created a separate module in `cosmrs` crate. I was not entirely sure whether this was  the most appropriate place for it.

From the interesting bits, I've added the following bit to `MsgData` and `TxMsgData`:
```rust
impl MsgData {
    pub fn try_decode_as<M: Msg>(&self) -> Result<M> {
        M::Proto::decode(&*self.data)?.try_into()
    }
}

impl TryFrom<tendermint::abci::Data> for TxMsgData {
    type Error = ErrorReport;

    fn try_from(data: tendermint::abci::Data) -> Result<TxMsgData> {
        let proto = proto::cosmos::base::abci::v1beta1::TxMsgData::decode(data.value().as_ref())?;
        proto.try_into()
    }
}
```

those allow me more easily decode `data` fields from transaction results, for example as follows (which was my original motivation for creating this PR):
```rust
let tx_hash = "FFEE0EF6FE512F34536D2CAAEE2D854BC9465FA7ED4E1D8A63F15E24F26BD6C9".parse().unwrap();
let client = tendermint_rpc::HttpClient::new("http://localhost:26657").unwrap();
let tx = client.tx(tx_hash, false).await.unwrap();

let tx_msg_data = TxMsgData::try_from(tx.tx_result.data).unwrap();
let decoded_result: cosmwasm::MsgExecuteContractResponse = tx_msg_data.data[0].try_decode_as().unwrap();
// for completion sake that prints MsgExecuteContractResponse { data: [0, 0, 0, 0, 0, 0, 0, 1] } and the data is exactly what I expected to obtain
println!("{:?}", decoded_result);
```

Edit: I also added further modules: `auth` and `vesting` for handling different types of `Account`, such as `proto: proto::cosmos::auth::v1beta1::BaseAccount` or `proto::cosmos::vesting::v1beta1::BaseVestingAccount`
