### PR TITLE
cosmos-sdk-proto v0.12.3

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.3 (2022-06-09)
+### Added
+- Additional `cosmwasm` protos ([#240], [#244])
+
+[#240]: https://github.com/cosmos/cosmos-rust/pull/240
+[#244]: https://github.com/cosmos/cosmos-rust/pull/244
+
 ## 0.12.2 (2022-05-16)
 ### Added
 - `grpc-transport` crate feature ([#230])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.12.2"
+version = "0.12.3"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",


### PR DESCRIPTION
### Added
- Additional `cosmwasm` protos ([#240], [#244])

[#240]: https://github.com/cosmos/cosmos-rust/pull/240
[#244]: https://github.com/cosmos/cosmos-rust/pull/244