### PR TITLE
cosmrs: enable more lints and test rustdoc in CI

### DIFF
--- a/.github/workflows/cosmrs.yml
+++ b/.github/workflows/cosmrs.yml
@@ -16,6 +16,7 @@ defaults:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
 
 jobs:
   build:
@@ -55,3 +56,14 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --all-features
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -3,6 +3,7 @@
     html_logo_url = "https://raw.githubusercontent.com/cosmos/cosmos-rust/main/.images/cosmos.png"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![allow(rustdoc::broken_intra_doc_links)]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 

--- a/cosmrs/src/dev.rs
+++ b/cosmrs/src/dev.rs
@@ -3,6 +3,8 @@
 //! This module contains support for integration testing against a
 //! Cosmos SDK-compatible full node (gaia) running inside of Docker.
 
+#![allow(clippy::panic)]
+
 use crate::{
     rpc::{self, Client},
     tx::{self, Tx},
@@ -80,7 +82,7 @@ pub async fn poll_for_first_block(rpc_client: &rpc::HttpClient) {
     rpc_client
         .wait_until_healthy(Duration::from_secs(5))
         .await
-        .unwrap();
+        .expect("error waiting for RPC to return healthy responses");
 
     let mut attempts_remaining = 25;
 

--- a/cosmrs/src/error.rs
+++ b/cosmrs/src/error.rs
@@ -57,6 +57,7 @@ pub enum Error {
         hash: tx::Hash,
     },
 
+    /// Invalid value for the given field of an enum.
     #[error("invalid proto enum value: {name:?}, value: {found_value:?}")]
     InvalidEnumValue {
         /// Name of the enum field

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -4,7 +4,18 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
-#![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+#![warn(
+    clippy::checked_conversions,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_import_braces
+)]
 
 pub mod bank;
 pub mod crypto;


### PR DESCRIPTION
Enables the following lints:

- `clippy::checked_conversions`
- `clippy::panic`
- `clippy::panic_in_result_fn`
- `clippy::unwrap_used`
- `missing_docs`
- `trivial_casts`
- `trivial_numeric_casts`
- `rust_2018_idioms`
- `unused_lifetimes`
- `unused_import_braces`

Also adds a `doc` job in CI that tests that rustdoc builds successfully without warnings.