### PR TITLE
Update tendermint-proto dependency to a version that works on wasmd

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 [dependencies]
 prost = "0.10"
 prost-types = "0.10"
-tendermint-proto = "=0.23.8"
+tendermint-proto = "=0.23.9"
 
 # Optional dependencies
 tonic = { version = "0.7", optional = true, default-features = false, features = ["codegen", "prost"] }


### PR DESCRIPTION
The current version of tendermint-proto used by cosmos-sdk-proto has a bad dependency that causes cosmwasm contracts that use cosmos-sdk-proto to not be allowed by wasmd. See https://github.com/informalsystems/tendermint-rs/blob/main/.changelog/v0.23.9/summary.md for the changelog and https://github.com/osmosis-labs/swaprouter/pull/1 for more details about the issue. 

Upgrading a minor version of the dependency fixes this. 