### PR TITLE
Bump tendermint-rs crates to v0.23.9

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.13.0"
+version = "0.14.0-pre"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-prost = "0.10"
-prost-types = "0.10"
-tendermint-proto = "=0.23.8"
+prost = "0.11"
+prost-types = "0.11"
+tendermint-proto = "=0.23.9"
 
 # Optional dependencies
-tonic = { version = "0.7", optional = true, default-features = false, features = ["codegen", "prost"] }
+tonic = { version = "0.8", optional = true, default-features = false, features = ["codegen", "prost"] }
 
 [features]
 default = ["grpc-transport"]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
@@ -88,6 +88,7 @@ pub struct QueryParamsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -117,6 +118,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -136,19 +141,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Accounts returns all the existing accounts
@@ -246,8 +251,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -270,6 +275,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -437,9 +454,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.auth.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
@@ -85,6 +85,7 @@ pub struct MsgRevokeResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the authz Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -114,6 +115,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -133,19 +138,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Grant grants the provided authorization to the grantee on the granter's
@@ -251,8 +256,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -275,6 +280,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -438,9 +455,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.authz.v1beta1.Msg";
     }
 }
@@ -512,6 +527,7 @@ pub struct QueryGranteeGrantsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -541,6 +557,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -560,19 +580,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Returns list of `Authorization`, granted to the grantee by the granter.
@@ -674,8 +694,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -698,6 +718,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -869,9 +901,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.authz.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
@@ -117,6 +117,7 @@ pub struct MsgMultiSendResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the bank Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -146,6 +147,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -165,19 +170,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Send defines a method for sending coins from one account to another account.
@@ -246,8 +251,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -270,6 +275,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -397,9 +414,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.bank.v1beta1.Msg";
     }
 }
@@ -549,6 +564,7 @@ pub struct QueryDenomMetadataResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -578,6 +594,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -597,19 +617,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Balance queries the balance of a single coin for a single account.
@@ -658,9 +678,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySpendableBalancesRequest>,
         ) -> Result<
-            tonic::Response<super::QuerySpendableBalancesResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QuerySpendableBalancesResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -803,9 +823,9 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QuerySpendableBalancesRequest>,
         ) -> Result<
