### PR TITLE
cosmrs v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.15.0-pre"
+version = "0.15.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ all other crates, simply make the required edits in [main.rs](proto-build/main.r
 
 ## Minimum Supported Rust Version
 
-Rust **1.63**
+Rust **1.72**
 
 [//]: # "crates"
 

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -10,15 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `gov::v1` module ([#437])
 
 ### Changed
+- MSRV 1.72 (#[428])
 - Migrate to `neoeinstein-prost`/`neoeinstein-tonic` ([#429])
 - Bump `tendermint-proto` dependency to v0.34 ([#431])
 - Replace `TypeUrl` trait with `prost::Name` trait ([#432])
+- Deprecate `MessageExt::{from_any, to_any}` ([#438])
 - Bump `COSMOS_SDK_REV` to v0.46.15 ([#439])
 
+[#428]: https://github.com/cosmos/cosmos-rust/pull/428
 [#429]: https://github.com/cosmos/cosmos-rust/pull/429
 [#431]: https://github.com/cosmos/cosmos-rust/pull/431
 [#432]: https://github.com/cosmos/cosmos-rust/pull/432
 [#437]: https://github.com/cosmos/cosmos-rust/pull/437
+[#438]: https://github.com/cosmos/cosmos-rust/pull/438
 [#439]: https://github.com/cosmos/cosmos-rust/pull/439
 
 ## 0.19.0 (2023-05-03)

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords = ["blockchain", "cosmos", "tendermint", "proto"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.72"
 
 [dependencies]
 prost = "0.12"

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -20,7 +20,7 @@ Pull requests to expand coverage are welcome.
 
 ## Minimum Supported Rust Version
 
-This crate is supported on Rust **1.63** or newer.
+This crate is supported on Rust **1.72** or newer.
 
 [//]: # "badges"
 [crate-image]: https://buildstats.info/crate/cosmos-sdk-proto
@@ -31,7 +31,7 @@ This crate is supported on Rust **1.63** or newer.
 [build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-proto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 
 [//]: # "links"
 [Protobufs]: (https://github.com/cosmos/cosmos-sdk/tree/master/proto/)

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0 (2023-10-03)
+### Added
+- Export `msg_clear_admin` and `msg_update_admin` types ([#419])
+- `getrandom` feature ([#434])
+
+### Changed
+- Bound `EcdsaSigner` trait on `Sync + Send` ([#410])
+- MSRV 1.72 ([#428])
+- Bump `tendermint`/`tendermint-rpc` dependencies to v0.34 ([#431])
+- Replace `TypeUrl` with `Name` trait ([#432])
+- Bump `cosmos-sdk-proto` to v0.20 ([#440])
+
+### Fixed
+- `PublicKey::to_any` ([#406])
+
+[#406]: https://github.com/cosmos/cosmos-rust/pull/406
+[#410]: https://github.com/cosmos/cosmos-rust/pull/410
+[#419]: https://github.com/cosmos/cosmos-rust/pull/419
+[#428]: https://github.com/cosmos/cosmos-rust/pull/428
+[#431]: https://github.com/cosmos/cosmos-rust/pull/431
+[#432]: https://github.com/cosmos/cosmos-rust/pull/432
+[#434]: https://github.com/cosmos/cosmos-rust/pull/434
+[#440]: https://github.com/cosmos/cosmos-rust/pull/440
+
 ## 0.14.0 (2023-05-03)
 ### Changed
 - Bump `tendermint`/`tendermint-rpc` to v0.32 ([#400])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.15.0-pre"
+version = "0.15.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/README.md
+++ b/cosmrs/README.md
@@ -30,7 +30,7 @@ and message passing.
 
 ## Minimum Supported Rust Version
 
-This crate is supported on Rust **1.63** or newer.
+This crate is supported on Rust **1.72** or newer.
 
 [//]: # "badges"
 [crate-image]: https://buildstats.info/crate/cosmrs
@@ -41,7 +41,7 @@ This crate is supported on Rust **1.63** or newer.
 [build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmrs.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 
 [//]: # "general links"
 [Cosmos]: https://cosmos.network/


### PR DESCRIPTION
### Added
- Export `msg_clear_admin` and `msg_update_admin` types ([#419])
- `getrandom` feature ([#434])

### Changed
- Bound `EcdsaSigner` trait on `Sync + Send` ([#410])
- MSRV 1.72 ([#428])
- Bump `tendermint`/`tendermint-rpc` dependencies to v0.34 ([#431])
- Replace `TypeUrl` with `Name` trait ([#432])
- Bump `cosmos-sdk-proto` to v0.20 ([#440])

### Fixed
- `PublicKey::to_any` ([#406])

[#406]: https://github.com/cosmos/cosmos-rust/pull/406
[#410]: https://github.com/cosmos/cosmos-rust/pull/410
[#419]: https://github.com/cosmos/cosmos-rust/pull/419
[#428]: https://github.com/cosmos/cosmos-rust/pull/428
[#431]: https://github.com/cosmos/cosmos-rust/pull/431
[#432]: https://github.com/cosmos/cosmos-rust/pull/432
[#434]: https://github.com/cosmos/cosmos-rust/pull/434
[#440]: https://github.com/cosmos/cosmos-rust/pull/440