### PR TITLE
Bump tendermint-rs crates to v0.23.8

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.12.3"
+version = "0.13.0-pre"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",
@@ -18,7 +18,7 @@ rust-version = "1.56"
 [dependencies]
 prost = "0.10"
 prost-types = "0.10"
-tendermint-proto = "=0.23.7"
+tendermint-proto = "=0.23.8"
 
 # Optional dependencies
 tonic = { version = "0.7", optional = true, default-features = false, features = ["codegen", "prost"] }

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.7.1"
+version = "0.8.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
@@ -12,22 +12,22 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.12", default-features = false, path = "../cosmos-sdk-proto" }
-ecdsa = { version = "0.13", features = ["std"] }
+cosmos-sdk-proto = { version = "=0.13.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
-k256 = { version = "0.10", features = ["ecdsa", "sha256"] }
+k256 = { version = "0.11", features = ["ecdsa", "sha256"] }
 prost = "0.10"
 prost-types = "0.10"
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "=0.23.7", features = ["secp256k1"] }
+tendermint = { version = "=0.23.8", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
-bip32 = { version = "0.3", optional = true }
-tendermint-rpc = { version = "=0.23.7", optional = true, features = ["http-client"] }
+bip32 = { version = "0.4", optional = true }
+tendermint-rpc = { version = "=0.23.8", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
NOTE: work-in-progress, sources 0.23.8-pre.1 from git

This includes the following additional dependency upgrades:

- `k256` v0.11
- `ecdsa` v0.14