### PR TITLE
cosmrs v0.9.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-08-08)
+### Added
+- `tx::BodyBuilder` ([#254])
+- Additional `feegrant` domain types ([#280])
+
+### Changed
+- Allow alphanumeric Bech32 prefixes on `AccountId` ([#281])
+- Bump tendermint-rs crates to v0.23.9 ([#277])
+- Bump `cosmos-sdk-proto` to v0.14 ([#283])
+
+### Removed
+- Direct dependencies on `prost` ([#282])
+
+[#254]: https://github.com/cosmos/cosmos-rust/pull/254
+[#277]: https://github.com/cosmos/cosmos-rust/pull/277
+[#280]: https://github.com/cosmos/cosmos-rust/pull/280
+[#281]: https://github.com/cosmos/cosmos-rust/pull/281
+[#282]: https://github.com/cosmos/cosmos-rust/pull/282
+[#283]: https://github.com/cosmos/cosmos-rust/pull/283
+
+
 ## 0.8.0 (2022-07-25)
 ### Added
 - `feegrant` module support ([#250])
@@ -33,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#258]: https://github.com/cosmos/cosmos-rust/pull/258
 [#260]: https://github.com/cosmos/cosmos-rust/pull/260
 
+
 ## 0.7.1 (2022-06-09)
 ### Added
 - `abci`, `auth`, `cosmwasm`, and `vesting` type wrappers ([#234])
@@ -45,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#237]: https://github.com/cosmos/cosmos-rust/pull/237
 [#243]: https://github.com/cosmos/cosmos-rust/pull/243
 
+
 ## 0.7.0 (2022-05-02)
 ### Changed
 - Bump tendermint-rs crates to v0.23.7 ([#215])
@@ -55,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#215]: https://github.com/cosmos/cosmos-rust/pull/215
 [#217]: https://github.com/cosmos/cosmos-rust/pull/217
 
+
 ## 0.6.1 (2022-04-28)
 ### Fixed
 - Better error message on `AccountId` Bech32 decode failure ([#209])
@@ -62,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#209]: https://github.com/cosmos/cosmos-rust/pull/209
 [#210]: https://github.com/cosmos/cosmos-rust/pull/210
+
 
 ## 0.6.0 (2022-04-22)
 ### Added
@@ -78,11 +103,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#205]: https://github.com/cosmos/cosmos-rust/pull/205
 [#206]: https://github.com/cosmos/cosmos-rust/pull/206
 
+
 ## 0.5.1 (2022-03-14)
 ### Fixed
 - `Denom` parsing for IBC addresses ([#182])
 
 [#182]: https://github.com/cosmos/cosmos-rust/pull/182
+
 
 ## 0.5.0 (2022-03-10)
 ### Changed
@@ -96,11 +123,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#178]: https://github.com/cosmos/cosmos-rust/pull/178
 [#180]: https://github.com/cosmos/cosmos-rust/pull/180
 
+
 ## 0.4.1 (2022-01-10)
 ### Changed
 - Bump `cosmos-sdk-proto` to v0.4.1 ([#165])
 
 [#165]: https://github.com/cosmos/cosmos-rust/pull/165
+
 
 ## 0.4.0 (2022-01-07) [YANKED]
 ### Changed
@@ -109,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#163]: https://github.com/cosmos/cosmos-rust/pull/163
 [#164]: https://github.com/cosmos/cosmos-rust/pull/164
+
 
 ## 0.3.0 (2021-10-28)
 ### Added
@@ -134,6 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#147]: https://github.com/cosmos/cosmos-rust/pull/147
 [#149]: https://github.com/cosmos/cosmos-rust/pull/149
 
+
 ## 0.2.1 (2021-10-06)
 ### Added
 - `PublicKey` JSON serialization support ([#133])
@@ -149,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#116]: https://github.com/cosmos/cosmos-rust/pull/116
 [#128]: https://github.com/cosmos/cosmos-rust/pull/128
 [#129]: https://github.com/cosmos/cosmos-rust/pull/129
+
 
 ## 0.1.0 (2021-08-25)
 - Initial release under `cosmrs` name

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.9.0-pre"
+version = "0.9.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Added
- `tx::BodyBuilder` ([#254])
- Additional `feegrant` domain types ([#280])

### Changed
- Allow alphanumeric Bech32 prefixes on `AccountId` ([#281])
- Bump tendermint-rs crates to v0.23.9 ([#277])
- Bump `cosmos-sdk-proto` to v0.14 ([#283])

### Removed
- Direct dependencies on `prost` ([#282])

[#254]: https://github.com/cosmos/cosmos-rust/pull/254
[#277]: https://github.com/cosmos/cosmos-rust/pull/277
[#280]: https://github.com/cosmos/cosmos-rust/pull/280
[#281]: https://github.com/cosmos/cosmos-rust/pull/281
[#282]: https://github.com/cosmos/cosmos-rust/pull/282
[#283]: https://github.com/cosmos/cosmos-rust/pull/283