-            tonic::Response<super::QuerySpendableBalancesResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QuerySpendableBalancesResponse>,
+                tonic::Status,
+            >;
         /// TotalSupply queries the total supply of all coins.
         async fn total_supply(
             &self,
@@ -836,8 +856,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -860,6 +880,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -1227,9 +1259,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.bank.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.query.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.query.v1beta1.rs
@@ -1,10 +1,10 @@
 /// PageRequest is to be embedded in gRPC request messages for efficient
 /// pagination. Ex:
 ///
-///  message SomeRequest {
-///          Foo some_parameter = 1;
-///          PageRequest pagination = 2;
-///  }
+///   message SomeRequest {
+///           Foo some_parameter = 1;
+///           PageRequest pagination = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageRequest {
     /// key is a value returned in PageResponse.next_key to begin
@@ -36,10 +36,10 @@ pub struct PageRequest {
 /// PageResponse is to be embedded in gRPC response messages where the
 /// corresponding request message has used PageRequest.
 ///
-///  message SomeResponse {
-///          repeated Bar results = 1;
-///          PageResponse page = 2;
-///  }
+///   message SomeResponse {
+///           repeated Bar results = 1;
+///           PageResponse page = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageResponse {
     /// next_key is the key to be passed to PageRequest.key to

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.rs
@@ -30,6 +30,7 @@ pub struct ListImplementationsResponse {
 pub mod reflection_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ReflectionService defines a service for interface reflection.
     #[derive(Debug, Clone)]
     pub struct ReflectionServiceClient<T> {
@@ -59,6 +60,10 @@ pub mod reflection_service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -78,19 +83,19 @@ pub mod reflection_service_client {
         {
             ReflectionServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// ListAllInterfaces lists all the interfaces registered in the interface
@@ -163,8 +168,8 @@ pub mod reflection_service_server {
     #[derive(Debug)]
     pub struct ReflectionServiceServer<T: ReflectionService> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: ReflectionService> ReflectionServiceServer<T> {
@@ -187,6 +192,18 @@ pub mod reflection_service_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ReflectionServiceServer<T>
@@ -322,9 +339,7 @@ pub mod reflection_service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: ReflectionService> tonic::transport::NamedService
+    impl<T: ReflectionService> tonic::server::NamedService
     for ReflectionServiceServer<T> {
         const NAME: &'static str = "cosmos.base.reflection.v1beta1.ReflectionService";
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.rs
@@ -232,6 +232,7 @@ pub struct QueryMethodDescriptor {
 pub mod reflection_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ReflectionService defines a service for application reflection.
     #[derive(Debug, Clone)]
     pub struct ReflectionServiceClient<T> {
@@ -261,6 +262,10 @@ pub mod reflection_service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -280,19 +285,19 @@ pub mod reflection_service_client {
         {
             ReflectionServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// GetAuthnDescriptor returns information on how to authenticate transactions in the application
@@ -362,9 +367,9 @@ pub mod reflection_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetConfigurationDescriptorRequest>,
         ) -> Result<
-            tonic::Response<super::GetConfigurationDescriptorResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::GetConfigurationDescriptorResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -385,9 +390,9 @@ pub mod reflection_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetQueryServicesDescriptorRequest>,
         ) -> Result<
-            tonic::Response<super::GetQueryServicesDescriptorResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::GetQueryServicesDescriptorResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -456,17 +461,17 @@ pub mod reflection_service_server {
             &self,
             request: tonic::Request<super::GetConfigurationDescriptorRequest>,
         ) -> Result<
-            tonic::Response<super::GetConfigurationDescriptorResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::GetConfigurationDescriptorResponse>,
+                tonic::Status,
+            >;
         /// GetQueryServicesDescriptor returns the available gRPC queryable services of the application
         async fn get_query_services_descriptor(
             &self,
             request: tonic::Request<super::GetQueryServicesDescriptorRequest>,
         ) -> Result<
-            tonic::Response<super::GetQueryServicesDescriptorResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::GetQueryServicesDescriptorResponse>,
+                tonic::Status,
+            >;
         /// GetTxDescriptor returns information on the used transaction object and available msgs that can be used
         async fn get_tx_descriptor(
             &self,
@@ -477,8 +482,8 @@ pub mod reflection_service_server {
     #[derive(Debug)]
     pub struct ReflectionServiceServer<T: ReflectionService> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: ReflectionService> ReflectionServiceServer<T> {
@@ -501,6 +506,18 @@ pub mod reflection_service_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ReflectionServiceServer<T>
@@ -806,9 +823,7 @@ pub mod reflection_service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: ReflectionService> tonic::transport::NamedService
+    impl<T: ReflectionService> tonic::server::NamedService
     for ReflectionServiceServer<T> {
         const NAME: &'static str = "cosmos.base.reflection.v2alpha1.ReflectionService";
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
@@ -136,6 +136,7 @@ pub struct Module {
 pub mod service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Service defines the gRPC querier service for tendermint queries.
     #[derive(Debug, Clone)]
     pub struct ServiceClient<T> {
@@ -165,6 +166,10 @@ pub mod service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -184,19 +189,19 @@ pub mod service_client {
         {
             ServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// GetNodeInfo queries the current node info.
@@ -284,9 +289,9 @@ pub mod service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetLatestValidatorSetRequest>,
         ) -> Result<
-            tonic::Response<super::GetLatestValidatorSetResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::GetLatestValidatorSetResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -307,9 +312,9 @@ pub mod service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetValidatorSetByHeightRequest>,
         ) -> Result<
-            tonic::Response<super::GetValidatorSetByHeightResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::GetValidatorSetByHeightResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -361,24 +366,24 @@ pub mod service_server {
             &self,
             request: tonic::Request<super::GetLatestValidatorSetRequest>,
         ) -> Result<
-            tonic::Response<super::GetLatestValidatorSetResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::GetLatestValidatorSetResponse>,
+                tonic::Status,
+            >;
         /// GetValidatorSetByHeight queries validator-set at a given height.
         async fn get_validator_set_by_height(
             &self,
             request: tonic::Request<super::GetValidatorSetByHeightRequest>,
         ) -> Result<
-            tonic::Response<super::GetValidatorSetByHeightResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::GetValidatorSetByHeightResponse>,
+                tonic::Status,
+            >;
     }
     /// Service defines the gRPC querier service for tendermint queries.
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Service> ServiceServer<T> {
@@ -401,6 +406,18 @@ pub mod service_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ServiceServer<T>
@@ -696,9 +713,7 @@ pub mod service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Service> tonic::transport::NamedService for ServiceServer<T> {
+    impl<T: Service> tonic::server::NamedService for ServiceServer<T> {
         const NAME: &'static str = "cosmos.base.tendermint.v1beta1.Service";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
@@ -18,6 +18,7 @@ pub struct MsgVerifyInvariantResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the bank Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -47,6 +48,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -66,19 +71,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// VerifyInvariant defines a method to verify a particular invariance.
@@ -122,8 +127,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -146,6 +151,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -239,9 +256,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.crisis.v1beta1.Msg";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
@@ -54,6 +54,7 @@ pub struct MsgFundCommunityPoolResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the distribution Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -83,6 +84,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -102,19 +107,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// SetWithdrawAddress defines a method to change the withdraw address
@@ -123,9 +128,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSetWithdrawAddress>,
         ) -> Result<
-            tonic::Response<super::MsgSetWithdrawAddressResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgSetWithdrawAddressResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -147,9 +152,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgWithdrawDelegatorReward>,
         ) -> Result<
-            tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -171,9 +176,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgWithdrawValidatorCommission>,
         ) -> Result<
-            tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -195,9 +200,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgFundCommunityPool>,
         ) -> Result<
-            tonic::Response<super::MsgFundCommunityPoolResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgFundCommunityPoolResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -230,27 +235,27 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgSetWithdrawAddress>,
         ) -> Result<
-            tonic::Response<super::MsgSetWithdrawAddressResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::MsgSetWithdrawAddressResponse>,
+                tonic::Status,
+            >;
         /// WithdrawDelegatorReward defines a method to withdraw rewards of delegator
         /// from a single validator.
         async fn withdraw_delegator_reward(
             &self,
             request: tonic::Request<super::MsgWithdrawDelegatorReward>,
         ) -> Result<
-            tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
+                tonic::Status,
+            >;
         /// WithdrawValidatorCommission defines a method to withdraw the
         /// full commission to the validator address.
         async fn withdraw_validator_commission(
             &self,
             request: tonic::Request<super::MsgWithdrawValidatorCommission>,
         ) -> Result<
-            tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
+                tonic::Status,
+            >;
         /// FundCommunityPool defines a method to allow an account to directly
         /// fund the community pool.
         async fn fund_community_pool(
@@ -262,8 +267,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -286,6 +291,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -501,9 +518,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.distribution.v1beta1.Msg";
     }
 }
@@ -526,11 +541,11 @@ pub struct Params {
 /// The reference count indicates the number of objects
 /// which might need to reference this historical entry at any point.
 /// ReferenceCount =
-///    number of outstanding delegations which ended the associated period (and
-///    might need to read that record)
-///  + number of slashes which ended the associated period (and might need to
-///  read that record)
-///  + one per validator for the zeroeth period, set on initialization
+///     number of outstanding delegations which ended the associated period (and
+///     might need to read that record)
+///   + number of slashes which ended the associated period (and might need to
+///   read that record)
+///   + one per validator for the zeroeth period, set on initialization
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorHistoricalRewards {
     #[prost(message, repeated, tag="1")]
@@ -797,6 +812,7 @@ pub struct QueryCommunityPoolResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service for distribution module.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -826,6 +842,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -845,19 +865,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params queries params of the distribution module.
@@ -887,9 +907,9 @@ pub mod query_client {
                 super::QueryValidatorOutstandingRewardsRequest,
             >,
         ) -> Result<
-            tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -910,9 +930,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorCommissionRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorCommissionResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryValidatorCommissionResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -933,9 +953,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorSlashesRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorSlashesResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryValidatorSlashesResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -956,9 +976,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationRewardsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegationRewardsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegationRewardsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -980,9 +1000,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationTotalRewardsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegationTotalRewardsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegationTotalRewardsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1003,9 +1023,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorValidatorsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1026,9 +1046,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorWithdrawAddressRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1085,58 +1105,58 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryValidatorOutstandingRewardsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
+                tonic::Status,
+            >;
         /// ValidatorCommission queries accumulated commission for a validator.
         async fn validator_commission(
             &self,
             request: tonic::Request<super::QueryValidatorCommissionRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorCommissionResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryValidatorCommissionResponse>,
+                tonic::Status,
+            >;
         /// ValidatorSlashes queries slash events of a validator.
         async fn validator_slashes(
             &self,
             request: tonic::Request<super::QueryValidatorSlashesRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorSlashesResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryValidatorSlashesResponse>,
+                tonic::Status,
+            >;
         /// DelegationRewards queries the total rewards accrued by a delegation.
         async fn delegation_rewards(
             &self,
             request: tonic::Request<super::QueryDelegationRewardsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegationRewardsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegationRewardsResponse>,
+                tonic::Status,
+            >;
         /// DelegationTotalRewards queries the total rewards accrued by a each
         /// validator.
         async fn delegation_total_rewards(
             &self,
             request: tonic::Request<super::QueryDelegationTotalRewardsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegationTotalRewardsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegationTotalRewardsResponse>,
+                tonic::Status,
+            >;
         /// DelegatorValidators queries the validators of a delegator.
         async fn delegator_validators(
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorValidatorsResponse>,
+                tonic::Status,
+            >;
         /// DelegatorWithdrawAddress queries withdraw address of a delegator.
         async fn delegator_withdraw_address(
             &self,
             request: tonic::Request<super::QueryDelegatorWithdrawAddressRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
+                tonic::Status,
+            >;
         /// CommunityPool queries the community pool coins.
         async fn community_pool(
             &self,
@@ -1147,8 +1167,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -1171,6 +1191,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -1595,9 +1627,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.distribution.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
@@ -20,6 +20,7 @@ pub struct MsgSubmitEvidenceResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the evidence Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -49,6 +50,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -68,19 +73,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// SubmitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or
@@ -126,8 +131,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -150,6 +155,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -243,9 +260,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.evidence.v1beta1.Msg";
     }
 }
@@ -301,6 +316,7 @@ pub struct QueryAllEvidenceResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -330,6 +346,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -349,19 +369,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Evidence queries evidence based on evidence hash.
@@ -430,8 +450,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -454,6 +474,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -587,9 +619,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.evidence.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.rs
@@ -36,6 +36,7 @@ pub struct MsgRevokeAllowanceResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the feegrant msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -65,6 +66,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -84,19 +89,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// GrantAllowance grants fee allowance to the grantee on the granter's
@@ -169,8 +174,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -193,6 +198,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -324,9 +341,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.feegrant.v1beta1.Msg";
     }
 }
@@ -432,6 +447,7 @@ pub struct QueryAllowancesResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -461,6 +477,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -480,19 +500,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Allowance returns fee granted to the grantee by the granter.
@@ -561,8 +581,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -585,6 +605,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -716,9 +748,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.feegrant.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
@@ -83,33 +83,33 @@ pub struct Vote {
 /// DepositParams defines the params for deposits on governance proposals.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DepositParams {
-    ///  Minimum deposit for a proposal to enter voting period.
+    ///   Minimum deposit for a proposal to enter voting period.
     #[prost(message, repeated, tag="1")]
     pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    ///  Maximum period for Atom holders to deposit on a proposal. Initial value: 2
-    ///  months.
+    ///   Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    ///   months.
     #[prost(message, optional, tag="2")]
     pub max_deposit_period: ::core::option::Option<::prost_types::Duration>,
 }
 /// VotingParams defines the params for voting on governance proposals.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VotingParams {
-    ///  Length of the voting period.
+    ///   Length of the voting period.
     #[prost(message, optional, tag="1")]
     pub voting_period: ::core::option::Option<::prost_types::Duration>,
 }
 /// TallyParams defines the params for tallying votes on governance proposals.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TallyParams {
-    ///  Minimum percentage of total stake needed to vote for a result to be
-    ///  considered valid.
+    ///   Minimum percentage of total stake needed to vote for a result to be
+    ///   considered valid.
     #[prost(bytes="vec", tag="1")]
     pub quorum: ::prost::alloc::vec::Vec<u8>,
-    ///  Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    ///   Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
     #[prost(bytes="vec", tag="2")]
     pub threshold: ::prost::alloc::vec::Vec<u8>,
-    ///  Minimum value of Veto votes to Total votes ratio for proposal to be
-    ///  vetoed. Default value: 1/3.
+    ///   Minimum value of Veto votes to Total votes ratio for proposal to be
+    ///   vetoed. Default value: 1/3.
     #[prost(bytes="vec", tag="3")]
     pub veto_threshold: ::prost::alloc::vec::Vec<u8>,
 }
@@ -127,6 +127,21 @@ pub enum VoteOption {
     No = 3,
     /// VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
     NoWithVeto = 4,
+}
+impl VoteOption {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            VoteOption::Unspecified => "VOTE_OPTION_UNSPECIFIED",
+            VoteOption::Yes => "VOTE_OPTION_YES",
+            VoteOption::Abstain => "VOTE_OPTION_ABSTAIN",
+            VoteOption::No => "VOTE_OPTION_NO",
+            VoteOption::NoWithVeto => "VOTE_OPTION_NO_WITH_VETO",
+        }
+    }
 }
 /// ProposalStatus enumerates the valid statuses of a proposal.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -149,6 +164,22 @@ pub enum ProposalStatus {
     /// PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
     /// failed.
     Failed = 5,
+}
+impl ProposalStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ProposalStatus::Unspecified => "PROPOSAL_STATUS_UNSPECIFIED",
+            ProposalStatus::DepositPeriod => "PROPOSAL_STATUS_DEPOSIT_PERIOD",
+            ProposalStatus::VotingPeriod => "PROPOSAL_STATUS_VOTING_PERIOD",
+            ProposalStatus::Passed => "PROPOSAL_STATUS_PASSED",
+            ProposalStatus::Rejected => "PROPOSAL_STATUS_REJECTED",
+            ProposalStatus::Failed => "PROPOSAL_STATUS_FAILED",
+        }
+    }
 }
 /// MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
 /// proposal Content.
@@ -219,6 +250,7 @@ pub struct MsgDepositResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the bank Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -248,6 +280,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -267,19 +303,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// SubmitProposal defines a method to create new proposal given a content.
@@ -402,8 +438,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -426,6 +462,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -629,9 +677,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.gov.v1beta1.Msg";
     }
 }
@@ -788,6 +834,7 @@ pub struct QueryTallyResultResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service for gov module
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -817,6 +864,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -836,19 +887,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Proposal queries proposal details based on ProposalID.
@@ -1067,8 +1118,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -1091,6 +1142,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -1446,9 +1509,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.gov.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
@@ -72,6 +72,7 @@ pub struct QueryAnnualProvisionsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -101,6 +102,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -120,19 +125,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params returns the total set of minting parameters.
@@ -180,9 +185,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAnnualProvisionsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryAnnualProvisionsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryAnnualProvisionsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -224,16 +229,16 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryAnnualProvisionsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryAnnualProvisionsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryAnnualProvisionsResponse>,
+                tonic::Status,
+            >;
     }
     /// Query provides defines the gRPC querier service.
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -256,6 +261,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -425,9 +442,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.mint.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.rs
@@ -42,6 +42,7 @@ pub struct QueryParamsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -71,6 +72,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -90,19 +95,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params queries a specific parameter of a module, given its subspace and
@@ -148,8 +153,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -172,6 +177,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -263,9 +280,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.params.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
@@ -14,6 +14,7 @@ pub struct MsgUnjailResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the slashing Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -43,6 +44,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -62,19 +67,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Unjail defines a method for unjailing a jailed validator, thus returning
@@ -122,8 +127,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -146,6 +151,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -237,9 +254,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.slashing.v1beta1.Msg";
     }
 }
@@ -332,6 +347,7 @@ pub struct QuerySigningInfosResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -361,6 +377,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -380,19 +400,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params queries the parameters of slashing module
@@ -486,8 +506,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -510,6 +530,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -681,9 +713,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.slashing.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
@@ -289,6 +289,20 @@ pub enum BondStatus {
     /// BONDED defines a validator that is bonded.
     Bonded = 3,
 }
+impl BondStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            BondStatus::Unspecified => "BOND_STATUS_UNSPECIFIED",
+            BondStatus::Unbonded => "BOND_STATUS_UNBONDED",
+            BondStatus::Unbonding => "BOND_STATUS_UNBONDING",
+            BondStatus::Bonded => "BOND_STATUS_BONDED",
+        }
+    }
+}
 /// MsgCreateValidator defines a SDK message for creating a new validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCreateValidator {
@@ -388,6 +402,7 @@ pub struct MsgUndelegateResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the staking Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -417,6 +432,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -436,19 +455,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// CreateValidator defines a method for creating a new validator.
@@ -598,8 +617,8 @@ pub mod msg_server {
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -622,6 +641,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -863,9 +894,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.staking.v1beta1.Msg";
     }
 }
@@ -1136,6 +1165,7 @@ pub struct QueryParamsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -1165,6 +1195,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -1184,19 +1218,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Validators queries all validators that match the given status.
@@ -1244,9 +1278,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorDelegationsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryValidatorDelegationsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1269,9 +1303,9 @@ pub mod query_client {
                 super::QueryValidatorUnbondingDelegationsRequest,
             >,
         ) -> Result<
-            tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1313,9 +1347,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUnbondingDelegationRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUnbondingDelegationResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryUnbondingDelegationResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1336,9 +1370,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorDelegationsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorDelegationsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1362,9 +1396,9 @@ pub mod query_client {
                 super::QueryDelegatorUnbondingDelegationsRequest,
             >,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1406,9 +1440,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorValidatorsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1430,9 +1464,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryDelegatorValidatorResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1534,17 +1568,17 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryValidatorDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorDelegationsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryValidatorDelegationsResponse>,
+                tonic::Status,
+            >;
         /// ValidatorUnbondingDelegations queries unbonding delegations of a validator.
         async fn validator_unbonding_delegations(
             &self,
             request: tonic::Request<super::QueryValidatorUnbondingDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
+                tonic::Status,
+            >;
         /// Delegation queries delegate info for given validator delegator pair.
         async fn delegation(
             &self,
@@ -1556,26 +1590,26 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryUnbondingDelegationRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUnbondingDelegationResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryUnbondingDelegationResponse>,
+                tonic::Status,
+            >;
         /// DelegatorDelegations queries all delegations of a given delegator address.
         async fn delegator_delegations(
             &self,
             request: tonic::Request<super::QueryDelegatorDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorDelegationsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorDelegationsResponse>,
+                tonic::Status,
+            >;
         /// DelegatorUnbondingDelegations queries all unbonding delegations of a given
         /// delegator address.
         async fn delegator_unbonding_delegations(
             &self,
             request: tonic::Request<super::QueryDelegatorUnbondingDelegationsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
+                tonic::Status,
+            >;
         /// Redelegations queries redelegations of given address.
         async fn redelegations(
             &self,
@@ -1587,18 +1621,18 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorsResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorValidatorsResponse>,
+                tonic::Status,
+            >;
         /// DelegatorValidator queries validator info for given delegator validator
         /// pair.
         async fn delegator_validator(
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorRequest>,
         ) -> Result<
-            tonic::Response<super::QueryDelegatorValidatorResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryDelegatorValidatorResponse>,
+                tonic::Status,
+            >;
         /// HistoricalInfo queries the historical info for given height.
         async fn historical_info(
             &self,
@@ -1619,8 +1653,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -1643,6 +1677,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -2262,9 +2308,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.staking.v1beta1.Query";
     }
 }
@@ -2318,6 +2362,20 @@ pub enum AuthorizationType {
     Undelegate = 2,
     /// AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for Msg/BeginRedelegate
     Redelegate = 3,
+}
+impl AuthorizationType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            AuthorizationType::Unspecified => "AUTHORIZATION_TYPE_UNSPECIFIED",
+            AuthorizationType::Delegate => "AUTHORIZATION_TYPE_DELEGATE",
+            AuthorizationType::Undelegate => "AUTHORIZATION_TYPE_UNDELEGATE",
+            AuthorizationType::Redelegate => "AUTHORIZATION_TYPE_REDELEGATE",
+        }
+    }
 }
 /// GenesisState defines the staking module's genesis state.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.signing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.signing.v1beta1.rs
@@ -94,3 +94,18 @@ pub enum SignMode {
     /// Since: cosmos-sdk 0.45.2
     Eip191 = 191,
 }
+impl SignMode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SignMode::Unspecified => "SIGN_MODE_UNSPECIFIED",
+            SignMode::Direct => "SIGN_MODE_DIRECT",
+            SignMode::Textual => "SIGN_MODE_TEXTUAL",
+            SignMode::LegacyAminoJson => "SIGN_MODE_LEGACY_AMINO_JSON",
+            SignMode::Eip191 => "SIGN_MODE_EIP_191",
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
@@ -317,6 +317,19 @@ pub enum OrderBy {
     /// ORDER_BY_DESC defines descending order
     Desc = 2,
 }
+impl OrderBy {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            OrderBy::Unspecified => "ORDER_BY_UNSPECIFIED",
+            OrderBy::Asc => "ORDER_BY_ASC",
+            OrderBy::Desc => "ORDER_BY_DESC",
+        }
+    }
+}
 /// BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -333,12 +346,27 @@ pub enum BroadcastMode {
     /// immediately.
     Async = 3,
 }
