### PR TITLE
Bump tendermint-rs crates to v0.39.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a80791cbd52540b05798837bf2d07cb53bd7b59eaffc2e5181196361926daec"
+checksum = "2f3afea7809ffaaf1e5d9c3c9997cb3a834df7e94fbfab2fad2bc4577f1cde41"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -1814,7 +1814,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prost",
- "prost-types",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -1831,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a61aff4a3fc93807f5a38d10c3abbf26f3260eda376360307ccad30c34ce4d7"
+checksum = "d8add7b85b0282e5901521f78fe441956ac1e2752452f4e1f2c0ce7e1f10d485"
 dependencies = [
  "flex-error",
  "serde",
@@ -1845,13 +1844,13 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.39.0"
-source = "git+https://github.com/informalsystems/tendermint-rs#f1ebab84321de74d7770672d54f4bdf28a9ac65c"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3abf34ecf33125621519e9952688e7a59a98232d51538037ba21fbe526a802"
 dependencies = [
  "bytes",
  "flex-error",
  "prost",
- "prost-types",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -1860,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc330a25442d7f6b64e94029de18f4cf4f1e408aa129ef07eca9a5afd33cbb2f"
+checksum = "9693f42544bf3b41be3cbbfa418650c86e137fb8f5a57981659a84b677721ecf"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = [
     "cosmos-sdk-proto",
     "cosmrs"
 ]
-
-[patch.crates-io]
-tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs" }

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.72"
 
 [dependencies]
 prost = { version = "0.13", default-features = false }
-tendermint-proto = "0.39"
+tendermint-proto = "0.39.1"
 
 # Optional dependencies
 tonic = { version = "0.12", optional = true, default-features = false, features = ["codegen", "prost"] }

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -21,12 +21,12 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 signature = { version = "2", features = ["std"] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.39", features = ["secp256k1"] }
+tendermint = { version = "0.39.1", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
 bip32 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "secp256k1"] }
-tendermint-rpc = { version = "0.39", optional = true, features = ["http-client"] }
+tendermint-rpc = { version = "0.39.1", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Also removes `[patch.crates-io]` from Cargo.toml

These releases include some various bugfixes and API changes we need.