### PR TITLE
cosmrs v0.8.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2022-07-25)
+### Added
+- `feegrant` module support ([#250])
+- `grpc` features ([#258])
+
+### Changed
+- Changed internal `Coin` representation to `u128` ([#235])
+- Implemented `serde` traits for `Denom` ([#235])
+- Bump `k256` to v0.11 ([#253])
+- Bump tendermint-rs crates to v0.23.8 ([#253])
+- Move protobuf traits from `cosmrs` => `cosmos-sdk-proto` ([#255])
+- MSRV 1.57 ([#257])
+- Bump `cosmos-sdk-proto` to v0.13.0 ([#260])
+
+### Fixed
+- Visibility on `cosmwasm::ContractInfo` ([#247])
+
+### Removed
+- `Decimal` type ([#235])
+
+[#235]: https://github.com/cosmos/cosmos-rust/pull/235
+[#247]: https://github.com/cosmos/cosmos-rust/pull/247
+[#250]: https://github.com/cosmos/cosmos-rust/pull/250
+[#253]: https://github.com/cosmos/cosmos-rust/pull/253
+[#255]: https://github.com/cosmos/cosmos-rust/pull/255
+[#257]: https://github.com/cosmos/cosmos-rust/pull/257
+[#258]: https://github.com/cosmos/cosmos-rust/pull/258
+[#260]: https://github.com/cosmos/cosmos-rust/pull/260
+
 ## 0.7.1 (2022-06-09)
 ### Added
 - `abci`, `auth`, `cosmwasm`, and `vesting` type wrappers ([#234])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.8.0-pre"
+version = "0.8.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -134,10 +134,6 @@ pub struct Coin {
     pub denom: Denom,
 
     /// Amount
-    // represent coin amount as an u128, which theoretically supports lower maximum value than
-    // cosmos-sdk's `Int` that has a maximum value of 2^256 - 1. (https://github.com/cosmos/cosmos-sdk/blob/v0.45.4/types/int.go#L72-L74=)
-    // But I would argue this is sufficient for the current realistic use cases and is less cumbersome to use than the `Decimal`
-    // (which should have been used for a `DecCoin`)
     pub amount: u128,
 }
 
@@ -177,9 +173,7 @@ impl From<&Coin> for proto::cosmos::base::v1beta1::Coin {
 
 impl fmt::Display for Coin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Follow the same formatting without the space between amount and denom as
-        // Cosmwasm in their Coin, which is furthermore consistent with the cosmos-sdk:
-        // https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/types/coin.go#L643-L645
+        // See: https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/types/coin.go#L643-L645
         write!(f, "{}{}", self.amount, self.denom)
     }
 }
@@ -235,7 +229,7 @@ mod tests {
 
     #[test]
     fn account_id() {
-        let _id = "juno1cma4czt2jnydvrvz3lrc9jvcmhpjxtds95s3c6"
+        "juno1cma4czt2jnydvrvz3lrc9jvcmhpjxtds95s3c6"
             .parse::<AccountId>()
             .unwrap();
     }


### PR DESCRIPTION
### Added
- `feegrant` module support ([#250])
- `grpc` features ([#258])

### Changed
- Changed internal `Coin` representation to `u128` ([#235])
- Implemented `serde` traits for `Denom` ([#235])
- Bump `k256` to v0.11 ([#253])
- Bump tendermint-rs crates to v0.23.8 ([#253])
- Move protobuf traits from `cosmrs` => `cosmos-sdk-proto` ([#255])
- MSRV 1.57 ([#257])
- Bump `cosmos-sdk-proto` to v0.13.0 ([#260])

### Fixed
- Visibility on `cosmwasm::ContractInfo` ([#247])

### Removed
- `Decimal` type ([#235])

[#235]: https://github.com/cosmos/cosmos-rust/pull/235
[#247]: https://github.com/cosmos/cosmos-rust/pull/247
[#250]: https://github.com/cosmos/cosmos-rust/pull/250
[#253]: https://github.com/cosmos/cosmos-rust/pull/253
[#255]: https://github.com/cosmos/cosmos-rust/pull/255
[#257]: https://github.com/cosmos/cosmos-rust/pull/257
[#258]: https://github.com/cosmos/cosmos-rust/pull/258
[#260]: https://github.com/cosmos/cosmos-rust/pull/260