### PR TITLE
cosmos-sdk-proto v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.19.0-pre.0"
+version = "0.19.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.0 (2023-05-03)
+### Changed
+- Use `buf` to generate Cosmos SDK protos ([#393])
+- Bump `COSMOS_SDK_REV` to v0.46.12 ([#395])
+- Bump `tendermint-proto` to v0.32 ([#400])
+
+[#393]: https://github.com/cosmos/cosmos-rust/pull/393
+[#395]: https://github.com/cosmos/cosmos-rust/pull/395
+[#400]: https://github.com/cosmos/cosmos-rust/pull/400
+
 ## 0.18.0 (2023-04-17)
 ### Added
 - TypeUrl for missing proposal types as well as others ([#360])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.19.0-pre.0"
+version = "0.19.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.19.0-pre.0", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.19", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.16", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Use `buf` to generate Cosmos SDK protos ([#393])
- Bump `COSMOS_SDK_REV` to v0.46.12 ([#395])
- Bump `tendermint-proto` to v0.32 ([#400])

[#393]: https://github.com/cosmos/cosmos-rust/pull/393
[#395]: https://github.com/cosmos/cosmos-rust/pull/395
[#400]: https://github.com/cosmos/cosmos-rust/pull/400