### PR TITLE
proto-build: remove unused tonic opts

### DIFF
--- a/proto-build/buf.sdk.gen.yaml
+++ b/proto-build/buf.sdk.gen.yaml
@@ -10,7 +10,3 @@ plugins:
     out: .
   - plugin: buf.build/community/neoeinstein-tonic:v0.3.0
     out: .
-    opt:
-      - compile_well_known_types
-      - extern_path=.google.protobuf=::tendermint_proto::google::protobuf
-      - extern_path=.tendermint=::tendermint_proto::v0_34

--- a/proto-build/buf.wasmd.gen.yaml
+++ b/proto-build/buf.wasmd.gen.yaml
@@ -11,6 +11,4 @@ plugins:
   - plugin: buf.build/community/neoeinstein-tonic:v0.3.0
     out: .
     opt:
-      - compile_well_known_types
-      - extern_path=.google.protobuf=::tendermint_proto::google::protobuf
       - no_server=true


### PR DESCRIPTION
These were inadvertently added to the config in the wrong place