### PR TITLE
Bump tendermint-rs dependencies to v0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,12 +136,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -250,7 +266,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.19.0"
+version = "0.20.0-pre"
 dependencies = [
  "prost",
  "prost-types",
@@ -260,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.14.0"
+version = "0.15.0-pre"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -308,15 +324,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
 ]
 
 [[package]]
@@ -432,6 +439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,7 +539,6 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -545,17 +560,6 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -592,13 +596,10 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -675,30 +676,6 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
-
-[[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.4",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
-]
 
 [[package]]
 name = "heck"
@@ -801,40 +778,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-proxy"
-version = "0.9.1"
+name = "hyper-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
- "bytes",
- "futures",
- "headers",
+ "futures-util",
  "http",
  "hyper",
- "hyper-rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -886,6 +840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,12 +882,6 @@ dependencies = [
  "sha2 0.10.8",
  "signature",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -1157,12 +1111,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1176,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1186,44 +1140,44 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck",
  "itertools",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.37",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
  "prost",
 ]
@@ -1318,6 +1272,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "reqwest"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78fdbab6a7e1d7b13cc8ff10197f47986b41c639300cc3c8158cac7847c9bbef"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,27 +1366,45 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
- "base64 0.13.1",
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1427,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1530,14 +1542,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1669,6 +1682,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0a7d05cf78524782337f8edd55cbc578d159a16ad4affe2135c92f7dbac7f0"
+checksum = "bc2294fa667c8b548ee27a9ba59115472d0a09c2ba255771092a7f1dcf03a789"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -1714,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a72dbbea6dde12045d261f2c70c0de039125675e8a026c8d5ad34522756372"
+checksum = "5a25dbe8b953e80f3d61789fbdb83bf9ad6c0ef16df5ca6546f49912542cc137"
 dependencies = [
  "flex-error",
  "serde",
@@ -1728,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cec054567d16d85e8c3f6a3139963d1a66d9d3051ed545d31562550e9bcc3d"
+checksum = "2cc728a4f9e891d71adf66af6ecaece146f9c7a11312288a3107b3e1d6979aaf"
 dependencies = [
  "bytes",
  "flex-error",
@@ -1746,21 +1780,18 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.32.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d83a130537fc4a98c3c9eb6899ebe857fea4860400a61675bfb5f0b35129"
+checksum = "dfbf0a4753b46a190f367337e0163d0b552a2674a6bac54e74f9f2cdcde2969b"
 dependencies = [
  "async-trait",
  "bytes",
  "flex-error",
  "futures",
  "getrandom",
- "http",
- "hyper",
- "hyper-proxy",
- "hyper-rustls",
  "peg",
  "pin-project",
+ "reqwest",
  "semver",
  "serde",
  "serde_bytes",
@@ -1881,13 +1912,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1926,16 +1956,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.4",
+ "base64",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1954,15 +1983,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2142,6 +2171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,25 +2219,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -2307,6 +2329,16 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
 
 [[package]]
 name = "zeroize"

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.19.0"
+version = "0.20.0-pre"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.63"
 
 [dependencies]
-prost = "0.11"
-prost-types = "0.11"
-tendermint-proto = "0.32"
+prost = "0.12"
+prost-types = "0.12"
+tendermint-proto = "0.34"
 
 # Optional dependencies
-tonic = { version = "0.9", optional = true, default-features = false, features = ["codegen", "prost"] }
+tonic = { version = "0.10", optional = true, default-features = false, features = ["codegen", "prost"] }
 
 [features]
 default = ["grpc-transport"]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.abci.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.abci.v1beta1.rs
@@ -49,7 +49,7 @@ pub struct TxResponse {
     ///
     /// Since: cosmos-sdk 0.42.11, 0.44.5, 0.45
     #[prost(message, repeated, tag = "13")]
-    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::abci::Event>,
+    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::v0_34::abci::Event>,
 }
 /// ABCIMessageLog defines a structure containing an indexed tx ABCI message log.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -107,7 +107,7 @@ pub struct Result {
     /// Events contains a slice of Event objects that were emitted during message
     /// or handler execution.
     #[prost(message, repeated, tag = "3")]
-    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::abci::Event>,
+    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::v0_34::abci::Event>,
     /// msg_responses contains the Msg handler responses type packed in Anys.
     ///
     /// Since: cosmos-sdk 0.46

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.rs
@@ -49,17 +49,20 @@ pub struct StoreKvPair {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockMetadata {
     #[prost(message, optional, tag = "1")]
-    pub request_begin_block: ::core::option::Option<::tendermint_proto::abci::RequestBeginBlock>,
+    pub request_begin_block:
+        ::core::option::Option<::tendermint_proto::v0_34::abci::RequestBeginBlock>,
     #[prost(message, optional, tag = "2")]
-    pub response_begin_block: ::core::option::Option<::tendermint_proto::abci::ResponseBeginBlock>,
+    pub response_begin_block:
+        ::core::option::Option<::tendermint_proto::v0_34::abci::ResponseBeginBlock>,
     #[prost(message, repeated, tag = "3")]
     pub deliver_txs: ::prost::alloc::vec::Vec<block_metadata::DeliverTx>,
     #[prost(message, optional, tag = "4")]
-    pub request_end_block: ::core::option::Option<::tendermint_proto::abci::RequestEndBlock>,
+    pub request_end_block: ::core::option::Option<::tendermint_proto::v0_34::abci::RequestEndBlock>,
     #[prost(message, optional, tag = "5")]
-    pub response_end_block: ::core::option::Option<::tendermint_proto::abci::ResponseEndBlock>,
+    pub response_end_block:
+        ::core::option::Option<::tendermint_proto::v0_34::abci::ResponseEndBlock>,
     #[prost(message, optional, tag = "6")]
-    pub response_commit: ::core::option::Option<::tendermint_proto::abci::ResponseCommit>,
+    pub response_commit: ::core::option::Option<::tendermint_proto::v0_34::abci::ResponseCommit>,
 }
 /// Nested message and enum types in `BlockMetadata`.
 pub mod block_metadata {
@@ -67,9 +70,9 @@ pub mod block_metadata {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DeliverTx {
         #[prost(message, optional, tag = "1")]
-        pub request: ::core::option::Option<::tendermint_proto::abci::RequestDeliverTx>,
+        pub request: ::core::option::Option<::tendermint_proto::v0_34::abci::RequestDeliverTx>,
         #[prost(message, optional, tag = "2")]
-        pub response: ::core::option::Option<::tendermint_proto::abci::ResponseDeliverTx>,
+        pub response: ::core::option::Option<::tendermint_proto::v0_34::abci::ResponseDeliverTx>,
     }
 }
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
@@ -6,18 +6,18 @@ pub struct Block {
     #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<Header>,
     #[prost(message, optional, tag = "2")]
-    pub data: ::core::option::Option<::tendermint_proto::types::Data>,
+    pub data: ::core::option::Option<::tendermint_proto::v0_34::types::Data>,
     #[prost(message, optional, tag = "3")]
-    pub evidence: ::core::option::Option<::tendermint_proto::types::EvidenceList>,
+    pub evidence: ::core::option::Option<::tendermint_proto::v0_34::types::EvidenceList>,
     #[prost(message, optional, tag = "4")]
-    pub last_commit: ::core::option::Option<::tendermint_proto::types::Commit>,
+    pub last_commit: ::core::option::Option<::tendermint_proto::v0_34::types::Commit>,
 }
 /// Header defines the structure of a Tendermint block header.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Header {
     /// basic block info
     #[prost(message, optional, tag = "1")]
-    pub version: ::core::option::Option<::tendermint_proto::version::Consensus>,
+    pub version: ::core::option::Option<::tendermint_proto::v0_34::version::Consensus>,
     #[prost(string, tag = "2")]
     pub chain_id: ::prost::alloc::string::String,
     #[prost(int64, tag = "3")]
@@ -26,7 +26,7 @@ pub struct Header {
     pub time: ::core::option::Option<::prost_types::Timestamp>,
     /// prev block info
     #[prost(message, optional, tag = "5")]
-    pub last_block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
+    pub last_block_id: ::core::option::Option<::tendermint_proto::v0_34::types::BlockId>,
     /// hashes of block data
     ///
     /// commit from validators from the last block
@@ -131,10 +131,10 @@ pub struct GetBlockByHeightRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockByHeightResponse {
     #[prost(message, optional, tag = "1")]
-    pub block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
+    pub block_id: ::core::option::Option<::tendermint_proto::v0_34::types::BlockId>,
     /// Deprecated: please use `sdk_block` instead
     #[prost(message, optional, tag = "2")]
-    pub block: ::core::option::Option<::tendermint_proto::types::Block>,
+    pub block: ::core::option::Option<::tendermint_proto::v0_34::types::Block>,
     /// Since: cosmos-sdk 0.47
     #[prost(message, optional, tag = "3")]
     pub sdk_block: ::core::option::Option<Block>,
@@ -148,10 +148,10 @@ pub struct GetLatestBlockRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestBlockResponse {
     #[prost(message, optional, tag = "1")]
-    pub block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
+    pub block_id: ::core::option::Option<::tendermint_proto::v0_34::types::BlockId>,
     /// Deprecated: please use `sdk_block` instead
     #[prost(message, optional, tag = "2")]
-    pub block: ::core::option::Option<::tendermint_proto::types::Block>,
+    pub block: ::core::option::Option<::tendermint_proto::v0_34::types::Block>,
     /// Since: cosmos-sdk 0.47
     #[prost(message, optional, tag = "3")]
     pub sdk_block: ::core::option::Option<Block>,
@@ -173,7 +173,7 @@ pub struct GetNodeInfoRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoResponse {
     #[prost(message, optional, tag = "1")]
-    pub default_node_info: ::core::option::Option<::tendermint_proto::p2p::DefaultNodeInfo>,
+    pub default_node_info: ::core::option::Option<::tendermint_proto::v0_34::p2p::DefaultNodeInfo>,
     #[prost(message, optional, tag = "2")]
     pub application_version: ::core::option::Option<VersionInfo>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
@@ -71,7 +71,7 @@ impl AuthorizationType {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistoricalInfo {
     #[prost(message, optional, tag = "1")]
-    pub header: ::core::option::Option<::tendermint_proto::types::Header>,
+    pub header: ::core::option::Option<::tendermint_proto::v0_34::types::Header>,
     #[prost(message, repeated, tag = "2")]
     pub valset: ::prost::alloc::vec::Vec<Validator>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
@@ -393,9 +393,9 @@ pub struct GetBlockWithTxsResponse {
     #[prost(message, repeated, tag = "1")]
     pub txs: ::prost::alloc::vec::Vec<Tx>,
     #[prost(message, optional, tag = "2")]
-    pub block_id: ::core::option::Option<::tendermint_proto::types::BlockId>,
+    pub block_id: ::core::option::Option<::tendermint_proto::v0_34::types::BlockId>,
     #[prost(message, optional, tag = "3")]
-    pub block: ::core::option::Option<::tendermint_proto::types::Block>,
+    pub block: ::core::option::Option<::tendermint_proto::v0_34::types::Block>,
     /// pagination defines a pagination for the response.
     #[prost(message, optional, tag = "4")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
@@ -231,7 +231,7 @@ pub struct QueryParamsResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomHashRequest {
-    /// The denomination trace (\[port_id]/[channel_id])+/[denom\]
+    /// The denomination trace (\[port_id\]/[channel_id])+/\[denom\]
     #[prost(string, tag = "1")]
     pub trace: ::prost::alloc::string::String,
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.tendermint.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.tendermint.v1.rs
@@ -31,7 +31,7 @@ pub struct ClientState {
     /// chained proof. NOTE: ClientState must stored under
     /// `{upgradePath}/{upgradeHeight}/clientState` ConsensusState must be stored
     /// under `{upgradepath}/{upgradeHeight}/consensusState` For SDK chains using
-    /// the default upgrade module, upgrade_path should be []string{"upgrade",
+    /// the default upgrade module, upgrade_path should be \[\]string{"upgrade",
     /// "upgradedIBCState"}`
     #[prost(string, repeated, tag = "9")]
     pub upgrade_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,

--- a/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
@@ -165,8 +165,8 @@ pub struct ProofSpec {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InnerSpec {
     /// Child order is the ordering of the children node, must count from 0
-    /// iavl tree is [0, 1] (left then right)
-    /// merk is [0, 2, 1] (left, right, here)
+    /// iavl tree is \[0, 1\] (left then right)
+    /// merk is \[0, 2, 1\] (left, right, here)
     #[prost(int32, repeated, tag = "1")]
     pub child_order: ::prost::alloc::vec::Vec<i32>,
     #[prost(int32, tag = "2")]

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.14.0"
+version = "0.15.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.19", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "=0.20.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = { version = "0.16", features = ["std"] }
 eyre = "0.6"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
@@ -20,12 +20,12 @@ rand_core = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.32", features = ["secp256k1"] }
+tendermint = { version = "0.34", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
 bip32 = { version = "0.5", optional = true }
-tendermint-rpc = { version = "0.32", optional = true, features = ["http-client"] }
+tendermint-rpc = { version = "0.34", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/cosmrs/src/cosmwasm/access_config.rs
+++ b/cosmrs/src/cosmwasm/access_config.rs
@@ -23,10 +23,11 @@ impl TryFrom<&proto::cosmwasm::wasm::v1::AccessConfig> for AccessConfig {
     type Error = ErrorReport;
 
     fn try_from(proto: &proto::cosmwasm::wasm::v1::AccessConfig) -> Result<AccessConfig> {
-        let permission = AccessType::from_i32(proto.permission).ok_or(Error::InvalidEnumValue {
-            name: "permission",
-            found_value: proto.permission,
-        })?;
+        let permission =
+            AccessType::try_from(proto.permission).map_err(|_| Error::InvalidEnumValue {
+                name: "permission",
+                found_value: proto.permission,
+            })?;
 
         let mut addresses = Vec::with_capacity(proto.addresses.len());
 

--- a/cosmrs/src/cosmwasm/contract_code_history_entry.rs
+++ b/cosmrs/src/cosmwasm/contract_code_history_entry.rs
@@ -27,8 +27,8 @@ impl TryFrom<proto::cosmwasm::wasm::v1::ContractCodeHistoryEntry> for ContractCo
         proto: proto::cosmwasm::wasm::v1::ContractCodeHistoryEntry,
     ) -> Result<ContractCodeHistoryEntry> {
         Ok(ContractCodeHistoryEntry {
-            operation: ContractCodeHistoryOperationType::from_i32(proto.operation).ok_or(
-                Error::InvalidEnumValue {
+            operation: ContractCodeHistoryOperationType::try_from(proto.operation).map_err(
+                |_| Error::InvalidEnumValue {
                     name: "operation",
                     found_value: proto.operation,
                 },

--- a/cosmrs/tests/integration.rs
+++ b/cosmrs/tests/integration.rs
@@ -88,8 +88,8 @@ fn msg_send() {
                 panic!("check_tx failed: {:?}", tx_commit_response.check_tx);
             }
 
-            if tx_commit_response.deliver_tx.code.is_err() {
-                panic!("deliver_tx failed: {:?}", tx_commit_response.deliver_tx);
+            if tx_commit_response.tx_result.code.is_err() {
+                panic!("tx_result error: {:?}", tx_commit_response.tx_result);
             }
 
             let tx = dev::poll_for_tx(&rpc_client, tx_commit_response.hash).await;

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-prost = "0.11"
-prost-build = "0.11"
-tonic = "0.9"
-tonic-build = "0.9"
+prost = "0.12"
+prost-build = "0.12"
+tonic = "0.10"
+tonic-build = "0.10"
 regex = "1"
 walkdir = "2"

--- a/proto-build/buf.sdk.gen.yaml
+++ b/proto-build/buf.sdk.gen.yaml
@@ -3,8 +3,8 @@ plugins:
   - plugin: buf.build/community/neoeinstein-prost:v0.2.1
     out: .
     opt:
-      - extern_path=.tendermint=::tendermint_proto
+      - extern_path=.tendermint=::tendermint_proto::v0_34
   - plugin: buf.build/community/neoeinstein-tonic:v0.3.0
     out: .
     opt:
-      - extern_path=.tendermint=::tendermint_proto
+      - extern_path=.tendermint=::tendermint_proto::v0_34


### PR DESCRIPTION
This additionally bumps `prost` to v0.12 and `tonic` to v0.10.

This release is the first we've used with tendermint-rs multi-version support, which for now we've also pinned to (upstream) Tendermint v0.34.