### PR TITLE
CI: install `protoc` within `rebuild-protos` workflow

### DIFF
--- a/.github/workflows/rebuild-protos.yml
+++ b/.github/workflows/rebuild-protos.yml
@@ -17,6 +17,8 @@ jobs:
           components: rustfmt
           override: true
           profile: minimal
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
       - name: Run proto-build
         id: build
         working-directory: proto-build


### PR DESCRIPTION
`prost-build` now requires `protoc` as a hard dependency as of v0.11