### PR TITLE
cosmos-sdk-proto v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.21.0 (2024-03-15)
+## 0.21.1 (2024-03-15)
+### Removed
+- Deprecated `MessageExt` methods: missed from v0.21.0, technically a breaking
+  change, but the just-published v0.21.0 release will be yanked ([#465])
+
+[#465]: https://github.com/cosmos/cosmos-rust/pull/465
+
+## 0.21.0 (2024-03-15) [YANKED]
 ### Changed
 - Update `tonic` to v0.11 ([#460])
 - Bump `tendermint-proto` dependency to v0.35 ([#461])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.21.0"
+version = "0.21.1"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",


### PR DESCRIPTION
### Removed
- Deprecated `MessageExt` methods: missed from v0.21.0, technically a breaking change, but the just-published v0.21.0 release will be yanked ([#465])

[#465]: https://github.com/cosmos/cosmos-rust/pull/465