### PR TITLE
cosmos-sdk-proto v0.16.0

### DIFF
--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 (2022-11-30)
+### Changed
+- Bump tendermint-rs crates to 0.27 ([#306])
+
+[#306]: https://github.com/cosmos/cosmos-rust/pull/306
+
 ## 0.15.0 (2022-11-07)
 ### Added
 - `TypeUrl` impl for auth accounts ([#285])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.10.0"
+version = "0.11.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.15", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.16", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Bump tendermint-rs crates to 0.27 ([#306])

[#306]: https://github.com/cosmos/cosmos-rust/pull/306