### PR TITLE
cosmos-sdk-proto: use `prost-build` to generate IBC `Name` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost",
 ]

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-prost = "0.12"
+prost = "0.12.3"
 prost-types = "0.12"
 tendermint-proto = "0.35"
 

--- a/cosmos-sdk-proto/src/prost/ibc-go/cosmos.auth.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/cosmos.auth.v1beta1.rs
@@ -13,6 +13,13 @@ pub struct BaseAccount {
     #[prost(uint64, tag = "4")]
     pub sequence: u64,
 }
+impl ::prost::Name for BaseAccount {
+    const NAME: &'static str = "BaseAccount";
+    const PACKAGE: &'static str = "cosmos.auth.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.auth.v1beta1.{}", Self::NAME)
+    }
+}
 /// ModuleAccount defines an account for modules that holds coins on a pool.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -23,6 +30,13 @@ pub struct ModuleAccount {
     pub name: ::prost::alloc::string::String,
     #[prost(string, repeated, tag = "3")]
     pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for ModuleAccount {
+    const NAME: &'static str = "ModuleAccount";
+    const PACKAGE: &'static str = "cosmos.auth.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.auth.v1beta1.{}", Self::NAME)
+    }
 }
 /// Params defines the parameters for the auth module.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -38,4 +52,11 @@ pub struct Params {
     pub sig_verify_cost_ed25519: u64,
     #[prost(uint64, tag = "5")]
     pub sig_verify_cost_secp256k1: u64,
+}
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "cosmos.auth.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.auth.v1beta1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.query.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.query.v1beta1.rs
@@ -29,6 +29,13 @@ pub struct PageRequest {
     #[prost(bool, tag = "4")]
     pub count_total: bool,
 }
+impl ::prost::Name for PageRequest {
+    const NAME: &'static str = "PageRequest";
+    const PACKAGE: &'static str = "cosmos.base.query.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.query.v1beta1.{}", Self::NAME)
+    }
+}
 /// PageResponse is to be embedded in gRPC response messages where the
 /// corresponding request message has used PageRequest.
 ///
@@ -47,4 +54,11 @@ pub struct PageResponse {
     /// was set, its value is undefined otherwise
     #[prost(uint64, tag = "2")]
     pub total: u64,
+}
+impl ::prost::Name for PageResponse {
+    const NAME: &'static str = "PageResponse";
+    const PACKAGE: &'static str = "cosmos.base.query.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.query.v1beta1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/cosmos.base.v1beta1.rs
@@ -10,6 +10,13 @@ pub struct Coin {
     #[prost(string, tag = "2")]
     pub amount: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Coin {
+    const NAME: &'static str = "Coin";
+    const PACKAGE: &'static str = "cosmos.base.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.v1beta1.{}", Self::NAME)
+    }
+}
 /// DecCoin defines a token with a denomination and a decimal amount.
 ///
 /// NOTE: The amount field is an Dec which implements the custom method
@@ -22,6 +29,13 @@ pub struct DecCoin {
     #[prost(string, tag = "2")]
     pub amount: ::prost::alloc::string::String,
 }
+impl ::prost::Name for DecCoin {
+    const NAME: &'static str = "DecCoin";
+    const PACKAGE: &'static str = "cosmos.base.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.v1beta1.{}", Self::NAME)
+    }
+}
 /// IntProto defines a Protobuf wrapper around an Int object.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -29,10 +43,24 @@ pub struct IntProto {
     #[prost(string, tag = "1")]
     pub int: ::prost::alloc::string::String,
 }
+impl ::prost::Name for IntProto {
+    const NAME: &'static str = "IntProto";
+    const PACKAGE: &'static str = "cosmos.base.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.v1beta1.{}", Self::NAME)
+    }
+}
 /// DecProto defines a Protobuf wrapper around a Dec object.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DecProto {
     #[prost(string, tag = "1")]
     pub dec: ::prost::alloc::string::String,
+}
+impl ::prost::Name for DecProto {
+    const NAME: &'static str = "DecProto";
+    const PACKAGE: &'static str = "cosmos.base.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.base.v1beta1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/cosmos.upgrade.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/cosmos.upgrade.v1beta1.rs
@@ -24,6 +24,13 @@ pub struct Plan {
     #[prost(string, tag = "4")]
     pub info: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Plan {
+    const NAME: &'static str = "Plan";
+    const PACKAGE: &'static str = "cosmos.upgrade.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.upgrade.v1beta1.{}", Self::NAME)
+    }
+}
 /// SoftwareUpgradeProposal is a gov Content type for initiating a software
 /// upgrade.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -36,6 +43,13 @@ pub struct SoftwareUpgradeProposal {
     #[prost(message, optional, tag = "3")]
     pub plan: ::core::option::Option<Plan>,
 }
+impl ::prost::Name for SoftwareUpgradeProposal {
+    const NAME: &'static str = "SoftwareUpgradeProposal";
+    const PACKAGE: &'static str = "cosmos.upgrade.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.upgrade.v1beta1.{}", Self::NAME)
+    }
+}
 /// CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software
 /// upgrade.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -45,4 +59,11 @@ pub struct CancelSoftwareUpgradeProposal {
     pub title: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
+}
+impl ::prost::Name for CancelSoftwareUpgradeProposal {
+    const NAME: &'static str = "CancelSoftwareUpgradeProposal";
+    const PACKAGE: &'static str = "cosmos.upgrade.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("cosmos.upgrade.v1beta1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.controller.v1.rs
@@ -7,10 +7,30 @@ pub struct Params {
     #[prost(bool, tag = "1")]
     pub controller_enabled: bool,
 }
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.controller.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.controller.v1.{}",
+            Self::NAME
+        )
+    }
+}
 /// QueryParamsRequest is the request type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsRequest {}
+impl ::prost::Name for QueryParamsRequest {
+    const NAME: &'static str = "QueryParamsRequest";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.controller.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.controller.v1.{}",
+            Self::NAME
+        )
+    }
+}
 /// QueryParamsResponse is the response type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -18,6 +38,16 @@ pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
+}
+impl ::prost::Name for QueryParamsResponse {
+    const NAME: &'static str = "QueryParamsResponse";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.controller.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.controller.v1.{}",
+            Self::NAME
+        )
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.host.v1.rs
@@ -10,10 +10,30 @@ pub struct Params {
     #[prost(string, repeated, tag = "2")]
     pub allow_messages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.host.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.host.v1.{}",
+            Self::NAME
+        )
+    }
+}
 /// QueryParamsRequest is the request type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsRequest {}
+impl ::prost::Name for QueryParamsRequest {
+    const NAME: &'static str = "QueryParamsRequest";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.host.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.host.v1.{}",
+            Self::NAME
+        )
+    }
+}
 /// QueryParamsResponse is the response type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -21,6 +41,16 @@ pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
+}
+impl ::prost::Name for QueryParamsResponse {
+    const NAME: &'static str = "QueryParamsResponse";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.host.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!(
+            "ibc.applications.interchain_accounts.host.v1.{}",
+            Self::NAME
+        )
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.interchain_accounts.v1.rs
@@ -8,6 +8,13 @@ pub struct InterchainAccount {
     #[prost(string, tag = "2")]
     pub account_owner: ::prost::alloc::string::String,
 }
+impl ::prost::Name for InterchainAccount {
+    const NAME: &'static str = "InterchainAccount";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// InterchainAccountPacketData is comprised of a raw transaction, type of transaction and optional memo field.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -19,12 +26,26 @@ pub struct InterchainAccountPacketData {
     #[prost(string, tag = "3")]
     pub memo: ::prost::alloc::string::String,
 }
