### PR TITLE
cosmrs: remove direct dependencies on `prost`

### DIFF
--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -16,8 +16,6 @@ cosmos-sdk-proto = { version = "=0.14.0-pre", default-features = false, path = "
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }
-prost = "0.11"
-prost-types = "0.11"
 rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"

--- a/cosmrs/src/abci.rs
+++ b/cosmrs/src/abci.rs
@@ -1,8 +1,10 @@
 //! Abci-related functionality
 
 use crate::tx::Msg;
-use crate::{proto, ErrorReport, Result};
-use prost::Message;
+use crate::{
+    proto::{self, traits::Message},
+    ErrorReport, Result,
+};
 use serde::{Deserialize, Serialize};
 use tendermint::abci::Gas;
 

--- a/cosmrs/src/crypto/legacy_amino.rs
+++ b/cosmrs/src/crypto/legacy_amino.rs
@@ -2,11 +2,13 @@
 
 use super::PublicKey;
 use crate::{
-    proto::{self, traits::MessageExt},
+    proto::{
+        self,
+        traits::{Message, MessageExt},
+    },
     Any, Error, ErrorReport, Result,
 };
 use eyre::WrapErr;
-use prost::Message;
 
 /// Legacy Amino multisig key.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/cosmrs/src/feegrant.rs
+++ b/cosmrs/src/feegrant.rs
@@ -2,8 +2,7 @@
 //!
 //! <https://docs.cosmos.network/master/modules/feegrant/>
 
-use crate::{proto, tx::Msg, AccountId, Coin, ErrorReport, Result};
-use prost_types::Any;
+use crate::{proto, tx::Msg, AccountId, Any, Coin, ErrorReport, Result};
 use std::time::{Duration, SystemTime};
 
 /// MsgGrantAllowance adds permission for Grantee to spend up to Allowance

--- a/cosmrs/src/lib.rs
+++ b/cosmrs/src/lib.rs
@@ -52,9 +52,8 @@ pub use crate::{
     tx::Tx,
 };
 
-pub use cosmos_sdk_proto as proto;
+pub use cosmos_sdk_proto::{self as proto, Any};
 pub use eyre::Report as ErrorReport;
-pub use prost_types::Any;
 pub use tendermint;
 
 #[cfg(feature = "bip32")]

--- a/cosmrs/src/tx.rs
+++ b/cosmrs/src/tx.rs
@@ -130,8 +130,10 @@ pub use crate::{
 };
 pub use tendermint::abci::{transaction::Hash, Gas};
 
-use crate::{proto, Error, Result};
-use prost::Message;
+use crate::{
+    proto::{self, traits::Message},
+    Error, Result,
+};
 
 #[cfg(feature = "rpc")]
 use crate::rpc;

--- a/cosmrs/src/tx/raw.rs
+++ b/cosmrs/src/tx/raw.rs
@@ -1,7 +1,10 @@
 //! Raw transaction.
 
 use crate::{
-    proto::{self, traits::MessageExt},
+    proto::{
+        self,
+        traits::{Message, MessageExt},
+    },
     Result,
 };
 
@@ -19,7 +22,7 @@ pub struct Raw(proto::cosmos::tx::v1beta1::TxRaw);
 impl Raw {
     /// Deserialize raw transaction from serialized protobuf.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        Ok(Raw(prost::Message::decode(bytes)?))
+        Ok(Raw(Message::decode(bytes)?))
     }
 
     /// Serialize raw transaction as a byte vector.


### PR DESCRIPTION
Accesses types/traits indirectly via `cosmos-sdk-proto` instead.