+impl BroadcastMode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            BroadcastMode::Unspecified => "BROADCAST_MODE_UNSPECIFIED",
+            BroadcastMode::Block => "BROADCAST_MODE_BLOCK",
+            BroadcastMode::Sync => "BROADCAST_MODE_SYNC",
+            BroadcastMode::Async => "BROADCAST_MODE_ASYNC",
+        }
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
 pub mod service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Service defines a gRPC service for interacting with transactions.
     #[derive(Debug, Clone)]
     pub struct ServiceClient<T> {
@@ -368,6 +396,10 @@ pub mod service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -387,19 +419,19 @@ pub mod service_client {
         {
             ServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Simulate simulates executing a transaction for estimating gas usage.
@@ -547,8 +579,8 @@ pub mod service_server {
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Service> ServiceServer<T> {
@@ -571,6 +603,18 @@ pub mod service_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ServiceServer<T>
@@ -818,9 +862,7 @@ pub mod service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Service> tonic::transport::NamedService for ServiceServer<T> {
+    impl<T: Service> tonic::server::NamedService for ServiceServer<T> {
         const NAME: &'static str = "cosmos.tx.v1beta1.Service";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
@@ -137,6 +137,7 @@ pub struct QueryModuleVersionsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query defines the gRPC upgrade querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -166,6 +167,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -185,19 +190,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// CurrentPlan queries the current upgrade plan.
@@ -250,9 +255,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUpgradedConsensusStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUpgradedConsensusStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryUpgradedConsensusStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -321,9 +326,9 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryUpgradedConsensusStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUpgradedConsensusStateResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::QueryUpgradedConsensusStateResponse>,
+                tonic::Status,
+            >;
         /// ModuleVersions queries the list of module versions from state.
         ///
         /// Since: cosmos-sdk 0.43
@@ -336,8 +341,8 @@ pub mod query_server {
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Query> QueryServer<T> {
@@ -360,6 +365,18 @@ pub mod query_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
@@ -578,9 +595,7 @@ pub mod query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Query> tonic::transport::NamedService for QueryServer<T> {
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.upgrade.v1beta1.Query";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.rs
@@ -23,6 +23,7 @@ pub struct MsgCreateVestingAccountResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the bank Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -52,6 +53,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -71,19 +76,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// CreateVestingAccount defines a method that enables creating a vesting
@@ -92,9 +97,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateVestingAccount>,
         ) -> Result<
-            tonic::Response<super::MsgCreateVestingAccountResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgCreateVestingAccountResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -127,16 +132,16 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgCreateVestingAccount>,
         ) -> Result<
-            tonic::Response<super::MsgCreateVestingAccountResponse>,
-            tonic::Status,
-        >;
+                tonic::Response<super::MsgCreateVestingAccountResponse>,
+                tonic::Status,
+            >;
     }
     /// Msg defines the bank Msg service.
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Msg> MsgServer<T> {
@@ -159,6 +164,18 @@ pub mod msg_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
@@ -254,9 +271,7 @@ pub mod msg_server {
             write!(f, "{:?}", self.0)
         }
     }
-    #[cfg(feature = "grpc-transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "grpc-transport")))]
-    impl<T: Msg> tonic::transport::NamedService for MsgServer<T> {
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
         const NAME: &'static str = "cosmos.vesting.v1beta1.Msg";
     }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.query.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.query.v1beta1.rs
@@ -1,10 +1,10 @@
 /// PageRequest is to be embedded in gRPC request messages for efficient
 /// pagination. Ex:
 ///
-///  message SomeRequest {
-///          Foo some_parameter = 1;
-///          PageRequest pagination = 2;
-///  }
+///   message SomeRequest {
+///           Foo some_parameter = 1;
+///           PageRequest pagination = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageRequest {
     /// key is a value returned in PageResponse.next_key to begin
@@ -31,10 +31,10 @@ pub struct PageRequest {
 /// PageResponse is to be embedded in gRPC response messages where the
 /// corresponding request message has used PageRequest.
 ///
-///  message SomeResponse {
-///          repeated Bar results = 1;
-///          PageResponse page = 2;
-///  }
+///   message SomeResponse {
+///           repeated Bar results = 1;
+///           PageResponse page = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageResponse {
     /// next_key is the key to be passed to PageRequest.key to

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
@@ -23,6 +23,7 @@ pub struct QueryParamsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -52,6 +53,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -71,19 +76,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params queries all parameters of the ICA controller submodule.

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
@@ -26,6 +26,7 @@ pub struct QueryParamsResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -55,6 +56,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -74,19 +79,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Params queries all parameters of the ICA host submodule.

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
@@ -32,6 +32,18 @@ pub enum Type {
     /// Execute a transaction on an interchain accounts host chain
     ExecuteTx = 1,
 }
+impl Type {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Type::Unspecified => "TYPE_UNSPECIFIED",
+            Type::ExecuteTx => "TYPE_EXECUTE_TX",
+        }
+    }
+}
 /// Metadata defines a set of protocol specific data encoded into the ICS27 channel version bytestring
 /// See ICS004: <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning>
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
@@ -37,6 +37,7 @@ pub struct MsgTransferResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the ibc/transfer Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -66,6 +67,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -85,19 +90,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Transfer defines a rpc handler method for MsgTransfer.
@@ -217,6 +222,7 @@ pub struct QueryDenomHashResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service.
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -246,6 +252,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -265,19 +275,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// DenomTrace queries a denomination trace information.

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
@@ -148,6 +148,21 @@ pub enum State {
     /// packets.
     Closed = 4,
 }
+impl State {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            State::UninitializedUnspecified => "STATE_UNINITIALIZED_UNSPECIFIED",
+            State::Init => "STATE_INIT",
+            State::Tryopen => "STATE_TRYOPEN",
+            State::Open => "STATE_OPEN",
+            State::Closed => "STATE_CLOSED",
+        }
+    }
+}
 /// Order defines if a channel is ORDERED or UNORDERED
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -159,6 +174,19 @@ pub enum Order {
     Unordered = 1,
     /// packets are delivered exactly in the order which they were sent
     Ordered = 2,
+}
+impl Order {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Order::NoneUnspecified => "ORDER_NONE_UNSPECIFIED",
+            Order::Unordered => "ORDER_UNORDERED",
+            Order::Ordered => "ORDER_ORDERED",
+        }
+    }
 }
 /// MsgChannelOpenInit defines an sdk.Msg to initialize a channel handshake. It
 /// is called by a relayer on Chain A.
@@ -373,12 +401,26 @@ pub enum ResponseResultType {
     /// The message was executed successfully
     ResponseResultSuccess = 2,
 }
+impl ResponseResultType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ResponseResultType::ResponseResultUnspecified => "RESPONSE_RESULT_UNSPECIFIED",
+            ResponseResultType::ResponseResultNoop => "RESPONSE_RESULT_NOOP",
+            ResponseResultType::ResponseResultSuccess => "RESPONSE_RESULT_SUCCESS",
+        }
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the ibc/channel Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -408,6 +450,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -427,19 +473,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// ChannelOpenInit defines a rpc handler method for MsgChannelOpenInit.
@@ -507,9 +553,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgChannelOpenConfirm>,
         ) -> Result<
