### PR TITLE
cosmos-sdk-proto v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.21.0-pre"
+version = "0.21.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased (0.21.0)
+## 0.21.0 (2024-03-15)
 ### Changed
-- Update `tonic` to v0.11
+- Update `tonic` to v0.11 ([#460])
+- Bump `tendermint-proto` dependency to v0.35 ([#461])
+- Use `prost-build` to gen IBC `Name` impls ([#462])
+
+[#460]: https://github.com/cosmos/cosmos-rust/pull/460
+[#461]: https://github.com/cosmos/cosmos-rust/pull/461
+[#462]: https://github.com/cosmos/cosmos-rust/pull/462
 
 ## 0.20.0 (2023-10-03)
 ### Added

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.21.0-pre"
+version = "0.21.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.21.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.21", default-features = false, path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Update `tonic` to v0.11 ([#460])
- Bump `tendermint-proto` dependency to v0.35 ([#461])
- Use `prost-build` to generate IBC `Name` impls ([#462])

[#460]: https://github.com/cosmos/cosmos-rust/pull/460
[#461]: https://github.com/cosmos/cosmos-rust/pull/461
[#462]: https://github.com/cosmos/cosmos-rust/pull/462