### PR TITLE
cosmos-sdk-proto v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.0 (2023-03-21)
+### Added
+- Support for `wasmd` >=0.29 by generating files via buf ([#358])
+
+### Changed
+- Bump tendermint-rs crates to 0.30 ([#354])
+- MSRV 1.63 ([#356])
+
+[#354]: https://github.com/cosmos/cosmos-rust/pull/354
+[#356]: https://github.com/cosmos/cosmos-rust/pull/356
+[#358]: https://github.com/cosmos/cosmos-rust/pull/358
+
 ## 0.16.0 (2022-11-30)
 ### Changed
 - Bump tendermint-rs crates to 0.27 ([#306])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.63"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.16", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.17", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.14", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- Support for `wasmd` >=0.29 by generating files via buf ([#358])

### Changed
- Bump tendermint-rs crates to 0.30 ([#354])
- MSRV 1.63 ([#356])

[#354]: https://github.com/cosmos/cosmos-rust/pull/354
[#356]: https://github.com/cosmos/cosmos-rust/pull/356
[#358]: https://github.com/cosmos/cosmos-rust/pull/358