### PR TITLE
cosmos-sdk-proto: deprecate `MessageExt::{from_any, to_any}`

### DIFF
--- a/cosmos-sdk-proto/src/traits.rs
+++ b/cosmos-sdk-proto/src/traits.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 /// Extension trait for [`Message`].
 pub trait MessageExt: Message {
     /// Parse this message proto from [`Any`].
+    #[deprecated(since = "0.20.0", note = "use Any::to_msg instead")]
     fn from_any(any: &Any) -> Result<Self, DecodeError>
     where
         Self: Default + Name + Sized,
@@ -17,6 +18,7 @@ pub trait MessageExt: Message {
     }
 
     /// Serialize this message proto as [`Any`].
+    #[deprecated(since = "0.20.0", note = "use Any::from_msg instead")]
     fn to_any(&self) -> Result<Any, EncodeError>
     where
         Self: Name + Sized,

--- a/cosmrs/src/tx/msg.rs
+++ b/cosmrs/src/tx/msg.rs
@@ -19,7 +19,7 @@ pub trait Msg:
 
     /// Parse this message proto from [`Any`].
     fn from_any(any: &Any) -> Result<Self> {
-        Self::Proto::from_any(any)?.try_into()
+        any.to_msg::<Self::Proto>()?.try_into()
     }
 
     /// Serialize this message proto as [`Any`].
@@ -29,6 +29,6 @@ pub trait Msg:
 
     /// Convert this message proto into [`Any`].
     fn into_any(self) -> Result<Any> {
-        Ok(self.into().to_any()?)
+        Ok(Any::from_msg(&self.into())?)
     }
 }


### PR DESCRIPTION
The `Any::{from_msg, to_msg}` methods can now be used instead.