### PR TITLE
Fix prefix address checks

### DIFF
--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -25,8 +25,7 @@ impl AccountId {
     pub fn new(prefix: &str, bytes: &[u8]) -> Result<Self> {
         let id = bech32::encode(prefix, &bytes);
 
-        // TODO(tarcieri): ensure this is the proper validation for an account prefix
-        if !prefix.chars().all(|c| matches!(c, 'a'..='z')) {
+        if !prefix.chars().all(|c| matches!(c, '!'..='@' | 'A'..='Z' | '['..='`' | 'a'..='z' | '{'..='~')) {
             return Err(Error::AccountId { id })
                 .wrap_err("expected prefix to be lowercase alphabetical characters only");
         }

--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -234,6 +234,13 @@ mod tests {
     }
 
     #[test]
+    fn account_id_with_digit() {
+        "okp41urdh3smlstyafjtyg0d606egllhwp8kvnw0d2f"
+            .parse::<AccountId>()
+            .unwrap();
+    }
+
+    #[test]
     fn denom_from_str() {
         assert!(
             "ibc/9F53D255F5320A4BE124FF20C29D46406E126CE8A09B00CA8D3CFF7905119728"

--- a/cosmrs/src/base.rs
+++ b/cosmrs/src/base.rs
@@ -25,9 +25,12 @@ impl AccountId {
     pub fn new(prefix: &str, bytes: &[u8]) -> Result<Self> {
         let id = bech32::encode(prefix, &bytes);
 
-        if !prefix.chars().all(|c| matches!(c, '!'..='@' | 'A'..='Z' | '['..='`' | 'a'..='z' | '{'..='~')) {
+        if !prefix
+            .chars()
+            .all(|c| matches!(c, '!'..='@' | 'A'..='Z' | '['..='`' | 'a'..='z' | '{'..='~'))
+        {
             return Err(Error::AccountId { id })
-                .wrap_err("expected prefix to be lowercase alphabetical characters only");
+                .wrap_err("expected prefix to be an US_ASCII characters with each character having a value in the range [33-126]");
         }
 
         if matches!(bytes.len(), 1..=MAX_ADDRESS_LENGTH) {


### PR DESCRIPTION
Based on the [bech32 specification](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32), address prefix must contain 1 to 83 US-ASCII characters, with each character having a value in the range [33-126]. 

Following subtle-encoding [implementation](https://docs.rs/subtle-encoding/latest/src/subtle_encoding/bech32.rs.html#192-197) of bech32, we have fixed the prefix verification when create a new `AccountId` according to this spec. 