### PR TITLE
cosmrs v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.14.0-pre"
+version = "0.14.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 (2023-05-03)
+### Changed
+- Bump `tendermint`/`tendermint-rpc` to v0.32 ([#400])
+- Bump `cosmos-sdk-proto` to v0.19 ([#401])
+
+[#400]: https://github.com/cosmos/cosmos-rust/pull/400
+[#401]: https://github.com/cosmos/cosmos-rust/pull/401
+
 ## 0.13.0 (2023-04-17)
 ### Changed
 - Bump signature + tendermint-rs dependencies; MSRV 1.65 ([#385])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.14.0-pre"
+version = "0.14.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump `tendermint`/`tendermint-rpc` to v0.32 ([#400])
- Bump `cosmos-sdk-proto` to v0.19 ([#401])

[#400]: https://github.com/cosmos/cosmos-rust/pull/400
[#401]: https://github.com/cosmos/cosmos-rust/pull/401