-            tonic::Response<super::MsgChannelOpenConfirmResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgChannelOpenConfirmResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -551,9 +597,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgChannelCloseConfirm>,
         ) -> Result<
-            tonic::Response<super::MsgChannelCloseConfirmResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgChannelCloseConfirmResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1005,6 +1051,7 @@ pub struct QueryNextSequenceReceiveResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -1034,6 +1081,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -1053,19 +1104,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Channel queries an IBC Channel.
@@ -1114,9 +1165,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConnectionChannelsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryConnectionChannelsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryConnectionChannelsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1138,9 +1189,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryChannelClientStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryChannelClientStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryChannelClientStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1162,9 +1213,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryChannelConsensusStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryChannelConsensusStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryChannelConsensusStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1185,9 +1236,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPacketCommitmentRequest>,
         ) -> Result<
-            tonic::Response<super::QueryPacketCommitmentResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryPacketCommitmentResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1209,9 +1260,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPacketCommitmentsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryPacketCommitmentsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryPacketCommitmentsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1253,9 +1304,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPacketAcknowledgementRequest>,
         ) -> Result<
-            tonic::Response<super::QueryPacketAcknowledgementResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryPacketAcknowledgementResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1277,9 +1328,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPacketAcknowledgementsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryPacketAcknowledgementsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryPacketAcknowledgementsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1301,9 +1352,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUnreceivedPacketsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUnreceivedPacketsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryUnreceivedPacketsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -1345,9 +1396,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryNextSequenceReceiveRequest>,
         ) -> Result<
