### PR TITLE
cosmrs: add `getrandom` feature

### DIFF
--- a/.github/workflows/cosmrs.yml
+++ b/.github/workflows/cosmrs.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --release
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,8 +158,6 @@ dependencies = [
  "bs58",
  "hmac",
  "k256",
- "once_cell",
- "pbkdf2",
  "rand_core",
  "ripemd",
  "sha2 0.10.8",
@@ -282,7 +280,6 @@ dependencies = [
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
- "getrandom",
  "hex-literal",
  "k256",
  "rand_core",
@@ -878,9 +875,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2 0.10.8",
- "signature",
 ]
 
 [[package]]
@@ -1007,16 +1002,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "peg"

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.72"
 
 [dependencies]
 cosmos-sdk-proto = { version = "=0.20.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
-ecdsa = { version = "0.16", features = ["std"] }
+ecdsa = "0.16"
 eyre = "0.6"
-k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
-rand_core = { version = "0.6", features = ["std"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }
+rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
@@ -24,20 +24,18 @@ tendermint = { version = "0.34", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
-bip32 = { version = "0.5", optional = true }
+bip32 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "secp256k1"] }
 tendermint-rpc = { version = "0.34", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 hex-literal = "0.4"
 
 [features]
-default   = ["bip32"]
+default   = ["bip32", "getrandom"]
 cosmwasm  = ["cosmos-sdk-proto/cosmwasm"]
 dev       = ["rpc", "tokio"]
+getrandom = ["rand_core/getrandom"]
 grpc      = ["cosmos-sdk-proto/grpc-transport", "grpc-core"]
 grpc-core = ["cosmos-sdk-proto/grpc"]
 rpc       = ["tendermint-rpc"]

--- a/cosmrs/src/tx.rs
+++ b/cosmrs/src/tx.rs
@@ -21,7 +21,8 @@
 //! The following example illustrates how to build, sign, and parse
 //! a Cosmos SDK transaction:
 //!
-//! ```
+#![cfg_attr(feature = "getrandom", doc = " ```ignore")]
+#![cfg_attr(not(feature = "getrandom"), doc = " ```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! use cosmrs::{
 //!     bank::MsgSend,


### PR DESCRIPTION
Enables support for using CosmRS in environments unsupported by `getrandom`, like non-JS WASM environments.

Fixes #407