### PR TITLE
Remove unneeded type parameter in SigningKey::derive_from_path

### DIFF
--- a/cosmrs/src/crypto/secp256k1/signing_key.rs
+++ b/cosmrs/src/crypto/secp256k1/signing_key.rs
@@ -49,7 +49,7 @@ impl SigningKey {
     /// therefore you can use `parse()` to parse it from a string.
     #[cfg(feature = "bip32")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bip32")))]
-    pub fn derive_from_path<S>(
+    pub fn derive_from_path(
         seed: impl AsRef<[u8]>,
         path: &bip32::DerivationPath,
     ) -> bip32::Result<Self> {


### PR DESCRIPTION
Fixes #242 

Implementing this fix allowed my crate to build.
Also, units tests using this function to derive private keys and then known addresses ([local testnet](https://docs.scrt.network/dev/LocalSecret.html#accounts)) now pass. 