-            tonic::Response<super::QueryNextSequenceReceiveResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryNextSequenceReceiveResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
@@ -185,6 +185,7 @@ pub struct MsgSubmitMisbehaviourResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the ibc/client Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -214,6 +215,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -233,19 +238,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// CreateClient defines a rpc handler method for MsgCreateClient.
@@ -313,9 +318,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSubmitMisbehaviour>,
         ) -> Result<
-            tonic::Response<super::MsgSubmitMisbehaviourResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgSubmitMisbehaviourResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -490,6 +495,7 @@ pub struct QueryUpgradedConsensusStateResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -519,6 +525,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -538,19 +548,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// ClientState queries an IBC light client.
@@ -620,9 +630,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConsensusStatesRequest>,
         ) -> Result<
-            tonic::Response<super::QueryConsensusStatesResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryConsensusStatesResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -683,9 +693,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUpgradedClientStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUpgradedClientStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryUpgradedClientStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -706,9 +716,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUpgradedConsensusStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryUpgradedConsensusStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryUpgradedConsensusStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
@@ -117,6 +117,20 @@ pub enum State {
     /// A connection end has completed the handshake.
     Open = 3,
 }
+impl State {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            State::UninitializedUnspecified => "STATE_UNINITIALIZED_UNSPECIFIED",
+            State::Init => "STATE_INIT",
+            State::Tryopen => "STATE_TRYOPEN",
+            State::Open => "STATE_OPEN",
+        }
+    }
+}
 /// MsgConnectionOpenInit defines the msg sent by an account on Chain A to
 /// initialize a connection with Chain B.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -234,6 +248,7 @@ pub struct MsgConnectionOpenConfirmResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the ibc/connection Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -263,6 +278,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -282,19 +301,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// ConnectionOpenInit defines a rpc handler method for MsgConnectionOpenInit.
