### PR TITLE
cosmos-sdk-proto v0.14.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 (2022-08-08)
+### Changed
+- Rename `cosmos::staking::v1beta1::IsStakeAuthroizationValidator` to `::Policy` ([#275])
+- Bump `prost` to v0.11 ([#277])
+- Bump `tendermint-proto` to v0.23.9 ([#277])
+- Bump `tonic` to v0.8 ([#277])
+
+### Removed
+- `pub` from `mod type_urls` ([#263])
+
+[#263]: https://github.com/cosmos/cosmos-rust/pull/263
+[#275]: https://github.com/cosmos/cosmos-rust/pull/275
+[#277]: https://github.com/cosmos/cosmos-rust/pull/277
+
 ## 0.13.0 (2022-07-25)
 ### Added
 - gRPC server definitions ([#249])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.14.0-pre"
+version = "0.14.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -20,7 +20,7 @@ Pull requests to expand coverage are welcome.
 
 ## Minimum Supported Rust Version
 
-This crate is supported on Rust **1.56** or newer.
+This crate is supported on Rust **1.57** or newer.
 
 [//]: # "badges"
 [crate-image]: https://buildstats.info/crate/cosmos-sdk-proto
@@ -31,8 +31,8 @@ This crate is supported on Rust **1.56** or newer.
 [build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-proto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 
-[//]: # "general links"
+[//]: # "links"
 [Protobufs]: (https://github.com/cosmos/cosmos-sdk/tree/master/proto/)
 [Cosmos SDK]: https://github.com/cosmos/cosmos-sdk

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.8.0"
+version = "0.9.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.14.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.14", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Rename `cosmos::staking::v1beta1::IsStakeAuthroizationValidator` to `::Policy` ([#275])
- Bump `prost` to v0.11 ([#277])
- Bump `tendermint-proto` to v0.23.9 ([#277])
- Bump `tonic` to v0.8 ([#277])

### Removed
- `pub` from `mod type_urls` ([#263])

[#263]: https://github.com/cosmos/cosmos-rust/pull/263
[#275]: https://github.com/cosmos/cosmos-rust/pull/275
[#277]: https://github.com/cosmos/cosmos-rust/pull/277