### PR TITLE
cosmrs v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.18.0-pre"
+version = "0.18.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,13 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.0 (2024-08-02)
+### Added
+- Support `Coin` with amount `0` and empty denom ([#479])
+- Impl `Default` for `Coin` and `Denom` ([#479])
+
+### Changed
+- Bump tendermint-rs dependencies to v0.38 ([#476])
+- Bump `cosmos-sdk-proto` to 0.23 ([#480])
+
+[#476]: https://github.com/cosmos/cosmos-rust/pull/476
+[#479]: https://github.com/cosmos/cosmos-rust/pull/479
+[#480]: https://github.com/cosmos/cosmos-rust/pull/480
+
 ## 0.17.0 (2024-06-27)
 ### Added
 - Basic parsing of `msg_responses` field inside `TxMsgData` ([#472])
 
 ### Changed
 - Bump tendermint-rs dependencies to v0.37 ([#469])
-- Match upstream Cosmos SDK's Denom validation logic ([#468], [#470])
+- Match upstream Cosmos SDK's `Denom` validation logic ([#468], [#470])
 - Bump `cosmos-sdk-proto` to v0.22 ([#473])
 
 [#468]: https://github.com/cosmos/cosmos-rust/pull/468

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.18.0-pre"
+version = "0.18.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Added
- Support `Coin` with amount `0` and empty denom ([#479])
- Impl `Default` for `Coin` and `Denom` ([#479])

### Changed
- Bump tendermint-rs dependencies to v0.38 ([#476])
- Bump `cosmos-sdk-proto` to 0.23 ([#480])

[#476]: https://github.com/cosmos/cosmos-rust/pull/476
[#479]: https://github.com/cosmos/cosmos-rust/pull/479
[#480]: https://github.com/cosmos/cosmos-rust/pull/480