### PR TITLE
cosmos-sdk-proto v0.13.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 (2022-07-25)
+### Added
+- gRPC server definitions ([#249])
+- Protobuf traits originally from `cosmrs` ([#255])
+
+### Changed
+- Bump `tendermint-proto` to v0.23.8 ([#253])
+
+[#249]: https://github.com/cosmos/cosmos-rust/pull/249
+[#253]: https://github.com/cosmos/cosmos-rust/pull/253
+[#255]: https://github.com/cosmos/cosmos-rust/pull/255
+
 ## 0.12.3 (2022-06-09)
 ### Added
 - Additional `cosmwasm` protos ([#240], [#244])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.13.0-pre"
+version = "0.13.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.13.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.13.0", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- gRPC server definitions ([#249])
- Protobuf traits originally from `cosmrs` ([#255])

### Changed
- Bump `tendermint-proto` to v0.23.8 ([#253])

[#249]: https://github.com/cosmos/cosmos-rust/pull/249
[#253]: https://github.com/cosmos/cosmos-rust/pull/253
[#255]: https://github.com/cosmos/cosmos-rust/pull/255