### PR TITLE
Add support for uppercase bech32

### DIFF
--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -83,7 +83,7 @@ impl FromStr for AccountId {
             bech32::decode_upper(s)
         } else {
             bech32::decode(s)
-        }.wrap_err(format!("invalid uppercase bech32: '{}'", s))?;
+        }.wrap_err(format!("invalid bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)
     }
 }

--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -79,6 +79,11 @@ impl FromStr for AccountId {
     type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
+        if s.starts_with(|c: char| c.is_uppercase()) {
+            let (hrp, bytes) =
+                bech32::decode_upper(s).wrap_err(format!("invalid uppercase bech32: '{}'", s))?;
+            return Self::new(&hrp, &bytes);
+        }
         let (hrp, bytes) = bech32::decode(s).wrap_err(format!("invalid bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)
     }
@@ -144,6 +149,14 @@ mod tests {
     #[test]
     fn with_digit() {
         "okp41urdh3smlstyafjtyg0d606egllhwp8kvnw0d2f"
+            .parse::<AccountId>()
+            .unwrap();
+    }
+
+    /// See https://en.bitcoin.it/wiki/BIP_0173 -- UPPERCASE is a valid bech32
+    #[test]
+    fn with_uppercase() {
+        "STARS1JUME25TTJLCAQQJZJJQX9HUMVZE3VCC8QF2KWL"
             .parse::<AccountId>()
             .unwrap();
     }

--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -79,12 +79,11 @@ impl FromStr for AccountId {
     type Err = ErrorReport;
 
     fn from_str(s: &str) -> Result<Self> {
-        if s.starts_with(|c: char| c.is_uppercase()) {
-            let (hrp, bytes) =
-                bech32::decode_upper(s).wrap_err(format!("invalid uppercase bech32: '{}'", s))?;
-            return Self::new(&hrp, &bytes);
-        }
-        let (hrp, bytes) = bech32::decode(s).wrap_err(format!("invalid bech32: '{}'", s))?;
+        let (hrp, bytes) = if s.starts_with(|c: char| c.is_uppercase()) {
+            bech32::decode_upper(s)
+        } else
+            bech32::decode(s)
+        }.wrap_err(format!("invalid uppercase bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)
     }
 }

--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -83,7 +83,8 @@ impl FromStr for AccountId {
             bech32::decode_upper(s)
         } else {
             bech32::decode(s)
-        }.wrap_err(format!("invalid bech32: '{}'", s))?;
+        }
+        .wrap_err(format!("invalid bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)
     }
 }

--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -81,7 +81,7 @@ impl FromStr for AccountId {
     fn from_str(s: &str) -> Result<Self> {
         let (hrp, bytes) = if s.starts_with(|c: char| c.is_uppercase()) {
             bech32::decode_upper(s)
-        } else
+        } else {
             bech32::decode(s)
         }.wrap_err(format!("invalid uppercase bech32: '{}'", s))?;
         Self::new(&hrp, &bytes)


### PR DESCRIPTION
Small fix to allow uppercase bech32 which you can see at https://www.mintscan.io/stargaze/tx/B198B9778B0873752E37F854C4BDEE6523C47EA10F1B9C12B671A9782FF3E0DE?height=4891489