### PR TITLE
cosmrs: support coins with amount `0`, empty denom

### DIFF
--- a/cosmrs/src/base/denom.rs
+++ b/cosmrs/src/base/denom.rs
@@ -3,7 +3,7 @@ use serde::{de, de::Error as _, ser, Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 /// Denomination.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Denom(String);
 
 impl Denom {


### PR DESCRIPTION
These can be used when the gas fee is zero, for example

Fixes #477