### PR TITLE
cosmrs v0.7.1

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2022-06-09)
+### Added
+- `abci`, `auth`, `cosmwasm`, and `vesting` type wrappers ([#234])
+- `bank::MsgMultiSend` support ([#237])
+
+### Fixed
+- Remove unneeded generic type parameter to `SigningKey::derive_from_path` ([#243])
+
+[#234]: https://github.com/cosmos/cosmos-rust/pull/234
+[#237]: https://github.com/cosmos/cosmos-rust/pull/237
+[#243]: https://github.com/cosmos/cosmos-rust/pull/243
+
 ## 0.7.0 (2022-05-02)
 ### Changed
 - Bump tendermint-rs crates to v0.23.7 ([#215])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Added
- `abci`, `auth`, `cosmwasm`, and `vesting` type wrappers ([#234])
- `bank::MsgMultiSend` support ([#237])

### Fixed
- Remove unneeded generic type parameter to `SigningKey::derive_from_path` ([#243])

[#234]: https://github.com/cosmos/cosmos-rust/pull/234
[#237]: https://github.com/cosmos/cosmos-rust/pull/237
[#243]: https://github.com/cosmos/cosmos-rust/pull/243