### PR TITLE
cosmos-sdk-proto: remove `pub` from `mod type_urls`

### DIFF
--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 
 pub mod traits;
-pub mod type_urls;
+mod type_urls;
 
 pub use prost;
 pub use prost_types::Any;


### PR DESCRIPTION
This module contains only trait impls and is therefore empty. It was mistakenly made `pub`.