@@ -302,9 +321,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgConnectionOpenInit>,
         ) -> Result<
-            tonic::Response<super::MsgConnectionOpenInitResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgConnectionOpenInitResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -325,9 +344,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgConnectionOpenTry>,
         ) -> Result<
-            tonic::Response<super::MsgConnectionOpenTryResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgConnectionOpenTryResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -348,9 +367,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgConnectionOpenAck>,
         ) -> Result<
-            tonic::Response<super::MsgConnectionOpenAckResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgConnectionOpenAckResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -372,9 +391,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgConnectionOpenConfirm>,
         ) -> Result<
-            tonic::Response<super::MsgConnectionOpenConfirmResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgConnectionOpenConfirmResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -515,6 +534,7 @@ pub struct QueryConnectionConsensusStateResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -544,6 +564,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -563,19 +587,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Connection queries an IBC connection end.
@@ -624,9 +648,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryClientConnectionsRequest>,
         ) -> Result<
-            tonic::Response<super::QueryClientConnectionsResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryClientConnectionsResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -648,9 +672,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConnectionClientStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryConnectionClientStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryConnectionClientStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -672,9 +696,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConnectionConsensusStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryConnectionConsensusStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryConnectionConsensusStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v1.rs
@@ -202,3 +202,23 @@ pub enum DataType {
     /// Data type for header verification
     Header = 9,
 }
+impl DataType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            DataType::UninitializedUnspecified => "DATA_TYPE_UNINITIALIZED_UNSPECIFIED",
+            DataType::ClientState => "DATA_TYPE_CLIENT_STATE",
+            DataType::ConsensusState => "DATA_TYPE_CONSENSUS_STATE",
+            DataType::ConnectionState => "DATA_TYPE_CONNECTION_STATE",
+            DataType::ChannelState => "DATA_TYPE_CHANNEL_STATE",
+            DataType::PacketCommitment => "DATA_TYPE_PACKET_COMMITMENT",
+            DataType::PacketAcknowledgement => "DATA_TYPE_PACKET_ACKNOWLEDGEMENT",
+            DataType::PacketReceiptAbsence => "DATA_TYPE_PACKET_RECEIPT_ABSENCE",
+            DataType::NextSequenceRecv => "DATA_TYPE_NEXT_SEQUENCE_RECV",
+            DataType::Header => "DATA_TYPE_HEADER",
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v2.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v2.rs
@@ -202,3 +202,23 @@ pub enum DataType {
     /// Data type for header verification
     Header = 9,
 }
+impl DataType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            DataType::UninitializedUnspecified => "DATA_TYPE_UNINITIALIZED_UNSPECIFIED",
+            DataType::ClientState => "DATA_TYPE_CLIENT_STATE",
+            DataType::ConsensusState => "DATA_TYPE_CONSENSUS_STATE",
+            DataType::ConnectionState => "DATA_TYPE_CONNECTION_STATE",
+            DataType::ChannelState => "DATA_TYPE_CHANNEL_STATE",
+            DataType::PacketCommitment => "DATA_TYPE_PACKET_COMMITMENT",
+            DataType::PacketAcknowledgement => "DATA_TYPE_PACKET_ACKNOWLEDGEMENT",
+            DataType::PacketReceiptAbsence => "DATA_TYPE_PACKET_RECEIPT_ABSENCE",
+            DataType::NextSequenceRecv => "DATA_TYPE_NEXT_SEQUENCE_RECV",
+            DataType::Header => "DATA_TYPE_HEADER",
+        }
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
@@ -1,23 +1,23 @@
-///*
-///ExistenceProof takes a key and a value and a set of steps to perform on it.
-///The result of peforming all these steps will provide a "root hash", which can
-///be compared to the value in a header.
+/// *
+/// ExistenceProof takes a key and a value and a set of steps to perform on it.
+/// The result of peforming all these steps will provide a "root hash", which can
+/// be compared to the value in a header.
 ///
-///Since it is computationally infeasible to produce a hash collission for any of the used
-///cryptographic hash functions, if someone can provide a series of operations to transform
-///a given key and value into a root hash that matches some trusted root, these key and values
-///must be in the referenced merkle tree.
+/// Since it is computationally infeasible to produce a hash collission for any of the used
+/// cryptographic hash functions, if someone can provide a series of operations to transform
+/// a given key and value into a root hash that matches some trusted root, these key and values
+/// must be in the referenced merkle tree.
 ///
-///The only possible issue is maliablity in LeafOp, such as providing extra prefix data,
-///which should be controlled by a spec. Eg. with lengthOp as NONE,
-///prefix = FOO, key = BAR, value = CHOICE
-///and
-///prefix = F, key = OOBAR, value = CHOICE
-///would produce the same value.
+/// The only possible issue is maliablity in LeafOp, such as providing extra prefix data,
+/// which should be controlled by a spec. Eg. with lengthOp as NONE,
+/// prefix = FOO, key = BAR, value = CHOICE
+/// and
+/// prefix = F, key = OOBAR, value = CHOICE
+/// would produce the same value.
 ///
-///With LengthOp this is tricker but not impossible. Which is why the "leafPrefixEqual" field
-///in the ProofSpec is valuable to prevent this mutability. And why all trees should
-///length-prefix the data before hashing it.
+/// With LengthOp this is tricker but not impossible. Which is why the "leafPrefixEqual" field
+/// in the ProofSpec is valuable to prevent this mutability. And why all trees should
+/// length-prefix the data before hashing it.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExistenceProof {
     #[prost(bytes="vec", tag="1")]
