### PR TITLE
cosmos-sdk-proto v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.0 (2023-04-17)
+### Added
+- TypeUrl for missing proposal types as well as others ([#360])
+- TypeUrl for some of structs from /cosmos.tx.v1beta1 namespace ([#384])
+
+### Changed
+- Bump `tendermint-proto` to v0.31 ([#385])
+- Bump `tonic` to v0.9 ([#386])
+
+[#360]: https://github.com/cosmos/cosmos-rust/pull/360
+[#384]: https://github.com/cosmos/cosmos-rust/pull/384
+[#385]: https://github.com/cosmos/cosmos-rust/pull/385
+[#386]: https://github.com/cosmos/cosmos-rust/pull/386
+
 ## 0.17.0 (2023-03-21)
 ### Added
 - Support for `wasmd` >=0.29 by generating files via buf ([#358])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.17.0"
+version = "0.18.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.17", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.18", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.16", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- TypeUrl for missing proposal types as well as others ([#360])
- TypeUrl for some of structs from /cosmos.tx.v1beta1 namespace ([#384])

### Changed
- Bump `tendermint-proto` to v0.31 ([#385])
- Bump `tonic` to v0.9 ([#386])

[#360]: https://github.com/cosmos/cosmos-rust/pull/360
[#384]: https://github.com/cosmos/cosmos-rust/pull/384
[#385]: https://github.com/cosmos/cosmos-rust/pull/385
[#386]: https://github.com/cosmos/cosmos-rust/pull/386