### PR TITLE
cosmos-sdk-proto v0.15.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0 (2022-11-07)
+### Added
+- `TypeUrl` impl for auth accounts ([#285])
+- `TypeUrl` impl for `MsgTransfer` ([#296])
+
+### Changed
+- Bump `tendermint-proto` to v0.26; MSRV 1.59 ([#302])
+
+[#285]: https://github.com/cosmos/cosmos-rust/pull/285
+[#296]: https://github.com/cosmos/cosmos-rust/pull/296
+[#302]: https://github.com/cosmos/cosmos-rust/pull/302
+
 ## 0.14.0 (2022-08-08)
 ### Changed
 - Rename `cosmos::staking::v1beta1::IsStakeAuthroizationValidator` to `::Policy` ([#275])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.15.0-pre"
+version = "0.15.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.15.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.15", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- `TypeUrl` impl for auth accounts ([#285])
- `TypeUrl` impl for `MsgTransfer` ([#296])

### Changed
- Bump `tendermint-proto` to v0.26; MSRV 1.59 ([#302])

[#285]: https://github.com/cosmos/cosmos-rust/pull/285
[#296]: https://github.com/cosmos/cosmos-rust/pull/296
[#302]: https://github.com/cosmos/cosmos-rust/pull/302