@@ -30,9 +30,9 @@ pub struct ExistenceProof {
     pub path: ::prost::alloc::vec::Vec<InnerOp>,
 }
 ///
-///NonExistenceProof takes a proof of two neighbors, one left of the desired key,
-///one right of the desired key. If both proofs are valid AND they are neighbors,
-///then there is no valid proof for the given key.
+/// NonExistenceProof takes a proof of two neighbors, one left of the desired key,
+/// one right of the desired key. If both proofs are valid AND they are neighbors,
+/// then there is no valid proof for the given key.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NonExistenceProof {
     /// TODO: remove this as unnecessary??? we prove a range
@@ -44,7 +44,7 @@ pub struct NonExistenceProof {
     pub right: ::core::option::Option<ExistenceProof>,
 }
 ///
-///CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
+/// CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommitmentProof {
     #[prost(oneof="commitment_proof::Proof", tags="1, 2, 3, 4")]
@@ -64,21 +64,21 @@ pub mod commitment_proof {
         Compressed(super::CompressedBatchProof),
     }
 }
-///*
-///LeafOp represents the raw key-value data we wish to prove, and
-///must be flexible to represent the internal transformation from
-///the original key-value pairs into the basis hash, for many existing
-///merkle trees.
+/// *
+/// LeafOp represents the raw key-value data we wish to prove, and
+/// must be flexible to represent the internal transformation from
+/// the original key-value pairs into the basis hash, for many existing
+/// merkle trees.
 ///
-///key and value are passed in. So that the signature of this operation is:
-///leafOp(key, value) -> output
+/// key and value are passed in. So that the signature of this operation is:
+/// leafOp(key, value) -> output
 ///
-///To process this, first prehash the keys and values if needed (ANY means no hash in this case):
-///hkey = prehashKey(key)
-///hvalue = prehashValue(value)
+/// To process this, first prehash the keys and values if needed (ANY means no hash in this case):
+/// hkey = prehashKey(key)
+/// hvalue = prehashValue(value)
 ///
-///Then combine the bytes, and hash it
-///output = hash(prefix || length(hkey) || hkey || length(hvalue) || hvalue)
+/// Then combine the bytes, and hash it
+/// output = hash(prefix || length(hkey) || hkey || length(hvalue) || hvalue)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafOp {
     #[prost(enumeration="HashOp", tag="1")]
@@ -94,22 +94,22 @@ pub struct LeafOp {
     #[prost(bytes="vec", tag="5")]
     pub prefix: ::prost::alloc::vec::Vec<u8>,
 }
-///*
-///InnerOp represents a merkle-proof step that is not a leaf.
-///It represents concatenating two children and hashing them to provide the next result.
+/// *
+/// InnerOp represents a merkle-proof step that is not a leaf.
+/// It represents concatenating two children and hashing them to provide the next result.
 ///
-///The result of the previous step is passed in, so the signature of this op is:
-///innerOp(child) -> output
+/// The result of the previous step is passed in, so the signature of this op is:
+/// innerOp(child) -> output
 ///
-///The result of applying InnerOp should be:
-///output = op.hash(op.prefix || child || op.suffix)
+/// The result of applying InnerOp should be:
+/// output = op.hash(op.prefix || child || op.suffix)
 ///
-///where the || operator is concatenation of binary data,
-///and child is the result of hashing all the tree below this step.
+/// where the || operator is concatenation of binary data,
+/// and child is the result of hashing all the tree below this step.
 ///
-///Any special data, like prepending child with the length, or prepending the entire operation with
-///some value to differentiate from leaf nodes, should be included in prefix and suffix.
-///If either of prefix or suffix is empty, we just treat it as an empty string
+/// Any special data, like prepending child with the length, or prepending the entire operation with
+/// some value to differentiate from leaf nodes, should be included in prefix and suffix.
+/// If either of prefix or suffix is empty, we just treat it as an empty string
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InnerOp {
     #[prost(enumeration="HashOp", tag="1")]
@@ -119,17 +119,17 @@ pub struct InnerOp {
     #[prost(bytes="vec", tag="3")]
     pub suffix: ::prost::alloc::vec::Vec<u8>,
 }
-///*
-///ProofSpec defines what the expected parameters are for a given proof type.
-///This can be stored in the client and used to validate any incoming proofs.
+/// *
+/// ProofSpec defines what the expected parameters are for a given proof type.
+/// This can be stored in the client and used to validate any incoming proofs.
 ///
-///verify(ProofSpec, Proof) -> Proof | Error
+/// verify(ProofSpec, Proof) -> Proof | Error
 ///
-///As demonstrated in tests, if we don't fix the algorithm used to calculate the
-///LeafHash for a given tree, there are many possible key-value pairs that can
-///generate a given hash (by interpretting the preimage differently).
-///We need this for proper security, requires client knows a priori what
-///tree format server uses. But not in code, rather a configuration object.
+/// As demonstrated in tests, if we don't fix the algorithm used to calculate the
+/// LeafHash for a given tree, there are many possible key-value pairs that can
+/// generate a given hash (by interpretting the preimage differently).
+/// We need this for proper security, requires client knows a priori what
+/// tree format server uses. But not in code, rather a configuration object.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofSpec {
     /// any field in the ExistenceProof must be the same as in this spec.
@@ -146,14 +146,14 @@ pub struct ProofSpec {
     pub min_depth: i32,
 }
 ///
-///InnerSpec contains all store-specific structure info to determine if two proofs from a
-///given store are neighbors.
+/// InnerSpec contains all store-specific structure info to determine if two proofs from a
+/// given store are neighbors.
 ///
-///This enables:
+/// This enables:
 ///
-///isLeftMost(spec: InnerSpec, op: InnerOp)
-///isRightMost(spec: InnerSpec, op: InnerOp)
-///isLeftNeighbor(spec: InnerSpec, left: InnerOp, right: InnerOp)
+/// isLeftMost(spec: InnerSpec, op: InnerOp)
+/// isRightMost(spec: InnerSpec, op: InnerOp)
+/// isLeftNeighbor(spec: InnerSpec, left: InnerOp, right: InnerOp)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InnerSpec {
     /// Child order is the ordering of the children node, must count from 0
@@ -175,7 +175,7 @@ pub struct InnerSpec {
     pub hash: i32,
 }
 ///
-///BatchProof is a group of multiple proof types than can be compressed
+/// BatchProof is a group of multiple proof types than can be compressed
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchProof {
     #[prost(message, repeated, tag="1")]
@@ -197,7 +197,7 @@ pub mod batch_entry {
         Nonexist(super::NonExistenceProof),
     }
 }
-//***** all items here are compressed forms ******
+// ***** all items here are compressed forms ******
 
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedBatchProof {
@@ -256,11 +256,27 @@ pub enum HashOp {
     /// ripemd160(sha256(x))
     Bitcoin = 5,
 }
-///*
-///LengthOp defines how to process the key and value of the LeafOp
-///to include length information. After encoding the length with the given
-///algorithm, the length will be prepended to the key and value bytes.
-///(Each one with it's own encoded length)
+impl HashOp {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            HashOp::NoHash => "NO_HASH",
+            HashOp::Sha256 => "SHA256",
+            HashOp::Sha512 => "SHA512",
+            HashOp::Keccak => "KECCAK",
+            HashOp::Ripemd160 => "RIPEMD160",
+            HashOp::Bitcoin => "BITCOIN",
+        }
+    }
+}
+/// *
+/// LengthOp defines how to process the key and value of the LeafOp
+/// to include length information. After encoding the length with the given
+/// algorithm, the length will be prepended to the key and value bytes.
+/// (Each one with it's own encoded length)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LengthOp {
@@ -282,4 +298,23 @@ pub enum LengthOp {
     Require32Bytes = 7,
     /// REQUIRE_64_BYTES is like NONE, but will fail if the input is not exactly 64 bytes (sha512 output)
     Require64Bytes = 8,
+}
+impl LengthOp {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            LengthOp::NoPrefix => "NO_PREFIX",
+            LengthOp::VarProto => "VAR_PROTO",
+            LengthOp::VarRlp => "VAR_RLP",
+            LengthOp::Fixed32Big => "FIXED32_BIG",
+            LengthOp::Fixed32Little => "FIXED32_LITTLE",
+            LengthOp::Fixed64Big => "FIXED64_BIG",
+            LengthOp::Fixed64Little => "FIXED64_LITTLE",
+            LengthOp::Require32Bytes => "REQUIRE_32_BYTES",
+            LengthOp::Require64Bytes => "REQUIRE_64_BYTES",
+        }
+    }
 }

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.query.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.query.v1beta1.rs
@@ -1,10 +1,10 @@
 /// PageRequest is to be embedded in gRPC request messages for efficient
 /// pagination. Ex:
 ///
