### PR TITLE
cosmrs v0.11.0

### DIFF
--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-11-30)
+### Changed
+- Bump tendermint-rs crates to 0.27 ([#306])
+- Bump `cosmos-sdk-proto` to v0.16 ([#307])
+
+[#306]: https://github.com/cosmos/cosmos-rust/pull/306
+[#307]: https://github.com/cosmos/cosmos-rust/pull/307
+
 ## 0.10.0 (2022-11-07)
 ### Added
 - `Coin` constructor ([#291])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.11.0-pre"
+version = "0.11.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump tendermint-rs crates to 0.27 ([#306])
- Bump `cosmos-sdk-proto` to v0.16 ([#307])

[#306]: https://github.com/cosmos/cosmos-rust/pull/306
[#307]: https://github.com/cosmos/cosmos-rust/pull/307