+impl ::prost::Name for InterchainAccountPacketData {
+    const NAME: &'static str = "InterchainAccountPacketData";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// CosmosTx contains a list of sdk.Msg's. It should be used when sending transactions to an SDK host chain.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CosmosTx {
     #[prost(message, repeated, tag = "1")]
     pub messages: ::prost::alloc::vec::Vec<::prost_types::Any>,
+}
+impl ::prost::Name for CosmosTx {
+    const NAME: &'static str = "CosmosTx";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
 }
 /// Type defines a classification of message issued from a controller chain to its associated interchain accounts
 /// host
@@ -81,6 +102,13 @@ pub struct Metadata {
     #[prost(string, tag = "6")]
     pub tx_type: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Metadata {
+    const NAME: &'static str = "Metadata";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// GenesisState defines the interchain accounts genesis state
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,6 +117,13 @@ pub struct GenesisState {
     pub controller_genesis_state: ::core::option::Option<ControllerGenesisState>,
     #[prost(message, optional, tag = "2")]
     pub host_genesis_state: ::core::option::Option<HostGenesisState>,
+}
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
 }
 /// ControllerGenesisState defines the interchain accounts controller genesis state
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -103,6 +138,13 @@ pub struct ControllerGenesisState {
     #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<super::controller::v1::Params>,
 }
+impl ::prost::Name for ControllerGenesisState {
+    const NAME: &'static str = "ControllerGenesisState";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// HostGenesisState defines the interchain accounts host genesis state
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -116,6 +158,13 @@ pub struct HostGenesisState {
     #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<super::host::v1::Params>,
 }
+impl ::prost::Name for HostGenesisState {
+    const NAME: &'static str = "HostGenesisState";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// ActiveChannel contains a connection ID, port ID and associated active channel ID
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -127,6 +176,13 @@ pub struct ActiveChannel {
     #[prost(string, tag = "3")]
     pub channel_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for ActiveChannel {
+    const NAME: &'static str = "ActiveChannel";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
+}
 /// RegisteredInterchainAccount contains a connection ID, port ID and associated interchain account address
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -137,4 +193,11 @@ pub struct RegisteredInterchainAccount {
     pub port_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub account_address: ::prost::alloc::string::String,
+}
+impl ::prost::Name for RegisteredInterchainAccount {
+    const NAME: &'static str = "RegisteredInterchainAccount";
+    const PACKAGE: &'static str = "ibc.applications.interchain_accounts.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.interchain_accounts.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v1.rs
@@ -28,10 +28,24 @@ pub struct MsgTransfer {
     #[prost(uint64, tag = "7")]
     pub timeout_timestamp: u64,
 }
+impl ::prost::Name for MsgTransfer {
+    const NAME: &'static str = "MsgTransfer";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// MsgTransferResponse defines the Msg/Transfer response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgTransferResponse {}
+impl ::prost::Name for MsgTransferResponse {
+    const NAME: &'static str = "MsgTransferResponse";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
 pub mod msg_client {
@@ -153,6 +167,13 @@ pub struct DenomTrace {
     #[prost(string, tag = "2")]
     pub base_denom: ::prost::alloc::string::String,
 }
+impl ::prost::Name for DenomTrace {
+    const NAME: &'static str = "DenomTrace";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// Params defines the set of IBC transfer parameters.
 /// NOTE: To prevent a single token from being transferred, set the
 /// TransfersEnabled parameter to true and then set the bank module's SendEnabled
@@ -169,6 +190,13 @@ pub struct Params {
     #[prost(bool, tag = "2")]
     pub receive_enabled: bool,
 }
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC
 /// method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -178,6 +206,13 @@ pub struct QueryDenomTraceRequest {
     #[prost(string, tag = "1")]
     pub hash: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryDenomTraceRequest {
+    const NAME: &'static str = "QueryDenomTraceRequest";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// QueryDenomTraceResponse is the response type for the Query/DenomTrace RPC
 /// method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -186,6 +221,13 @@ pub struct QueryDenomTraceResponse {
     /// denom_trace returns the requested denomination trace information.
     #[prost(message, optional, tag = "1")]
     pub denom_trace: ::core::option::Option<DenomTrace>,
+}
+impl ::prost::Name for QueryDenomTraceResponse {
+    const NAME: &'static str = "QueryDenomTraceResponse";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionsRequest is the request type for the Query/DenomTraces RPC
 /// method
@@ -197,6 +239,13 @@ pub struct QueryDenomTracesRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryDenomTracesRequest {
+    const NAME: &'static str = "QueryDenomTracesRequest";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionsResponse is the response type for the Query/DenomTraces RPC
 /// method.
@@ -212,10 +261,24 @@ pub struct QueryDenomTracesResponse {
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
 }
+impl ::prost::Name for QueryDenomTracesResponse {
+    const NAME: &'static str = "QueryDenomTracesResponse";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// QueryParamsRequest is the request type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsRequest {}
+impl ::prost::Name for QueryParamsRequest {
+    const NAME: &'static str = "QueryParamsRequest";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// QueryParamsResponse is the response type for the Query/Params RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -223,6 +286,13 @@ pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
+}
+impl ::prost::Name for QueryParamsResponse {
+    const NAME: &'static str = "QueryParamsResponse";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
 }
 /// QueryDenomHashRequest is the request type for the Query/DenomHash RPC
 /// method
@@ -233,6 +303,13 @@ pub struct QueryDenomHashRequest {
     #[prost(string, tag = "1")]
     pub trace: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryDenomHashRequest {
+    const NAME: &'static str = "QueryDenomHashRequest";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
+}
 /// QueryDenomHashResponse is the response type for the Query/DenomHash RPC
 /// method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -241,6 +318,13 @@ pub struct QueryDenomHashResponse {
     /// hash (in hex format) of the denomination trace information.
     #[prost(string, tag = "1")]
     pub hash: ::prost::alloc::string::String,
+}
+impl ::prost::Name for QueryDenomHashResponse {
+    const NAME: &'static str = "QueryDenomHashResponse";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
@@ -432,4 +516,11 @@ pub struct GenesisState {
     pub denom_traces: ::prost::alloc::vec::Vec<DenomTrace>,
     #[prost(message, optional, tag = "3")]
     pub params: ::core::option::Option<Params>,
+}
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v2.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.applications.transfer.v2.rs
@@ -17,3 +17,10 @@ pub struct FungibleTokenPacketData {
     #[prost(string, tag = "4")]
     pub receiver: ::prost::alloc::string::String,
 }
+impl ::prost::Name for FungibleTokenPacketData {
+    const NAME: &'static str = "FungibleTokenPacketData";
+    const PACKAGE: &'static str = "ibc.applications.transfer.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.applications.transfer.v2.{}", Self::NAME)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.channel.v1.rs
@@ -21,6 +21,13 @@ pub struct Channel {
     #[prost(string, tag = "5")]
     pub version: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Channel {
+    const NAME: &'static str = "Channel";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// IdentifiedChannel defines a channel with additional port and channel
 /// identifier fields.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -49,6 +56,13 @@ pub struct IdentifiedChannel {
     #[prost(string, tag = "7")]
     pub channel_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for IdentifiedChannel {
+    const NAME: &'static str = "IdentifiedChannel";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// Counterparty defines a channel end counterparty
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -59,6 +73,13 @@ pub struct Counterparty {
     /// channel end on the counterparty chain
     #[prost(string, tag = "2")]
     pub channel_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for Counterparty {
+    const NAME: &'static str = "Counterparty";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// Packet defines a type that carries data across different chains through IBC
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -91,6 +112,13 @@ pub struct Packet {
     #[prost(uint64, tag = "8")]
     pub timeout_timestamp: u64,
 }
+impl ::prost::Name for Packet {
+    const NAME: &'static str = "Packet";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// PacketState defines the generic type necessary to retrieve and store
 /// packet commitments, acknowledgements, and receipts.
 /// Caller is responsible for knowing the context necessary to interpret this
@@ -110,6 +138,13 @@ pub struct PacketState {
     /// embedded data that represents packet state.
     #[prost(bytes = "vec", tag = "4")]
     pub data: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for PacketState {
+    const NAME: &'static str = "PacketState";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// Acknowledgement is the recommended acknowledgement format to be used by
 /// app-specific protocols.
@@ -135,6 +170,13 @@ pub mod acknowledgement {
         Result(::prost::alloc::vec::Vec<u8>),
         #[prost(string, tag = "22")]
         Error(::prost::alloc::string::String),
+    }
+}
+impl ::prost::Name for Acknowledgement {
+    const NAME: &'static str = "Acknowledgement";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
     }
 }
 /// State defines if a channel is in one of the following states:
@@ -227,12 +269,26 @@ pub struct MsgChannelOpenInit {
     #[prost(string, tag = "3")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelOpenInit {
+    const NAME: &'static str = "MsgChannelOpenInit";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenInitResponse defines the Msg/ChannelOpenInit response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenInitResponse {
     #[prost(string, tag = "1")]
     pub channel_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for MsgChannelOpenInitResponse {
+    const NAME: &'static str = "MsgChannelOpenInitResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// MsgChannelOpenInit defines a msg sent by a Relayer to try to open a channel
 /// on Chain B. The version field within the Channel field has been deprecated. Its
@@ -258,10 +314,24 @@ pub struct MsgChannelOpenTry {
     #[prost(string, tag = "7")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelOpenTry {
+    const NAME: &'static str = "MsgChannelOpenTry";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenTryResponse defines the Msg/ChannelOpenTry response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenTryResponse {}
+impl ::prost::Name for MsgChannelOpenTryResponse {
+    const NAME: &'static str = "MsgChannelOpenTryResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenAck defines a msg sent by a Relayer to Chain A to acknowledge
 /// the change of channel state to TRYOPEN on Chain B.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -282,10 +352,24 @@ pub struct MsgChannelOpenAck {
     #[prost(string, tag = "7")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelOpenAck {
+    const NAME: &'static str = "MsgChannelOpenAck";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenAckResponse defines the Msg/ChannelOpenAck response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenAckResponse {}
+impl ::prost::Name for MsgChannelOpenAckResponse {
+    const NAME: &'static str = "MsgChannelOpenAckResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenConfirm defines a msg sent by a Relayer to Chain B to
 /// acknowledge the change of channel state to OPEN on Chain A.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -302,11 +386,25 @@ pub struct MsgChannelOpenConfirm {
     #[prost(string, tag = "5")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelOpenConfirm {
+    const NAME: &'static str = "MsgChannelOpenConfirm";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response
 /// type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelOpenConfirmResponse {}
+impl ::prost::Name for MsgChannelOpenConfirmResponse {
+    const NAME: &'static str = "MsgChannelOpenConfirmResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelCloseInit defines a msg sent by a Relayer to Chain A
 /// to close a channel with Chain B.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -319,10 +417,24 @@ pub struct MsgChannelCloseInit {
     #[prost(string, tag = "3")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelCloseInit {
+    const NAME: &'static str = "MsgChannelCloseInit";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelCloseInitResponse defines the Msg/ChannelCloseInit response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelCloseInitResponse {}
+impl ::prost::Name for MsgChannelCloseInitResponse {
+    const NAME: &'static str = "MsgChannelCloseInitResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelCloseConfirm defines a msg sent by a Relayer to Chain B
 /// to acknowledge the change of channel state to CLOSED on Chain A.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -339,11 +451,25 @@ pub struct MsgChannelCloseConfirm {
     #[prost(string, tag = "5")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgChannelCloseConfirm {
+    const NAME: &'static str = "MsgChannelCloseConfirm";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response
 /// type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelCloseConfirmResponse {}
+impl ::prost::Name for MsgChannelCloseConfirmResponse {
+    const NAME: &'static str = "MsgChannelCloseConfirmResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgRecvPacket receives incoming IBC packet
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -357,12 +483,26 @@ pub struct MsgRecvPacket {
     #[prost(string, tag = "4")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgRecvPacket {
+    const NAME: &'static str = "MsgRecvPacket";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgRecvPacketResponse defines the Msg/RecvPacket response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgRecvPacketResponse {
     #[prost(enumeration = "ResponseResultType", tag = "1")]
     pub result: i32,
+}
+impl ::prost::Name for MsgRecvPacketResponse {
+    const NAME: &'static str = "MsgRecvPacketResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// MsgTimeout receives timed-out packet
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -379,12 +519,26 @@ pub struct MsgTimeout {
     #[prost(string, tag = "5")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgTimeout {
+    const NAME: &'static str = "MsgTimeout";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgTimeoutResponse defines the Msg/Timeout response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgTimeoutResponse {
     #[prost(enumeration = "ResponseResultType", tag = "1")]
     pub result: i32,
+}
+impl ::prost::Name for MsgTimeoutResponse {
+    const NAME: &'static str = "MsgTimeoutResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// MsgTimeoutOnClose timed-out packet upon counterparty channel closure.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -403,12 +557,26 @@ pub struct MsgTimeoutOnClose {
     #[prost(string, tag = "6")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgTimeoutOnClose {
+    const NAME: &'static str = "MsgTimeoutOnClose";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgTimeoutOnCloseResponse defines the Msg/TimeoutOnClose response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgTimeoutOnCloseResponse {
     #[prost(enumeration = "ResponseResultType", tag = "1")]
     pub result: i32,
+}
+impl ::prost::Name for MsgTimeoutOnCloseResponse {
+    const NAME: &'static str = "MsgTimeoutOnCloseResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// MsgAcknowledgement receives incoming IBC acknowledgement
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -425,12 +593,26 @@ pub struct MsgAcknowledgement {
     #[prost(string, tag = "5")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgAcknowledgement {
+    const NAME: &'static str = "MsgAcknowledgement";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// MsgAcknowledgementResponse defines the Msg/Acknowledgement response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgAcknowledgementResponse {
     #[prost(enumeration = "ResponseResultType", tag = "1")]
     pub result: i32,
+}
+impl ::prost::Name for MsgAcknowledgementResponse {
+    const NAME: &'static str = "MsgAcknowledgementResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// ResponseResultType defines the possible outcomes of the execution of a message
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -774,6 +956,13 @@ pub struct QueryChannelRequest {
     #[prost(string, tag = "2")]
     pub channel_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryChannelRequest {
+    const NAME: &'static str = "QueryChannelRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryChannelResponse is the response type for the Query/Channel RPC method.
 /// Besides the Channel end, it includes a proof and the height from which the
 /// proof was retrieved.
@@ -790,6 +979,13 @@ pub struct QueryChannelResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryChannelResponse {
+    const NAME: &'static str = "QueryChannelResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryChannelsRequest is the request type for the Query/Channels RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -799,6 +995,13 @@ pub struct QueryChannelsRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryChannelsRequest {
+    const NAME: &'static str = "QueryChannelsRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryChannelsResponse is the response type for the Query/Channels RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -816,6 +1019,13 @@ pub struct QueryChannelsResponse {
     #[prost(message, optional, tag = "3")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryChannelsResponse {
+    const NAME: &'static str = "QueryChannelsResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryConnectionChannelsRequest is the request type for the
 /// Query/QueryConnectionChannels RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -829,6 +1039,13 @@ pub struct QueryConnectionChannelsRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryConnectionChannelsRequest {
+    const NAME: &'static str = "QueryConnectionChannelsRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionChannelsResponse is the Response type for the
 /// Query/QueryConnectionChannels RPC method
@@ -847,6 +1064,13 @@ pub struct QueryConnectionChannelsResponse {
     #[prost(message, optional, tag = "3")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryConnectionChannelsResponse {
+    const NAME: &'static str = "QueryConnectionChannelsResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryChannelClientStateRequest is the request type for the Query/ClientState
 /// RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -858,6 +1082,13 @@ pub struct QueryChannelClientStateRequest {
     /// channel unique identifier
     #[prost(string, tag = "2")]
     pub channel_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for QueryChannelClientStateRequest {
+    const NAME: &'static str = "QueryChannelClientStateRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryChannelClientStateResponse is the Response type for the
 /// Query/QueryChannelClientState RPC method
@@ -874,6 +1105,13 @@ pub struct QueryChannelClientStateResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryChannelClientStateResponse {
+    const NAME: &'static str = "QueryChannelClientStateResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryChannelConsensusStateRequest is the request type for the
 /// Query/ConsensusState RPC method
@@ -893,6 +1131,13 @@ pub struct QueryChannelConsensusStateRequest {
     #[prost(uint64, tag = "4")]
     pub revision_height: u64,
 }
+impl ::prost::Name for QueryChannelConsensusStateRequest {
+    const NAME: &'static str = "QueryChannelConsensusStateRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryChannelClientStateResponse is the Response type for the
 /// Query/QueryChannelClientState RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -911,6 +1156,13 @@ pub struct QueryChannelConsensusStateResponse {
     #[prost(message, optional, tag = "4")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryChannelConsensusStateResponse {
+    const NAME: &'static str = "QueryChannelConsensusStateResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryPacketCommitmentRequest is the request type for the
 /// Query/PacketCommitment RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -925,6 +1177,13 @@ pub struct QueryPacketCommitmentRequest {
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
+}
+impl ::prost::Name for QueryPacketCommitmentRequest {
+    const NAME: &'static str = "QueryPacketCommitmentRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryPacketCommitmentResponse defines the client query response for a packet
 /// which also includes a proof and the height from which the proof was
@@ -941,6 +1200,13 @@ pub struct QueryPacketCommitmentResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryPacketCommitmentResponse {
+    const NAME: &'static str = "QueryPacketCommitmentResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryPacketCommitmentsRequest is the request type for the
 /// Query/QueryPacketCommitments RPC method
@@ -959,6 +1225,13 @@ pub struct QueryPacketCommitmentsRequest {
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
 }
+impl ::prost::Name for QueryPacketCommitmentsRequest {
+    const NAME: &'static str = "QueryPacketCommitmentsRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryPacketCommitmentsResponse is the request type for the
 /// Query/QueryPacketCommitments RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -975,6 +1248,13 @@ pub struct QueryPacketCommitmentsResponse {
     #[prost(message, optional, tag = "3")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryPacketCommitmentsResponse {
+    const NAME: &'static str = "QueryPacketCommitmentsResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryPacketReceiptRequest is the request type for the
 /// Query/PacketReceipt RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -989,6 +1269,13 @@ pub struct QueryPacketReceiptRequest {
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
+}
+impl ::prost::Name for QueryPacketReceiptRequest {
+    const NAME: &'static str = "QueryPacketReceiptRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryPacketReceiptResponse defines the client query response for a packet
 /// receipt which also includes a proof, and the height from which the proof was
@@ -1006,6 +1293,13 @@ pub struct QueryPacketReceiptResponse {
     #[prost(message, optional, tag = "4")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryPacketReceiptResponse {
+    const NAME: &'static str = "QueryPacketReceiptResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryPacketAcknowledgementRequest is the request type for the
 /// Query/PacketAcknowledgement RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1020,6 +1314,13 @@ pub struct QueryPacketAcknowledgementRequest {
     /// packet sequence
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
+}
+impl ::prost::Name for QueryPacketAcknowledgementRequest {
+    const NAME: &'static str = "QueryPacketAcknowledgementRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryPacketAcknowledgementResponse defines the client query response for a
 /// packet which also includes a proof and the height from which the
@@ -1036,6 +1337,13 @@ pub struct QueryPacketAcknowledgementResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryPacketAcknowledgementResponse {
+    const NAME: &'static str = "QueryPacketAcknowledgementResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryPacketAcknowledgementsRequest is the request type for the
 /// Query/QueryPacketCommitments RPC method
@@ -1057,6 +1365,13 @@ pub struct QueryPacketAcknowledgementsRequest {
     #[prost(uint64, repeated, tag = "4")]
     pub packet_commitment_sequences: ::prost::alloc::vec::Vec<u64>,
 }
+impl ::prost::Name for QueryPacketAcknowledgementsRequest {
+    const NAME: &'static str = "QueryPacketAcknowledgementsRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryPacketAcknowledgemetsResponse is the request type for the
 /// Query/QueryPacketAcknowledgements RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1073,6 +1388,13 @@ pub struct QueryPacketAcknowledgementsResponse {
     #[prost(message, optional, tag = "3")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryPacketAcknowledgementsResponse {
+    const NAME: &'static str = "QueryPacketAcknowledgementsResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryUnreceivedPacketsRequest is the request type for the
 /// Query/UnreceivedPackets RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1088,6 +1410,13 @@ pub struct QueryUnreceivedPacketsRequest {
     #[prost(uint64, repeated, tag = "3")]
     pub packet_commitment_sequences: ::prost::alloc::vec::Vec<u64>,
 }
+impl ::prost::Name for QueryUnreceivedPacketsRequest {
+    const NAME: &'static str = "QueryUnreceivedPacketsRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryUnreceivedPacketsResponse is the response type for the
 /// Query/UnreceivedPacketCommitments RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1099,6 +1428,13 @@ pub struct QueryUnreceivedPacketsResponse {
     /// query block height
     #[prost(message, optional, tag = "2")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryUnreceivedPacketsResponse {
+    const NAME: &'static str = "QueryUnreceivedPacketsResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QueryUnreceivedAcks is the request type for the
 /// Query/UnreceivedAcks RPC method
@@ -1115,6 +1451,13 @@ pub struct QueryUnreceivedAcksRequest {
     #[prost(uint64, repeated, tag = "3")]
     pub packet_ack_sequences: ::prost::alloc::vec::Vec<u64>,
 }
+impl ::prost::Name for QueryUnreceivedAcksRequest {
+    const NAME: &'static str = "QueryUnreceivedAcksRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryUnreceivedAcksResponse is the response type for the
 /// Query/UnreceivedAcks RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1127,6 +1470,13 @@ pub struct QueryUnreceivedAcksResponse {
     #[prost(message, optional, tag = "2")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryUnreceivedAcksResponse {
+    const NAME: &'static str = "QueryUnreceivedAcksResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// QueryNextSequenceReceiveRequest is the request type for the
 /// Query/QueryNextSequenceReceiveRequest RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1138,6 +1488,13 @@ pub struct QueryNextSequenceReceiveRequest {
     /// channel unique identifier
     #[prost(string, tag = "2")]
     pub channel_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for QueryNextSequenceReceiveRequest {
+    const NAME: &'static str = "QueryNextSequenceReceiveRequest";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// QuerySequenceResponse is the request type for the
 /// Query/QueryNextSequenceReceiveResponse RPC method
@@ -1153,6 +1510,13 @@ pub struct QueryNextSequenceReceiveResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryNextSequenceReceiveResponse {
+    const NAME: &'static str = "QueryNextSequenceReceiveResponse";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
@@ -1577,6 +1941,13 @@ pub struct GenesisState {
     #[prost(uint64, tag = "8")]
     pub next_channel_sequence: u64,
 }
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
+}
 /// PacketSequence defines the genesis type necessary to retrieve and store
 /// next send and receive sequences.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1588,4 +1959,11 @@ pub struct PacketSequence {
     pub channel_id: ::prost::alloc::string::String,
     #[prost(uint64, tag = "3")]
     pub sequence: u64,
+}
+impl ::prost::Name for PacketSequence {
+    const NAME: &'static str = "PacketSequence";
+    const PACKAGE: &'static str = "ibc.core.channel.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.channel.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.client.v1.rs
@@ -10,6 +10,13 @@ pub struct IdentifiedClientState {
     #[prost(message, optional, tag = "2")]
     pub client_state: ::core::option::Option<::prost_types::Any>,
 }
+impl ::prost::Name for IdentifiedClientState {
+    const NAME: &'static str = "IdentifiedClientState";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// ConsensusStateWithHeight defines a consensus state with an additional height
 /// field.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -22,6 +29,13 @@ pub struct ConsensusStateWithHeight {
     #[prost(message, optional, tag = "2")]
     pub consensus_state: ::core::option::Option<::prost_types::Any>,
 }
+impl ::prost::Name for ConsensusStateWithHeight {
+    const NAME: &'static str = "ConsensusStateWithHeight";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// ClientConsensusStates defines all the stored consensus states for a given
 /// client.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -33,6 +47,13 @@ pub struct ClientConsensusStates {
     /// consensus states and their heights associated with the client
     #[prost(message, repeated, tag = "2")]
     pub consensus_states: ::prost::alloc::vec::Vec<ConsensusStateWithHeight>,
+}
+impl ::prost::Name for ClientConsensusStates {
+    const NAME: &'static str = "ClientConsensusStates";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// ClientUpdateProposal is a governance proposal. If it passes, the substitute
 /// client's latest consensus state is copied over to the subject client. The proposal
@@ -55,6 +76,13 @@ pub struct ClientUpdateProposal {
     #[prost(string, tag = "4")]
     pub substitute_client_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for ClientUpdateProposal {
+    const NAME: &'static str = "ClientUpdateProposal";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// UpgradeProposal is a gov Content type for initiating an IBC breaking
 /// upgrade.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -74,6 +102,13 @@ pub struct UpgradeProposal {
     /// planned chain upgrades
     #[prost(message, optional, tag = "4")]
     pub upgraded_client_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for UpgradeProposal {
+    const NAME: &'static str = "UpgradeProposal";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// Height is a monotonically increasing data type
 /// that can be compared against another Height for the purposes of updating and
@@ -95,6 +130,13 @@ pub struct Height {
     #[prost(uint64, tag = "2")]
     pub revision_height: u64,
 }
+impl ::prost::Name for Height {
+    const NAME: &'static str = "Height";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// Params defines the set of IBC light client parameters.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -102,6 +144,13 @@ pub struct Params {
     /// allowed_clients defines the list of allowed client state types.
     #[prost(string, repeated, tag = "1")]
     pub allowed_clients: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// MsgCreateClient defines a message to create an IBC client
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -118,10 +167,24 @@ pub struct MsgCreateClient {
     #[prost(string, tag = "3")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgCreateClient {
+    const NAME: &'static str = "MsgCreateClient";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgCreateClientResponse defines the Msg/CreateClient response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCreateClientResponse {}
+impl ::prost::Name for MsgCreateClientResponse {
+    const NAME: &'static str = "MsgCreateClientResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgUpdateClient defines an sdk.Msg to update a IBC client state using
 /// the given header.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -137,10 +200,24 @@ pub struct MsgUpdateClient {
     #[prost(string, tag = "3")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgUpdateClient {
+    const NAME: &'static str = "MsgUpdateClient";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgUpdateClientResponse defines the Msg/UpdateClient response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgUpdateClientResponse {}
+impl ::prost::Name for MsgUpdateClientResponse {
+    const NAME: &'static str = "MsgUpdateClientResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgUpgradeClient defines an sdk.Msg to upgrade an IBC client to a new client
 /// state
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -166,10 +243,24 @@ pub struct MsgUpgradeClient {
     #[prost(string, tag = "6")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgUpgradeClient {
+    const NAME: &'static str = "MsgUpgradeClient";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgUpgradeClientResponse defines the Msg/UpgradeClient response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgUpgradeClientResponse {}
+impl ::prost::Name for MsgUpgradeClientResponse {
+    const NAME: &'static str = "MsgUpgradeClientResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgSubmitMisbehaviour defines an sdk.Msg type that submits Evidence for
 /// light client misbehaviour.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -185,11 +276,25 @@ pub struct MsgSubmitMisbehaviour {
     #[prost(string, tag = "3")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgSubmitMisbehaviour {
+    const NAME: &'static str = "MsgSubmitMisbehaviour";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response
 /// type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitMisbehaviourResponse {}
+impl ::prost::Name for MsgSubmitMisbehaviourResponse {
+    const NAME: &'static str = "MsgSubmitMisbehaviourResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
 pub mod msg_client {
@@ -365,6 +470,13 @@ pub struct QueryClientStateRequest {
     #[prost(string, tag = "1")]
     pub client_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryClientStateRequest {
+    const NAME: &'static str = "QueryClientStateRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientStateResponse is the response type for the Query/ClientState RPC
 /// method. Besides the client state, it includes a proof and the height from
 /// which the proof was retrieved.
@@ -381,6 +493,13 @@ pub struct QueryClientStateResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<Height>,
 }
+impl ::prost::Name for QueryClientStateResponse {
+    const NAME: &'static str = "QueryClientStateResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientStatesRequest is the request type for the Query/ClientStates RPC
 /// method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -391,6 +510,13 @@ pub struct QueryClientStatesRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryClientStatesRequest {
+    const NAME: &'static str = "QueryClientStatesRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// QueryClientStatesResponse is the response type for the Query/ClientStates RPC
 /// method.
@@ -405,6 +531,13 @@ pub struct QueryClientStatesResponse {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
+}
+impl ::prost::Name for QueryClientStatesResponse {
+    const NAME: &'static str = "QueryClientStatesResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// QueryConsensusStateRequest is the request type for the Query/ConsensusState
 /// RPC method. Besides the consensus state, it includes a proof and the height
@@ -426,6 +559,13 @@ pub struct QueryConsensusStateRequest {
     #[prost(bool, tag = "4")]
     pub latest_height: bool,
 }
+impl ::prost::Name for QueryConsensusStateRequest {
+    const NAME: &'static str = "QueryConsensusStateRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryConsensusStateResponse is the response type for the Query/ConsensusState
 /// RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -441,6 +581,13 @@ pub struct QueryConsensusStateResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<Height>,
 }
+impl ::prost::Name for QueryConsensusStateResponse {
+    const NAME: &'static str = "QueryConsensusStateResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryConsensusStatesRequest is the request type for the Query/ConsensusStates
 /// RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -454,6 +601,13 @@ pub struct QueryConsensusStatesRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryConsensusStatesRequest {
+    const NAME: &'static str = "QueryConsensusStatesRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// QueryConsensusStatesResponse is the response type for the
 /// Query/ConsensusStates RPC method
@@ -469,6 +623,13 @@ pub struct QueryConsensusStatesResponse {
         super::super::super::super::cosmos::base::query::v1beta1::PageResponse,
     >,
 }
+impl ::prost::Name for QueryConsensusStatesResponse {
+    const NAME: &'static str = "QueryConsensusStatesResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientStatusRequest is the request type for the Query/ClientStatus RPC
 /// method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -478,6 +639,13 @@ pub struct QueryClientStatusRequest {
     #[prost(string, tag = "1")]
     pub client_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryClientStatusRequest {
+    const NAME: &'static str = "QueryClientStatusRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientStatusResponse is the response type for the Query/ClientStatus RPC
 /// method. It returns the current status of the IBC client.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -486,11 +654,25 @@ pub struct QueryClientStatusResponse {
     #[prost(string, tag = "1")]
     pub status: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryClientStatusResponse {
+    const NAME: &'static str = "QueryClientStatusResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientParamsRequest is the request type for the Query/ClientParams RPC
 /// method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryClientParamsRequest {}
+impl ::prost::Name for QueryClientParamsRequest {
+    const NAME: &'static str = "QueryClientParamsRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientParamsResponse is the response type for the Query/ClientParams RPC
 /// method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -500,11 +682,25 @@ pub struct QueryClientParamsResponse {
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
 }
+impl ::prost::Name for QueryClientParamsResponse {
+    const NAME: &'static str = "QueryClientParamsResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryUpgradedClientStateRequest is the request type for the
 /// Query/UpgradedClientState RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryUpgradedClientStateRequest {}
+impl ::prost::Name for QueryUpgradedClientStateRequest {
+    const NAME: &'static str = "QueryUpgradedClientStateRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryUpgradedClientStateResponse is the response type for the
 /// Query/UpgradedClientState RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -514,11 +710,25 @@ pub struct QueryUpgradedClientStateResponse {
     #[prost(message, optional, tag = "1")]
     pub upgraded_client_state: ::core::option::Option<::prost_types::Any>,
 }
+impl ::prost::Name for QueryUpgradedClientStateResponse {
+    const NAME: &'static str = "QueryUpgradedClientStateResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryUpgradedConsensusStateRequest is the request type for the
 /// Query/UpgradedConsensusState RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryUpgradedConsensusStateRequest {}
+impl ::prost::Name for QueryUpgradedConsensusStateRequest {
+    const NAME: &'static str = "QueryUpgradedConsensusStateRequest";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// QueryUpgradedConsensusStateResponse is the response type for the
 /// Query/UpgradedConsensusState RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -527,6 +737,13 @@ pub struct QueryUpgradedConsensusStateResponse {
     /// Consensus state associated with the request identifier
     #[prost(message, optional, tag = "1")]
     pub upgraded_consensus_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for QueryUpgradedConsensusStateResponse {
+    const NAME: &'static str = "QueryUpgradedConsensusStateResponse";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
@@ -815,6 +1032,13 @@ pub struct GenesisState {
     #[prost(uint64, tag = "6")]
     pub next_client_sequence: u64,
 }
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// GenesisMetadata defines the genesis type for metadata that clients may return
 /// with ExportMetadata
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -827,6 +1051,13 @@ pub struct GenesisMetadata {
     #[prost(bytes = "vec", tag = "2")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for GenesisMetadata {
+    const NAME: &'static str = "GenesisMetadata";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
+}
 /// IdentifiedGenesisMetadata has the client metadata with the corresponding
 /// client id.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -836,4 +1067,11 @@ pub struct IdentifiedGenesisMetadata {
     pub client_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub client_metadata: ::prost::alloc::vec::Vec<GenesisMetadata>,
+}
+impl ::prost::Name for IdentifiedGenesisMetadata {
+    const NAME: &'static str = "IdentifiedGenesisMetadata";
+    const PACKAGE: &'static str = "ibc.core.client.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.client.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.commitment.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.commitment.v1.rs
@@ -6,6 +6,13 @@ pub struct MerkleRoot {
     #[prost(bytes = "vec", tag = "1")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for MerkleRoot {
+    const NAME: &'static str = "MerkleRoot";
+    const PACKAGE: &'static str = "ibc.core.commitment.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.commitment.v1.{}", Self::NAME)
+    }
+}
 /// MerklePrefix is merkle path prefixed to the key.
 /// The constructed key from the Path and the key will be append(Path.KeyPath,
 /// append(Path.KeyPrefix, key...))
@@ -15,6 +22,13 @@ pub struct MerklePrefix {
     #[prost(bytes = "vec", tag = "1")]
     pub key_prefix: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for MerklePrefix {
+    const NAME: &'static str = "MerklePrefix";
+    const PACKAGE: &'static str = "ibc.core.commitment.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.commitment.v1.{}", Self::NAME)
+    }
+}
 /// MerklePath is the path used to verify commitment proofs, which can be an
 /// arbitrary structured object (defined by a commitment type).
 /// MerklePath is represented from root-to-leaf
@@ -23,6 +37,13 @@ pub struct MerklePrefix {
 pub struct MerklePath {
     #[prost(string, repeated, tag = "1")]
     pub key_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for MerklePath {
+    const NAME: &'static str = "MerklePath";
+    const PACKAGE: &'static str = "ibc.core.commitment.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.commitment.v1.{}", Self::NAME)
+    }
 }
 /// MerkleProof is a wrapper type over a chain of CommitmentProofs.
 /// It demonstrates membership or non-membership for an element or set of
@@ -34,4 +55,11 @@ pub struct MerklePath {
 pub struct MerkleProof {
     #[prost(message, repeated, tag = "1")]
     pub proofs: ::prost::alloc::vec::Vec<super::super::super::super::ics23::CommitmentProof>,
+}
+impl ::prost::Name for MerkleProof {
+    const NAME: &'static str = "MerkleProof";
+    const PACKAGE: &'static str = "ibc.core.commitment.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.commitment.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.connection.v1.rs
@@ -24,6 +24,13 @@ pub struct ConnectionEnd {
     #[prost(uint64, tag = "5")]
     pub delay_period: u64,
 }
+impl ::prost::Name for ConnectionEnd {
+    const NAME: &'static str = "ConnectionEnd";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// IdentifiedConnection defines a connection with additional connection
 /// identifier field.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -49,6 +56,13 @@ pub struct IdentifiedConnection {
     #[prost(uint64, tag = "6")]
     pub delay_period: u64,
 }
+impl ::prost::Name for IdentifiedConnection {
+    const NAME: &'static str = "IdentifiedConnection";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// Counterparty defines the counterparty chain associated with a connection end.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -65,6 +79,13 @@ pub struct Counterparty {
     #[prost(message, optional, tag = "3")]
     pub prefix: ::core::option::Option<super::super::commitment::v1::MerklePrefix>,
 }
+impl ::prost::Name for Counterparty {
+    const NAME: &'static str = "Counterparty";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// ClientPaths define all the connection paths for a client state.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -72,6 +93,13 @@ pub struct ClientPaths {
     /// list of connection paths
     #[prost(string, repeated, tag = "1")]
     pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for ClientPaths {
+    const NAME: &'static str = "ClientPaths";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// ConnectionPaths define all the connection paths for a given client state.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -83,6 +111,13 @@ pub struct ConnectionPaths {
     /// list of connection paths
     #[prost(string, repeated, tag = "2")]
     pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for ConnectionPaths {
+    const NAME: &'static str = "ConnectionPaths";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// Version defines the versioning scheme used to negotiate the IBC verison in
 /// the connection handshake.
@@ -96,6 +131,13 @@ pub struct Version {
     #[prost(string, repeated, tag = "2")]
     pub features: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+impl ::prost::Name for Version {
+    const NAME: &'static str = "Version";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// Params defines the set of Connection parameters.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -105,6 +147,13 @@ pub struct Params {
     /// conditions. A safe choice is 3-5x the expected time per block.
     #[prost(uint64, tag = "1")]
     pub max_expected_time_per_block: u64,
+}
+impl ::prost::Name for Params {
+    const NAME: &'static str = "Params";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// State defines if a connection is in one of the following states:
 /// INIT, TRYOPEN, OPEN or UNINITIALIZED.
@@ -161,11 +210,25 @@ pub struct MsgConnectionOpenInit {
     #[prost(string, tag = "5")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgConnectionOpenInit {
+    const NAME: &'static str = "MsgConnectionOpenInit";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response
 /// type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenInitResponse {}
+impl ::prost::Name for MsgConnectionOpenInitResponse {
+    const NAME: &'static str = "MsgConnectionOpenInitResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenTry defines a msg sent by a Relayer to try to open a
 /// connection on Chain B.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -202,10 +265,24 @@ pub struct MsgConnectionOpenTry {
     #[prost(string, tag = "12")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgConnectionOpenTry {
+    const NAME: &'static str = "MsgConnectionOpenTry";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenTryResponse defines the Msg/ConnectionOpenTry response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenTryResponse {}
+impl ::prost::Name for MsgConnectionOpenTryResponse {
+    const NAME: &'static str = "MsgConnectionOpenTryResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenAck defines a msg sent by a Relayer to Chain A to
 /// acknowledge the change of connection state to TRYOPEN on Chain B.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -236,10 +313,24 @@ pub struct MsgConnectionOpenAck {
     #[prost(string, tag = "10")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgConnectionOpenAck {
+    const NAME: &'static str = "MsgConnectionOpenAck";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenAckResponse defines the Msg/ConnectionOpenAck response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenAckResponse {}
+impl ::prost::Name for MsgConnectionOpenAckResponse {
+    const NAME: &'static str = "MsgConnectionOpenAckResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenConfirm defines a msg sent by a Relayer to Chain B to
 /// acknowledge the change of connection state to OPEN on Chain A.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -255,11 +346,25 @@ pub struct MsgConnectionOpenConfirm {
     #[prost(string, tag = "4")]
     pub signer: ::prost::alloc::string::String,
 }
+impl ::prost::Name for MsgConnectionOpenConfirm {
+    const NAME: &'static str = "MsgConnectionOpenConfirm";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm
 /// response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgConnectionOpenConfirmResponse {}
+impl ::prost::Name for MsgConnectionOpenConfirmResponse {
+    const NAME: &'static str = "MsgConnectionOpenConfirmResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
 pub mod msg_client {
@@ -450,6 +555,13 @@ pub struct QueryConnectionRequest {
     #[prost(string, tag = "1")]
     pub connection_id: ::prost::alloc::string::String,
 }
+impl ::prost::Name for QueryConnectionRequest {
+    const NAME: &'static str = "QueryConnectionRequest";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// QueryConnectionResponse is the response type for the Query/Connection RPC
 /// method. Besides the connection end, it includes a proof and the height from
 /// which the proof was retrieved.
@@ -466,6 +578,13 @@ pub struct QueryConnectionResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryConnectionResponse {
+    const NAME: &'static str = "QueryConnectionResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// QueryConnectionsRequest is the request type for the Query/Connections RPC
 /// method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -475,6 +594,13 @@ pub struct QueryConnectionsRequest {
     pub pagination: ::core::option::Option<
         super::super::super::super::cosmos::base::query::v1beta1::PageRequest,
     >,
+}
+impl ::prost::Name for QueryConnectionsRequest {
+    const NAME: &'static str = "QueryConnectionsRequest";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionsResponse is the response type for the Query/Connections RPC
 /// method.
@@ -493,6 +619,13 @@ pub struct QueryConnectionsResponse {
     #[prost(message, optional, tag = "3")]
     pub height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryConnectionsResponse {
+    const NAME: &'static str = "QueryConnectionsResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// QueryClientConnectionsRequest is the request type for the
 /// Query/ClientConnections RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -501,6 +634,13 @@ pub struct QueryClientConnectionsRequest {
     /// client identifier associated with a connection
     #[prost(string, tag = "1")]
     pub client_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for QueryClientConnectionsRequest {
+    const NAME: &'static str = "QueryClientConnectionsRequest";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// QueryClientConnectionsResponse is the response type for the
 /// Query/ClientConnections RPC method
@@ -517,6 +657,13 @@ pub struct QueryClientConnectionsResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryClientConnectionsResponse {
+    const NAME: &'static str = "QueryClientConnectionsResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// QueryConnectionClientStateRequest is the request type for the
 /// Query/ConnectionClientState RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -525,6 +672,13 @@ pub struct QueryConnectionClientStateRequest {
     /// connection identifier
     #[prost(string, tag = "1")]
     pub connection_id: ::prost::alloc::string::String,
+}
+impl ::prost::Name for QueryConnectionClientStateRequest {
+    const NAME: &'static str = "QueryConnectionClientStateRequest";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionClientStateResponse is the response type for the
 /// Query/ConnectionClientState RPC method
@@ -542,6 +696,13 @@ pub struct QueryConnectionClientStateResponse {
     #[prost(message, optional, tag = "3")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
 }
+impl ::prost::Name for QueryConnectionClientStateResponse {
+    const NAME: &'static str = "QueryConnectionClientStateResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
+}
 /// QueryConnectionConsensusStateRequest is the request type for the
 /// Query/ConnectionConsensusState RPC method
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -554,6 +715,13 @@ pub struct QueryConnectionConsensusStateRequest {
     pub revision_number: u64,
     #[prost(uint64, tag = "3")]
     pub revision_height: u64,
+}
+impl ::prost::Name for QueryConnectionConsensusStateRequest {
+    const NAME: &'static str = "QueryConnectionConsensusStateRequest";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// QueryConnectionConsensusStateResponse is the response type for the
 /// Query/ConnectionConsensusState RPC method
@@ -572,6 +740,13 @@ pub struct QueryConnectionConsensusStateResponse {
     /// height at which the proof was retrieved
     #[prost(message, optional, tag = "4")]
     pub proof_height: ::core::option::Option<super::super::client::v1::Height>,
+}
+impl ::prost::Name for QueryConnectionConsensusStateResponse {
+    const NAME: &'static str = "QueryConnectionConsensusStateResponse";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "grpc")]
@@ -797,4 +972,11 @@ pub struct GenesisState {
     pub next_connection_sequence: u64,
     #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<Params>,
+}
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.core.connection.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.connection.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.types.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.core.types.v1.rs
@@ -12,3 +12,10 @@ pub struct GenesisState {
     #[prost(message, optional, tag = "3")]
     pub channel_genesis: ::core::option::Option<super::super::channel::v1::GenesisState>,
 }
+impl ::prost::Name for GenesisState {
+    const NAME: &'static str = "GenesisState";
+    const PACKAGE: &'static str = "ibc.core.types.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.core.types.v1.{}", Self::NAME)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.localhost.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.localhost.v1.rs
@@ -10,3 +10,10 @@ pub struct ClientState {
     #[prost(message, optional, tag = "2")]
     pub height: ::core::option::Option<super::super::super::core::client::v1::Height>,
 }
+impl ::prost::Name for ClientState {
+    const NAME: &'static str = "ClientState";
+    const PACKAGE: &'static str = "ibc.lightclients.localhost.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.localhost.v1.{}", Self::NAME)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v1.rs
@@ -16,6 +16,13 @@ pub struct ClientState {
     #[prost(bool, tag = "4")]
     pub allow_update_after_proposal: bool,
 }
+impl ::prost::Name for ClientState {
+    const NAME: &'static str = "ClientState";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// ConsensusState defines a solo machine consensus state. The sequence of a
 /// consensus state is contained in the "height" key used in storing the
 /// consensus state.
@@ -33,6 +40,13 @@ pub struct ConsensusState {
     #[prost(uint64, tag = "3")]
     pub timestamp: u64,
 }
+impl ::prost::Name for ConsensusState {
+    const NAME: &'static str = "ConsensusState";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// Header defines a solo machine consensus header
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -49,6 +63,13 @@ pub struct Header {
     #[prost(string, tag = "5")]
     pub new_diversifier: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Header {
+    const NAME: &'static str = "Header";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// Misbehaviour defines misbehaviour for a solo machine which consists
 /// of a sequence and two signatures over different messages at that sequence.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -62,6 +83,13 @@ pub struct Misbehaviour {
     pub signature_one: ::core::option::Option<SignatureAndData>,
     #[prost(message, optional, tag = "4")]
     pub signature_two: ::core::option::Option<SignatureAndData>,
+}
+impl ::prost::Name for Misbehaviour {
+    const NAME: &'static str = "Misbehaviour";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// SignatureAndData contains a signature and the data signed over to create that
 /// signature.
@@ -77,6 +105,13 @@ pub struct SignatureAndData {
     #[prost(uint64, tag = "4")]
     pub timestamp: u64,
 }
+impl ::prost::Name for SignatureAndData {
+    const NAME: &'static str = "SignatureAndData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// TimestampedSignatureData contains the signature data and the timestamp of the
 /// signature.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -86,6 +121,13 @@ pub struct TimestampedSignatureData {
     pub signature_data: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub timestamp: u64,
+}
+impl ::prost::Name for TimestampedSignatureData {
+    const NAME: &'static str = "TimestampedSignatureData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// SignBytes defines the signed bytes used for signature verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -104,6 +146,13 @@ pub struct SignBytes {
     #[prost(bytes = "vec", tag = "5")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for SignBytes {
+    const NAME: &'static str = "SignBytes";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// HeaderData returns the SignBytes data for update verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -115,6 +164,13 @@ pub struct HeaderData {
     #[prost(string, tag = "2")]
     pub new_diversifier: ::prost::alloc::string::String,
 }
+impl ::prost::Name for HeaderData {
+    const NAME: &'static str = "HeaderData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// ClientStateData returns the SignBytes data for client state verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -123,6 +179,13 @@ pub struct ClientStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub client_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for ClientStateData {
+    const NAME: &'static str = "ClientStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// ConsensusStateData returns the SignBytes data for consensus state
 /// verification.
@@ -133,6 +196,13 @@ pub struct ConsensusStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub consensus_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for ConsensusStateData {
+    const NAME: &'static str = "ConsensusStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// ConnectionStateData returns the SignBytes data for connection state
 /// verification.
@@ -145,6 +215,13 @@ pub struct ConnectionStateData {
     pub connection:
         ::core::option::Option<super::super::super::core::connection::v1::ConnectionEnd>,
 }
+impl ::prost::Name for ConnectionStateData {
+    const NAME: &'static str = "ConnectionStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// ChannelStateData returns the SignBytes data for channel state
 /// verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -154,6 +231,13 @@ pub struct ChannelStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub channel: ::core::option::Option<super::super::super::core::channel::v1::Channel>,
+}
+impl ::prost::Name for ChannelStateData {
+    const NAME: &'static str = "ChannelStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// PacketCommitmentData returns the SignBytes data for packet commitment
 /// verification.
@@ -165,6 +249,13 @@ pub struct PacketCommitmentData {
     #[prost(bytes = "vec", tag = "2")]
     pub commitment: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for PacketCommitmentData {
+    const NAME: &'static str = "PacketCommitmentData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// PacketAcknowledgementData returns the SignBytes data for acknowledgement
 /// verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -175,6 +266,13 @@ pub struct PacketAcknowledgementData {
     #[prost(bytes = "vec", tag = "2")]
     pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for PacketAcknowledgementData {
+    const NAME: &'static str = "PacketAcknowledgementData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
+}
 /// PacketReceiptAbsenceData returns the SignBytes data for
 /// packet receipt absence verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -182,6 +280,13 @@ pub struct PacketAcknowledgementData {
 pub struct PacketReceiptAbsenceData {
     #[prost(bytes = "vec", tag = "1")]
     pub path: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for PacketReceiptAbsenceData {
+    const NAME: &'static str = "PacketReceiptAbsenceData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// NextSequenceRecvData returns the SignBytes data for verification of the next
 /// sequence to be received.
@@ -192,6 +297,13 @@ pub struct NextSequenceRecvData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub next_seq_recv: u64,
+}
+impl ::prost::Name for NextSequenceRecvData {
+    const NAME: &'static str = "NextSequenceRecvData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v1.{}", Self::NAME)
+    }
 }
 /// DataType defines the type of solo machine proof being created. This is done
 /// to preserve uniqueness of different data sign byte encodings.

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v2.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.solomachine.v2.rs
@@ -16,6 +16,13 @@ pub struct ClientState {
     #[prost(bool, tag = "4")]
     pub allow_update_after_proposal: bool,
 }
+impl ::prost::Name for ClientState {
+    const NAME: &'static str = "ClientState";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// ConsensusState defines a solo machine consensus state. The sequence of a
 /// consensus state is contained in the "height" key used in storing the
 /// consensus state.
@@ -33,6 +40,13 @@ pub struct ConsensusState {
     #[prost(uint64, tag = "3")]
     pub timestamp: u64,
 }
+impl ::prost::Name for ConsensusState {
+    const NAME: &'static str = "ConsensusState";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// Header defines a solo machine consensus header
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -49,6 +63,13 @@ pub struct Header {
     #[prost(string, tag = "5")]
     pub new_diversifier: ::prost::alloc::string::String,
 }
+impl ::prost::Name for Header {
+    const NAME: &'static str = "Header";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// Misbehaviour defines misbehaviour for a solo machine which consists
 /// of a sequence and two signatures over different messages at that sequence.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -62,6 +83,13 @@ pub struct Misbehaviour {
     pub signature_one: ::core::option::Option<SignatureAndData>,
     #[prost(message, optional, tag = "4")]
     pub signature_two: ::core::option::Option<SignatureAndData>,
+}
+impl ::prost::Name for Misbehaviour {
+    const NAME: &'static str = "Misbehaviour";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// SignatureAndData contains a signature and the data signed over to create that
 /// signature.
@@ -77,6 +105,13 @@ pub struct SignatureAndData {
     #[prost(uint64, tag = "4")]
     pub timestamp: u64,
 }
+impl ::prost::Name for SignatureAndData {
+    const NAME: &'static str = "SignatureAndData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// TimestampedSignatureData contains the signature data and the timestamp of the
 /// signature.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -86,6 +121,13 @@ pub struct TimestampedSignatureData {
     pub signature_data: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub timestamp: u64,
+}
+impl ::prost::Name for TimestampedSignatureData {
+    const NAME: &'static str = "TimestampedSignatureData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// SignBytes defines the signed bytes used for signature verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -104,6 +146,13 @@ pub struct SignBytes {
     #[prost(bytes = "vec", tag = "5")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for SignBytes {
+    const NAME: &'static str = "SignBytes";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// HeaderData returns the SignBytes data for update verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -115,6 +164,13 @@ pub struct HeaderData {
     #[prost(string, tag = "2")]
     pub new_diversifier: ::prost::alloc::string::String,
 }
+impl ::prost::Name for HeaderData {
+    const NAME: &'static str = "HeaderData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// ClientStateData returns the SignBytes data for client state verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -123,6 +179,13 @@ pub struct ClientStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub client_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for ClientStateData {
+    const NAME: &'static str = "ClientStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// ConsensusStateData returns the SignBytes data for consensus state
 /// verification.
@@ -133,6 +196,13 @@ pub struct ConsensusStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub consensus_state: ::core::option::Option<::prost_types::Any>,
+}
+impl ::prost::Name for ConsensusStateData {
+    const NAME: &'static str = "ConsensusStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// ConnectionStateData returns the SignBytes data for connection state
 /// verification.
@@ -145,6 +215,13 @@ pub struct ConnectionStateData {
     pub connection:
         ::core::option::Option<super::super::super::core::connection::v1::ConnectionEnd>,
 }
+impl ::prost::Name for ConnectionStateData {
+    const NAME: &'static str = "ConnectionStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// ChannelStateData returns the SignBytes data for channel state
 /// verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -154,6 +231,13 @@ pub struct ChannelStateData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub channel: ::core::option::Option<super::super::super::core::channel::v1::Channel>,
+}
+impl ::prost::Name for ChannelStateData {
+    const NAME: &'static str = "ChannelStateData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// PacketCommitmentData returns the SignBytes data for packet commitment
 /// verification.
@@ -165,6 +249,13 @@ pub struct PacketCommitmentData {
     #[prost(bytes = "vec", tag = "2")]
     pub commitment: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for PacketCommitmentData {
+    const NAME: &'static str = "PacketCommitmentData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// PacketAcknowledgementData returns the SignBytes data for acknowledgement
 /// verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -175,6 +266,13 @@ pub struct PacketAcknowledgementData {
     #[prost(bytes = "vec", tag = "2")]
     pub acknowledgement: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for PacketAcknowledgementData {
+    const NAME: &'static str = "PacketAcknowledgementData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
+}
 /// PacketReceiptAbsenceData returns the SignBytes data for
 /// packet receipt absence verification.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -182,6 +280,13 @@ pub struct PacketAcknowledgementData {
 pub struct PacketReceiptAbsenceData {
     #[prost(bytes = "vec", tag = "1")]
     pub path: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for PacketReceiptAbsenceData {
+    const NAME: &'static str = "PacketReceiptAbsenceData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// NextSequenceRecvData returns the SignBytes data for verification of the next
 /// sequence to be received.
@@ -192,6 +297,13 @@ pub struct NextSequenceRecvData {
     pub path: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "2")]
     pub next_seq_recv: u64,
+}
+impl ::prost::Name for NextSequenceRecvData {
+    const NAME: &'static str = "NextSequenceRecvData";
+    const PACKAGE: &'static str = "ibc.lightclients.solomachine.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.solomachine.v2.{}", Self::NAME)
+    }
 }
 /// DataType defines the type of solo machine proof being created. This is done
 /// to preserve uniqueness of different data sign byte encodings.

--- a/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.tendermint.v1.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ibc.lightclients.tendermint.v1.rs
@@ -44,6 +44,13 @@ pub struct ClientState {
     #[prost(bool, tag = "11")]
     pub allow_update_after_misbehaviour: bool,
 }
+impl ::prost::Name for ClientState {
+    const NAME: &'static str = "ClientState";
+    const PACKAGE: &'static str = "ibc.lightclients.tendermint.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.tendermint.v1.{}", Self::NAME)
+    }
+}
 /// ConsensusState defines the consensus state from Tendermint.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -58,6 +65,13 @@ pub struct ConsensusState {
     #[prost(bytes = "vec", tag = "3")]
     pub next_validators_hash: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for ConsensusState {
+    const NAME: &'static str = "ConsensusState";
+    const PACKAGE: &'static str = "ibc.lightclients.tendermint.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.tendermint.v1.{}", Self::NAME)
+    }
+}
 /// Misbehaviour is a wrapper over two conflicting Headers
 /// that implements Misbehaviour interface expected by ICS-02
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -69,6 +83,13 @@ pub struct Misbehaviour {
     pub header_1: ::core::option::Option<Header>,
     #[prost(message, optional, tag = "3")]
     pub header_2: ::core::option::Option<Header>,
+}
+impl ::prost::Name for Misbehaviour {
+    const NAME: &'static str = "Misbehaviour";
+    const PACKAGE: &'static str = "ibc.lightclients.tendermint.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.tendermint.v1.{}", Self::NAME)
+    }
 }
 /// Header defines the Tendermint client consensus Header.
 /// It encapsulates all the information necessary to update from a trusted
@@ -94,6 +115,13 @@ pub struct Header {
     #[prost(message, optional, tag = "4")]
     pub trusted_validators: ::core::option::Option<::tendermint_proto::types::ValidatorSet>,
 }
+impl ::prost::Name for Header {
+    const NAME: &'static str = "Header";
+    const PACKAGE: &'static str = "ibc.lightclients.tendermint.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.tendermint.v1.{}", Self::NAME)
+    }
+}
 /// Fraction defines the protobuf message type for tmmath.Fraction that only
 /// supports positive values.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -103,4 +131,11 @@ pub struct Fraction {
     pub numerator: u64,
     #[prost(uint64, tag = "2")]
     pub denominator: u64,
+}
+impl ::prost::Name for Fraction {
+    const NAME: &'static str = "Fraction";
+    const PACKAGE: &'static str = "ibc.lightclients.tendermint.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ibc.lightclients.tendermint.v1.{}", Self::NAME)
+    }
 }

--- a/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
+++ b/cosmos-sdk-proto/src/prost/ibc-go/ics23.rs
@@ -30,6 +30,13 @@ pub struct ExistenceProof {
     #[prost(message, repeated, tag = "4")]
     pub path: ::prost::alloc::vec::Vec<InnerOp>,
 }
+impl ::prost::Name for ExistenceProof {
+    const NAME: &'static str = "ExistenceProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 ///
 /// NonExistenceProof takes a proof of two neighbors, one left of the desired key,
 /// one right of the desired key. If both proofs are valid AND they are neighbors,
@@ -44,6 +51,13 @@ pub struct NonExistenceProof {
     pub left: ::core::option::Option<ExistenceProof>,
     #[prost(message, optional, tag = "3")]
     pub right: ::core::option::Option<ExistenceProof>,
+}
+impl ::prost::Name for NonExistenceProof {
+    const NAME: &'static str = "NonExistenceProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 ///
 /// CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
@@ -66,6 +80,13 @@ pub mod commitment_proof {
         Batch(super::BatchProof),
         #[prost(message, tag = "4")]
         Compressed(super::CompressedBatchProof),
+    }
+}
+impl ::prost::Name for CommitmentProof {
+    const NAME: &'static str = "CommitmentProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
     }
 }
 /// *
@@ -99,6 +120,13 @@ pub struct LeafOp {
     #[prost(bytes = "vec", tag = "5")]
     pub prefix: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for LeafOp {
+    const NAME: &'static str = "LeafOp";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 /// *
 /// InnerOp represents a merkle-proof step that is not a leaf.
 /// It represents concatenating two children and hashing them to provide the next result.
@@ -124,6 +152,13 @@ pub struct InnerOp {
     pub prefix: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
     pub suffix: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for InnerOp {
+    const NAME: &'static str = "InnerOp";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 /// *
 /// ProofSpec defines what the expected parameters are for a given proof type.
@@ -151,6 +186,13 @@ pub struct ProofSpec {
     /// min_depth (if > 0) is the minimum number of InnerOps allowed (mainly for fixed-depth tries)
     #[prost(int32, tag = "4")]
     pub min_depth: i32,
+}
+impl ::prost::Name for ProofSpec {
+    const NAME: &'static str = "ProofSpec";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 ///
 /// InnerSpec contains all store-specific structure info to determine if two proofs from a
@@ -182,6 +224,13 @@ pub struct InnerSpec {
     #[prost(enumeration = "HashOp", tag = "6")]
     pub hash: i32,
 }
+impl ::prost::Name for InnerSpec {
+    const NAME: &'static str = "InnerSpec";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 ///
 /// BatchProof is a group of multiple proof types than can be compressed
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -189,6 +238,13 @@ pub struct InnerSpec {
 pub struct BatchProof {
     #[prost(message, repeated, tag = "1")]
     pub entries: ::prost::alloc::vec::Vec<BatchEntry>,
+}
+impl ::prost::Name for BatchProof {
+    const NAME: &'static str = "BatchProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 /// Use BatchEntry not CommitmentProof, to avoid recursion
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -208,6 +264,13 @@ pub mod batch_entry {
         Nonexist(super::NonExistenceProof),
     }
 }
+impl ::prost::Name for BatchEntry {
+    const NAME: &'static str = "BatchEntry";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedBatchProof {
@@ -215,6 +278,13 @@ pub struct CompressedBatchProof {
     pub entries: ::prost::alloc::vec::Vec<CompressedBatchEntry>,
     #[prost(message, repeated, tag = "2")]
     pub lookup_inners: ::prost::alloc::vec::Vec<InnerOp>,
+}
+impl ::prost::Name for CompressedBatchProof {
+    const NAME: &'static str = "CompressedBatchProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 /// Use BatchEntry not CommitmentProof, to avoid recursion
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -234,6 +304,13 @@ pub mod compressed_batch_entry {
         Nonexist(super::CompressedNonExistenceProof),
     }
 }
+impl ::prost::Name for CompressedBatchEntry {
+    const NAME: &'static str = "CompressedBatchEntry";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedExistenceProof {
@@ -247,6 +324,13 @@ pub struct CompressedExistenceProof {
     #[prost(int32, repeated, tag = "4")]
     pub path: ::prost::alloc::vec::Vec<i32>,
 }
+impl ::prost::Name for CompressedExistenceProof {
+    const NAME: &'static str = "CompressedExistenceProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompressedNonExistenceProof {
@@ -257,6 +341,13 @@ pub struct CompressedNonExistenceProof {
     pub left: ::core::option::Option<CompressedExistenceProof>,
     #[prost(message, optional, tag = "3")]
     pub right: ::core::option::Option<CompressedExistenceProof>,
+}
+impl ::prost::Name for CompressedNonExistenceProof {
+    const NAME: &'static str = "CompressedNonExistenceProof";
+    const PACKAGE: &'static str = "ics23";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("ics23.{}", Self::NAME)
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/cosmos-sdk-proto/src/type_names.rs
+++ b/cosmos-sdk-proto/src/type_names.rs
@@ -3,103 +3,16 @@
 // TODO(tarcieri): generate these automatically using `prost-build`
 // See: https://github.com/tokio-rs/prost/issues/926
 
-use crate::{cosmos, ibc, traits::Name};
+use crate::{cosmos, traits::Name};
 
 macro_rules! impl_name {
     ($type:ty, $package:expr, $name:expr) => {
         impl Name for $type {
             const NAME: &'static str = $name;
             const PACKAGE: &'static str = $package;
-
-            fn full_name() -> String {
-                full_name::<Self>()
-            }
         }
     };
 }
-
-impl_name!(
-    ibc::core::connection::v1::MsgConnectionOpenTry,
-    "ibc.core.connection.v1",
-    "MsgConnectionOpenTry"
-);
-impl_name!(
-    ibc::core::connection::v1::MsgConnectionOpenInit,
-    "ibc.core.connection.v1",
-    "MsgConnectionOpenInit"
-);
-impl_name!(
-    ibc::core::connection::v1::MsgConnectionOpenAck,
-    "ibc.core.connection.v1",
-    "MsgConnectionOpenAck"
-);
-impl_name!(
-    ibc::core::connection::v1::MsgConnectionOpenConfirm,
-    "ibc.core.connection.v1",
-    "MsgConnectionOpenConfirm"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgChannelOpenInit,
-    "ibc.core.channel.v1",
-    "MsgChannelOpenInit"
-);
-
-impl_name!(
-    ibc::core::client::v1::ClientUpdateProposal,
-    "ibc.core.client.v1",
-    "ClientUpdateProposal"
-);
-impl_name!(
-    ibc::core::client::v1::MsgCreateClient,
-    "ibc.core.client.v1",
-    "MsgCreateClient"
-);
-impl_name!(
-    ibc::core::client::v1::MsgUpdateClient,
-    "ibc.core.client.v1",
-    "MsgUpdateClient"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgChannelCloseConfirm,
-    "ibc.core.channel.v1",
-    "MsgChannelCloseConfirm"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgChannelOpenConfirm,
-    "ibc.core.channel.v1",
-    "MsgChannelOpenConfirm"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgChannelOpenTry,
-    "ibc.core.channel.v1",
-    "MsgChannelOpenTry"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgAcknowledgement,
-    "ibc.core.channel.v1",
-    "MsgAcknowledgement"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgChannelOpenAck,
-    "ibc.core.channel.v1",
-    "MsgChannelOpenAck"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgTimeout,
-    "ibc.core.channel.v1",
-    "MsgTimeout"
-);
-impl_name!(
-    ibc::core::channel::v1::MsgRecvPacket,
-    "ibc.core.channel.v1",
-    "MsgRecvPacket"
-);
-
-impl_name!(
-    ibc::applications::transfer::v1::MsgTransfer,
-    "ibc.applications.transfer.v1",
-    "MsgTransfer"
-);
 
 impl_name!(
     cosmos::upgrade::v1beta1::SoftwareUpgradeProposal,
@@ -442,7 +355,6 @@ impl_name!(
 
 #[cfg(feature = "cosmwasm")]
 mod wasm {
-    use super::full_name;
     use crate::{cosmwasm, traits::Name};
 
     const COSMWASM_PACKAGE: &str = "cosmwasm.wasm.v1";
@@ -572,9 +484,4 @@ mod wasm {
         COSMWASM_PACKAGE,
         "MsgClearAdminResponse"
     );
-}
-
-// TODO(tarcieri): remove this when tokio-rs/prost#923 is released (v0.12.1?)
-fn full_name<T: Name>() -> String {
-    format!("{}.{}", T::PACKAGE, T::NAME)
 }

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 prost = "0.12"
-prost-build = "0.12"
+prost-build = "0.12.3"
 tonic = "0.11"
 tonic-build = "0.11"
 regex = "1"

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -276,11 +276,16 @@ fn compile_ibc_protos_and_services(out_dir: &Path) {
         format!("{}/proto/ibc/lightclients/solomachine", ibc_dir.display()),
         format!("{}/proto/ibc/lightclients/tendermint", ibc_dir.display()),
     ];
+
     // List available proto files
     let mut protos: Vec<PathBuf> = vec![];
     collect_protos(&proto_paths, &mut protos);
 
     let includes: Vec<PathBuf> = proto_includes_paths.iter().map(PathBuf::from).collect();
+
+    // Enable generation of `prost::Name` annotations for all types
+    let mut config = prost_build::Config::new();
+    config.enable_type_names();
 
     // Compile all of the proto files, along with the grpc service clients
     info!("Compiling proto definitions and clients for GRPC services!");
@@ -289,7 +294,7 @@ fn compile_ibc_protos_and_services(out_dir: &Path) {
         .build_server(false)
         .out_dir(out_dir)
         .extern_path(".tendermint", "::tendermint_proto")
-        .compile(&protos, &includes)
+        .compile_with_config(config, &protos, &includes)
         .unwrap();
 
     info!("=> Done!");


### PR DESCRIPTION
Uses the recently added support in `prost-build` for automatically generating impls of the `Name` trait for IBC-related types, rather than maintaining them by hand in the `type_names` module.

Unfortunately we can only do this for the IBC protos, since we build the others using `buf`.