### PR TITLE
cosmos-sdk-proto v0.19.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.19.0-pre"
+version = "0.19.0-pre.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.19.0-pre"
+version = "0.19.0-pre.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.19.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "=0.19.0-pre.0", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.16", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
Prerelease which includes #395: bump `COSMOS_SDK_REV` to v0.46.12