-///  message SomeRequest {
-///          Foo some_parameter = 1;
-///          PageRequest pagination = 2;
-///  }
+///   message SomeRequest {
+///           Foo some_parameter = 1;
+///           PageRequest pagination = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageRequest {
     /// key is a value returned in PageResponse.next_key to begin
@@ -36,10 +36,10 @@ pub struct PageRequest {
 /// PageResponse is to be embedded in gRPC response messages where the
 /// corresponding request message has used PageRequest.
 ///
-///  message SomeResponse {
-///          repeated Bar results = 1;
-///          PageResponse page = 2;
-///  }
+///   message SomeResponse {
+///           repeated Bar results = 1;
+///           PageResponse page = 2;
+///   }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageResponse {
     /// next_key is the key to be passed to PageRequest.key to

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.rs
@@ -111,6 +111,20 @@ pub enum AccessType {
     /// AccessTypeEverybody unrestricted
     Everybody = 3,
 }
+impl AccessType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            AccessType::Unspecified => "ACCESS_TYPE_UNSPECIFIED",
+            AccessType::Nobody => "ACCESS_TYPE_NOBODY",
+            AccessType::OnlyAddress => "ACCESS_TYPE_ONLY_ADDRESS",
+            AccessType::Everybody => "ACCESS_TYPE_EVERYBODY",
+        }
+    }
+}
 /// ContractCodeHistoryOperationType actions that caused a code change
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -123,6 +137,20 @@ pub enum ContractCodeHistoryOperationType {
     Migrate = 2,
     /// ContractCodeHistoryOperationTypeGenesis based on genesis data
     Genesis = 3,
+}
+impl ContractCodeHistoryOperationType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ContractCodeHistoryOperationType::Unspecified => "CONTRACT_CODE_HISTORY_OPERATION_TYPE_UNSPECIFIED",
+            ContractCodeHistoryOperationType::Init => "CONTRACT_CODE_HISTORY_OPERATION_TYPE_INIT",
+            ContractCodeHistoryOperationType::Migrate => "CONTRACT_CODE_HISTORY_OPERATION_TYPE_MIGRATE",
+            ContractCodeHistoryOperationType::Genesis => "CONTRACT_CODE_HISTORY_OPERATION_TYPE_GENESIS",
+        }
+    }
 }
 /// MsgStoreCode submit Wasm code to the system
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -262,6 +290,7 @@ pub struct MsgClearAdminResponse {
 pub mod msg_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Msg defines the wasm Msg service.
     #[derive(Debug, Clone)]
     pub struct MsgClient<T> {
@@ -291,6 +320,10 @@ pub mod msg_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -310,19 +343,19 @@ pub mod msg_client {
         {
             MsgClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// StoreCode to submit Wasm code to the system
@@ -350,9 +383,9 @@ pub mod msg_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MsgInstantiateContract>,
         ) -> Result<
-            tonic::Response<super::MsgInstantiateContractResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::MsgInstantiateContractResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -635,6 +668,7 @@ pub struct QueryPinnedCodesResponse {
 pub mod query_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Query provides defines the gRPC querier service
     #[derive(Debug, Clone)]
     pub struct QueryClient<T> {
@@ -664,6 +698,10 @@ pub mod query_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -683,19 +721,19 @@ pub mod query_client {
         {
             QueryClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// ContractInfo gets the contract meta data
@@ -723,9 +761,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractHistoryRequest>,
         ) -> Result<
-            tonic::Response<super::QueryContractHistoryResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryContractHistoryResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -746,9 +784,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractsByCodeRequest>,
         ) -> Result<
-            tonic::Response<super::QueryContractsByCodeResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryContractsByCodeResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -769,9 +807,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllContractStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryAllContractStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryAllContractStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -792,9 +830,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryRawContractStateRequest>,
         ) -> Result<
-            tonic::Response<super::QueryRawContractStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QueryRawContractStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await
@@ -815,9 +853,9 @@ pub mod query_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySmartContractStateRequest>,
         ) -> Result<
-            tonic::Response<super::QuerySmartContractStateResponse>,
-            tonic::Status,
-        > {
+                tonic::Response<super::QuerySmartContractStateResponse>,
+                tonic::Status,
+            > {
             self.inner
                 .ready()
                 .await

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,22 +12,22 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.13.0", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "=0.14.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.11"
+prost-types = "0.11"
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "=0.23.8", features = ["secp256k1"] }
+tendermint = { version = "=0.23.9", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
 bip32 = { version = "0.4", optional = true }
-tendermint-rpc = { version = "=0.23.8", optional = true, features = ["http-client"] }
+tendermint-rpc = { version = "=0.23.9", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 
 [dependencies]
-prost = "0.10"
-prost-build = "0.10"
-tonic = "0.7"
-tonic-build = "0.7"
+prost = "0.11"
+prost-build = "0.11"
+tonic = "0.8"
+tonic-build = "0.8"
 regex = "1"
 walkdir = "2"


### PR DESCRIPTION
This includes the following additional dependency upgrades:

- `prost` v0.11
- `prost-build` v0.11
- `prost-types` v0.11
- `tonic` v0.8
- `tonic-build` v0.11

Additionally includes a commit which regenerates the protobuf-derived code using `proto-build`.