### PR TITLE
cosmos-sdk-proto: expose `gov::v1` module

### DIFF
--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -163,6 +163,9 @@ pub mod cosmos {
 
     /// Messages and services handling governance
     pub mod gov {
+        pub mod v1 {
+            include!("prost/cosmos-sdk/cosmos.gov.v1.rs");
+        }
         pub mod v1beta1 {
             include!("prost/cosmos-sdk/cosmos.gov.v1beta1.rs");
         }


### PR DESCRIPTION
Continuation of #421