### PR TITLE
Expose `cosmwasm::msg_migrate_contract` structs

### DIFF
--- a/cosmrs/src/cosmwasm.rs
+++ b/cosmrs/src/cosmwasm.rs
@@ -24,6 +24,7 @@ pub use self::{
     contract_info::ContractInfo,
     msg_execute_contract::{MsgExecuteContract, MsgExecuteContractResponse},
     msg_initiate_contract::{MsgInstantiateContract, MsgInstantiateContractResponse},
+    msg_migrate_contract::{MsgMigrateContract, MsgMigrateContractResponse},
     msg_store_code::{MsgStoreCode, MsgStoreCodeResponse},
     query_code_response::QueryCodeResponse,
 };


### PR DESCRIPTION
This PR exposes `MsgMigrateContract` and `MsgMigrateContractResponse`.