### PR TITLE
cosmos-sdk-proto: add support for no_std

### DIFF
--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-prost = "0.13"
-prost-types = "0.13"
+prost = { version = "0.13", default-features = false }
+prost-types = { version = "0.13", default-features = false }
 tendermint-proto = "0.38"
 
 # Optional dependencies
@@ -25,7 +25,8 @@ tonic = { version = "0.12", optional = true, default-features = false, features 
 
 [features]
 default = ["grpc-transport"]
-grpc = ["tonic"]
+std = ["prost/std", "prost-types/std"]
+grpc = ["std", "tonic"]
 grpc-transport = ["grpc", "tonic/transport"]
 cosmwasm = []
 

--- a/cosmos-sdk-proto/src/lib.rs
+++ b/cosmos-sdk-proto/src/lib.rs
@@ -10,6 +10,9 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod traits;
 mod type_names;

--- a/cosmos-sdk-proto/src/traits.rs
+++ b/cosmos-sdk-proto/src/traits.rs
@@ -2,8 +2,9 @@
 
 pub use prost::{Message, Name};
 
+use alloc::{string::String, vec::Vec};
+use core::str::FromStr;
 use prost::EncodeError;
-use std::str::FromStr;
 
 /// Extension trait for [`Message`].
 pub trait MessageExt: Message {

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.23.0-pre", default-features = false, path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "=0.23.0-pre", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
This PR adds `no_std` support to `cosmos-sdk-proto` in a similar way that `tendermint-proto` chose. (`tendermint-proto` supports `no_std` by default unless the feature `grpc` is enabled. However, checking the feature `std` is a more common way to disable `std`.)

This would be a partial implementation of #397.