### PR TITLE
cosmrs: error handling cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
+ "signature",
  "subtle-encoding",
  "tendermint",
  "tendermint-rpc",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -19,6 +19,7 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha25
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
+signature = { version = "2", features = ["std"] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tendermint = { version = "0.34", features = ["secp256k1"] }
 thiserror = "1"

--- a/cosmrs/src/crypto/secp256k1/signing_key.rs
+++ b/cosmrs/src/crypto/secp256k1/signing_key.rs
@@ -5,7 +5,6 @@ use crate::{
     ErrorReport, Result,
 };
 use ecdsa::signature::{Keypair, Signer};
-use eyre::eyre;
 use k256::ecdsa::VerifyingKey;
 
 #[cfg(feature = "getrandom")]
@@ -38,8 +37,7 @@ impl SigningKey {
 
     /// Initialize from a raw scalar value (big endian).
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        let signing_key =
-            k256::ecdsa::SigningKey::from_slice(bytes).map_err(|_| eyre!("invalid signing key"))?;
+        let signing_key = k256::ecdsa::SigningKey::from_slice(bytes)?;
         Ok(Self::new(Box::new(signing_key)))
     }
 
@@ -63,9 +61,7 @@ impl SigningKey {
 
     /// Sign the given message, returning a signature.
     pub fn sign(&self, msg: &[u8]) -> Result<Signature> {
-        self.inner
-            .try_sign(msg)
-            .map_err(|_| eyre!("signing failure"))
+        Ok(self.inner.try_sign(msg)?)
     }
 
     /// Get the [`PublicKey`] for this [`SigningKey`].


### PR DESCRIPTION
Followup from #434 which enables `ecdsa/std` and uses eyre's built-in `Error`-trait based error propagation.