### PR TITLE
cosmrs: document re-exports

### DIFF
--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -17,6 +17,15 @@
     unused_import_braces
 )]
 
+//! ## Re-exports
+//!
+//! CosmRS re-exports the following crates for easy access:
+//!
+//! - `bip32`: re-exported as `cosmrs::bip32`
+//! - `cosmos-sdk-proto`: re-exported as `cosmrs::proto`
+//! - `tendermint`: re-exported as `cosmrs::tendermint`
+//! - `tendermint-rpc`: re-exported as `cosmrs::rpc` (requires `rpc` crate feature)
+
 pub mod abci;
 pub mod auth;
 pub mod bank;


### PR DESCRIPTION
The re-exports CosmRS provides are easily overlooked, and many downstream users explicitly include `cosmrs`, `cosmos-sdk-proto`, and `tendermint` in their Cargo.toml.

This documentation should help steer people towards using the re-exports.