### PR TITLE
proto-build: migrate to neoeinstein-prost/tonic

### DIFF
--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.tonic.rs
@@ -97,7 +97,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         /** Config returns the current app config.

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
@@ -217,7 +217,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn accounts(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.tonic.rs
@@ -123,7 +123,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn grants(
@@ -443,7 +443,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn grant(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
@@ -212,7 +212,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn balance(
@@ -730,7 +730,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn send(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.tonic.rs
@@ -94,7 +94,7 @@ pub mod service_client {
 pub mod service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
     #[async_trait]
     pub trait Service: Send + Sync + 'static {
         async fn config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.tonic.rs
@@ -111,7 +111,7 @@ pub mod reflection_service_client {
 pub mod reflection_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ReflectionServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ReflectionServiceServer.
     #[async_trait]
     pub trait ReflectionService: Send + Sync + 'static {
         async fn list_all_interfaces(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.tonic.rs
@@ -177,7 +177,7 @@ pub mod reflection_service_client {
 pub mod reflection_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ReflectionServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ReflectionServiceServer.
     #[async_trait]
     pub trait ReflectionService: Send + Sync + 'static {
         async fn get_authn_descriptor(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.tonic.rs
@@ -192,7 +192,7 @@ pub mod service_client {
 pub mod service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
     #[async_trait]
     pub trait Service: Send + Sync + 'static {
         async fn get_node_info(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
@@ -91,7 +91,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn verify_invariant(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
@@ -227,7 +227,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn params(
@@ -802,7 +802,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn set_withdraw_address(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.tonic.rs
@@ -109,7 +109,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn evidence(
@@ -363,7 +363,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn submit_evidence(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.tonic.rs
@@ -126,7 +126,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn allowance(
@@ -434,7 +434,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn grant_allowance(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
@@ -191,7 +191,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn proposal(
@@ -710,7 +710,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn submit_proposal(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.tonic.rs
@@ -192,7 +192,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn proposal(
@@ -698,7 +698,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn submit_proposal(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.tonic.rs
@@ -287,7 +287,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn group_info(
@@ -1180,7 +1180,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn create_group(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
@@ -122,7 +122,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn params(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.tonic.rs
@@ -177,7 +177,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn balance(
@@ -605,7 +605,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn send(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.tonic.rs
@@ -108,7 +108,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn params(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
@@ -124,7 +124,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn params(
@@ -412,7 +412,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn unjail(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
@@ -302,7 +302,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn validators(
@@ -1087,7 +1087,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn create_validator(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
@@ -152,7 +152,7 @@ pub mod service_client {
 pub mod service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ServiceServer.
     #[async_trait]
     pub trait Service: Send + Sync + 'static {
         async fn simulate(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.tonic.rs
@@ -157,7 +157,7 @@ pub mod query_client {
 pub mod query_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
     #[async_trait]
     pub trait Query: Send + Sync + 'static {
         async fn current_plan(
@@ -537,7 +537,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn software_upgrade(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.tonic.rs
@@ -127,7 +127,7 @@ pub mod msg_client {
 pub mod msg_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
     #[async_trait]
     pub trait Msg: Send + Sync + 'static {
         async fn create_vesting_account(

--- a/proto-build/buf.sdk.gen.yaml
+++ b/proto-build/buf.sdk.gen.yaml
@@ -1,10 +1,10 @@
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost:v0.2.1
     out: .
     opt:
       - extern_path=.tendermint=::tendermint_proto
-  - remote: buf.build/prost/plugins/tonic:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-tonic:v0.2.2
     out: .
     opt:
       - extern_path=.tendermint=::tendermint_proto

--- a/proto-build/buf.wasmd.gen.yaml
+++ b/proto-build/buf.wasmd.gen.yaml
@@ -1,8 +1,8 @@
 version: v1
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-prost:v0.2.1
     out: .
-  - remote: buf.build/prost/plugins/tonic:v0.2.1-1
+  - plugin: buf.build/community/neoeinstein-tonic:v0.2.2
     out: .
     opt:
       - no_server=true


### PR DESCRIPTION
The old `buf` plugin we were using is now 404.

Closes #427

~~NOTE: running into an error with the tonic plugin:~~

Fixed by downgrading to older versions of the plugin.