### PR TITLE
bugfix: ContractCodeHistoryEntry populate 'updated' and 'msg' fields from proto data

### DIFF
--- a/cosmrs/src/cosmwasm/contract_code_history_entry.rs
+++ b/cosmrs/src/cosmwasm/contract_code_history_entry.rs
@@ -34,8 +34,8 @@ impl TryFrom<proto::cosmwasm::wasm::v1::ContractCodeHistoryEntry> for ContractCo
                 },
             )?,
             code_id: proto.code_id,
-            updated: None,
-            msg: vec![],
+            updated: proto.updated.map(TryFrom::try_from).transpose()?,
+            msg: proto.msg,
         })
     }
 }


### PR DESCRIPTION
a simple bugfix to `ContractCodeHistoryEntry` type. Rather then using default values of `None` and `vec![]` for `updated` and `msg` respectively, parse those fields out of the protobuf response instead