### PR TITLE
cosmos-sdk-proto: fix type name clash in cosmos.staking.v1beta1.rs

### DIFF
--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
@@ -2281,27 +2281,27 @@ pub struct StakeAuthorization {
     #[prost(enumeration="AuthorizationType", tag="4")]
     pub authorization_type: i32,
     /// validators is the oneof that represents either allow_list or deny_list
-    #[prost(oneof="stake_authorization::IsStakeAuthorizationValidators", tags="2, 3")]
-    pub validators: ::core::option::Option<stake_authorization::IsStakeAuthorizationValidators>,
+    #[prost(oneof="stake_authorization::Policy", tags="2, 3")]
+    pub validators: ::core::option::Option<stake_authorization::Policy>,
 }
 /// Nested message and enum types in `StakeAuthorization`.
 pub mod stake_authorization {
     /// Validators defines list of validator addresses.
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct StakeAuthorizationValidators {
+    pub struct Validators {
         #[prost(string, repeated, tag="1")]
         pub address: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
     /// validators is the oneof that represents either allow_list or deny_list
     #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum IsStakeAuthorizationValidators {
+    pub enum Policy {
         /// allow_list specifies list of validator addresses to whom grantee can delegate tokens on behalf of granter's
         /// account.
         #[prost(message, tag="2")]
-        AllowList(StakeAuthorizationValidators),
+        AllowList(Validators),
         /// deny_list specifies list of validator addresses to whom grantee can not delegate tokens.
         #[prost(message, tag="3")]
-        DenyList(StakeAuthorizationValidators),
+        DenyList(Validators),
     }
 }
 /// AuthorizationType defines the type of staking module authorization type


### PR DESCRIPTION
The prost-generated `stake_authorization` module contains clashing `struct Validators` and `enum Validators` owning to a `oneof` on a field named `validators`. See #154.

We've been patching this by hand for quite some time, and this PR finally automates the process, implementing the solution suggested upstream at cosmos/cosmos-sdk#12316:

- Renames `enum Validators` to `enum Policy`(formerly `IsStakeAuthorizationValidators`)
- Retains `struct Validators` as-is, as this matches the `message` defined in the schema.