### PR TITLE
cosmos-sdk-go: bump to v0.47.10 (fixups)

### DIFF
--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/amino.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/amino.rs
@@ -1,0 +1,2 @@
+// @generated
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.rs
@@ -1,0 +1,47 @@
+// @generated
+/// Module is the config object for the runtime module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// app_name is the name of the app.
+    #[prost(string, tag = "1")]
+    pub app_name: ::prost::alloc::string::String,
+    /// begin_blockers specifies the module names of begin blockers
+    /// to call in the order in which they should be called. If this is left empty
+    /// no begin blocker will be registered.
+    #[prost(string, repeated, tag = "2")]
+    pub begin_blockers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// end_blockers specifies the module names of the end blockers
+    /// to call in the order in which they should be called. If this is left empty
+    /// no end blocker will be registered.
+    #[prost(string, repeated, tag = "3")]
+    pub end_blockers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// init_genesis specifies the module names of init genesis functions
+    /// to call in the order in which they should be called. If this is left empty
+    /// no init genesis function will be registered.
+    #[prost(string, repeated, tag = "4")]
+    pub init_genesis: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// export_genesis specifies the order in which to export module genesis data.
+    /// If this is left empty, the init_genesis order will be used for export genesis
+    /// if it is specified.
+    #[prost(string, repeated, tag = "5")]
+    pub export_genesis: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// override_store_keys is an optional list of overrides for the module store keys
+    /// to be used in keeper construction.
+    #[prost(message, repeated, tag = "6")]
+    pub override_store_keys: ::prost::alloc::vec::Vec<StoreKeyConfig>,
+}
+/// StoreKeyConfig may be supplied to override the default module store key, which
+/// is the module name.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StoreKeyConfig {
+    /// name of the module to override the store key of
+    #[prost(string, tag = "1")]
+    pub module_name: ::prost::alloc::string::String,
+    /// the kv store key to use instead of the module name.
+    #[prost(string, tag = "2")]
+    pub kv_store_key: ::prost::alloc::string::String,
+}
+include!("cosmos.app.runtime.v1alpha1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.serde.rs
@@ -1,0 +1,312 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.app_name.is_empty() {
+            len += 1;
+        }
+        if !self.begin_blockers.is_empty() {
+            len += 1;
+        }
+        if !self.end_blockers.is_empty() {
+            len += 1;
+        }
+        if !self.init_genesis.is_empty() {
+            len += 1;
+        }
+        if !self.export_genesis.is_empty() {
+            len += 1;
+        }
+        if !self.override_store_keys.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.app.runtime.v1alpha1.Module", len)?;
+        if !self.app_name.is_empty() {
+            struct_ser.serialize_field("appName", &self.app_name)?;
+        }
+        if !self.begin_blockers.is_empty() {
+            struct_ser.serialize_field("beginBlockers", &self.begin_blockers)?;
+        }
+        if !self.end_blockers.is_empty() {
+            struct_ser.serialize_field("endBlockers", &self.end_blockers)?;
+        }
+        if !self.init_genesis.is_empty() {
+            struct_ser.serialize_field("initGenesis", &self.init_genesis)?;
+        }
+        if !self.export_genesis.is_empty() {
+            struct_ser.serialize_field("exportGenesis", &self.export_genesis)?;
+        }
+        if !self.override_store_keys.is_empty() {
+            struct_ser.serialize_field("overrideStoreKeys", &self.override_store_keys)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "app_name",
+            "appName",
+            "begin_blockers",
+            "beginBlockers",
+            "end_blockers",
+            "endBlockers",
+            "init_genesis",
+            "initGenesis",
+            "export_genesis",
+            "exportGenesis",
+            "override_store_keys",
+            "overrideStoreKeys",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AppName,
+            BeginBlockers,
+            EndBlockers,
+            InitGenesis,
+            ExportGenesis,
+            OverrideStoreKeys,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "appName" | "app_name" => Ok(GeneratedField::AppName),
+                            "beginBlockers" | "begin_blockers" => Ok(GeneratedField::BeginBlockers),
+                            "endBlockers" | "end_blockers" => Ok(GeneratedField::EndBlockers),
+                            "initGenesis" | "init_genesis" => Ok(GeneratedField::InitGenesis),
+                            "exportGenesis" | "export_genesis" => Ok(GeneratedField::ExportGenesis),
+                            "overrideStoreKeys" | "override_store_keys" => {
+                                Ok(GeneratedField::OverrideStoreKeys)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.app.runtime.v1alpha1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut app_name__ = None;
+                let mut begin_blockers__ = None;
+                let mut end_blockers__ = None;
+                let mut init_genesis__ = None;
+                let mut export_genesis__ = None;
+                let mut override_store_keys__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AppName => {
+                            if app_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("appName"));
+                            }
+                            app_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BeginBlockers => {
+                            if begin_blockers__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("beginBlockers"));
+                            }
+                            begin_blockers__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::EndBlockers => {
+                            if end_blockers__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("endBlockers"));
+                            }
+                            end_blockers__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::InitGenesis => {
+                            if init_genesis__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("initGenesis"));
+                            }
+                            init_genesis__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ExportGenesis => {
+                            if export_genesis__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("exportGenesis"));
+                            }
+                            export_genesis__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::OverrideStoreKeys => {
+                            if override_store_keys__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("overrideStoreKeys"));
+                            }
+                            override_store_keys__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    app_name: app_name__.unwrap_or_default(),
+                    begin_blockers: begin_blockers__.unwrap_or_default(),
+                    end_blockers: end_blockers__.unwrap_or_default(),
+                    init_genesis: init_genesis__.unwrap_or_default(),
+                    export_genesis: export_genesis__.unwrap_or_default(),
+                    override_store_keys: override_store_keys__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.app.runtime.v1alpha1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for StoreKeyConfig {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.module_name.is_empty() {
+            len += 1;
+        }
+        if !self.kv_store_key.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.app.runtime.v1alpha1.StoreKeyConfig", len)?;
+        if !self.module_name.is_empty() {
+            struct_ser.serialize_field("moduleName", &self.module_name)?;
+        }
+        if !self.kv_store_key.is_empty() {
+            struct_ser.serialize_field("kvStoreKey", &self.kv_store_key)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for StoreKeyConfig {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["module_name", "moduleName", "kv_store_key", "kvStoreKey"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ModuleName,
+            KvStoreKey,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "moduleName" | "module_name" => Ok(GeneratedField::ModuleName),
+                            "kvStoreKey" | "kv_store_key" => Ok(GeneratedField::KvStoreKey),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StoreKeyConfig;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.app.runtime.v1alpha1.StoreKeyConfig")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StoreKeyConfig, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut module_name__ = None;
+                let mut kv_store_key__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::ModuleName => {
+                            if module_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("moduleName"));
+                            }
+                            module_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::KvStoreKey => {
+                            if kv_store_key__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("kvStoreKey"));
+                            }
+                            kv_store_key__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(StoreKeyConfig {
+                    module_name: module_name__.unwrap_or_default(),
+                    kv_store_key: kv_store_key__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.app.runtime.v1alpha1.StoreKeyConfig",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.rs
@@ -92,6 +92,11 @@ pub struct Config {
     /// modules are the module configurations for the app.
     #[prost(message, repeated, tag = "1")]
     pub modules: ::prost::alloc::vec::Vec<ModuleConfig>,
+    /// golang_bindings specifies explicit interface to implementation type bindings which
+    /// depinject uses to resolve interface inputs to provider functions.  The scope of this
+    /// field's configuration is global (not module specific).
+    #[prost(message, repeated, tag = "2")]
+    pub golang_bindings: ::prost::alloc::vec::Vec<GolangBinding>,
 }
 /// ModuleConfig is a module configuration for an app.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -113,6 +118,22 @@ pub struct ModuleConfig {
     /// define a ModuleDescriptor using the cosmos.app.v1alpha1.is_module extension.
     #[prost(message, optional, tag = "2")]
     pub config: ::core::option::Option<::tendermint_proto::google::protobuf::Any>,
+    /// golang_bindings specifies explicit interface to implementation type bindings which
+    /// depinject uses to resolve interface inputs to provider functions.  The scope of this
+    /// field's configuration is module specific.
+    #[prost(message, repeated, tag = "3")]
+    pub golang_bindings: ::prost::alloc::vec::Vec<GolangBinding>,
+}
+/// GolangBinding is an explicit interface type to implementing type binding for dependency injection.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GolangBinding {
+    /// interface_type is the interface type which will be bound to a specific implementation type
+    #[prost(string, tag = "1")]
+    pub interface_type: ::prost::alloc::string::String,
+    /// implementation is the implementing type which will be supplied when an input of type interface is requested
+    #[prost(string, tag = "2")]
+    pub implementation: ::prost::alloc::string::String,
 }
 /// QueryConfigRequest is the Query/Config request type.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.serde.rs
@@ -11,9 +11,15 @@ impl serde::Serialize for Config {
         if !self.modules.is_empty() {
             len += 1;
         }
+        if !self.golang_bindings.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("cosmos.app.v1alpha1.Config", len)?;
         if !self.modules.is_empty() {
             struct_ser.serialize_field("modules", &self.modules)?;
+        }
+        if !self.golang_bindings.is_empty() {
+            struct_ser.serialize_field("golangBindings", &self.golang_bindings)?;
         }
         struct_ser.end()
     }
@@ -25,11 +31,12 @@ impl<'de> serde::Deserialize<'de> for Config {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["modules"];
+        const FIELDS: &[&str] = &["modules", "golang_bindings", "golangBindings"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Modules,
+            GolangBindings,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -56,6 +63,9 @@ impl<'de> serde::Deserialize<'de> for Config {
                     {
                         match value {
                             "modules" => Ok(GeneratedField::Modules),
+                            "golangBindings" | "golang_bindings" => {
+                                Ok(GeneratedField::GolangBindings)
+                            }
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -76,6 +86,7 @@ impl<'de> serde::Deserialize<'de> for Config {
                 V: serde::de::MapAccess<'de>,
             {
                 let mut modules__ = None;
+                let mut golang_bindings__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Modules => {
@@ -84,14 +95,137 @@ impl<'de> serde::Deserialize<'de> for Config {
                             }
                             modules__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::GolangBindings => {
+                            if golang_bindings__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("golangBindings"));
+                            }
+                            golang_bindings__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(Config {
                     modules: modules__.unwrap_or_default(),
+                    golang_bindings: golang_bindings__.unwrap_or_default(),
                 })
             }
         }
         deserializer.deserialize_struct("cosmos.app.v1alpha1.Config", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for GolangBinding {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.interface_type.is_empty() {
+            len += 1;
+        }
+        if !self.implementation.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.app.v1alpha1.GolangBinding", len)?;
+        if !self.interface_type.is_empty() {
+            struct_ser.serialize_field("interfaceType", &self.interface_type)?;
+        }
+        if !self.implementation.is_empty() {
+            struct_ser.serialize_field("implementation", &self.implementation)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for GolangBinding {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["interface_type", "interfaceType", "implementation"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            InterfaceType,
+            Implementation,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "interfaceType" | "interface_type" => Ok(GeneratedField::InterfaceType),
+                            "implementation" => Ok(GeneratedField::Implementation),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GolangBinding;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.app.v1alpha1.GolangBinding")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GolangBinding, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut interface_type__ = None;
+                let mut implementation__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::InterfaceType => {
+                            if interface_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("interfaceType"));
+                            }
+                            interface_type__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Implementation => {
+                            if implementation__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("implementation"));
+                            }
+                            implementation__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(GolangBinding {
+                    interface_type: interface_type__.unwrap_or_default(),
+                    implementation: implementation__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.app.v1alpha1.GolangBinding",
+            FIELDS,
+            GeneratedVisitor,
+        )
     }
 }
 #[cfg(feature = "serde")]
@@ -209,6 +343,9 @@ impl serde::Serialize for ModuleConfig {
         if self.config.is_some() {
             len += 1;
         }
+        if !self.golang_bindings.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.app.v1alpha1.ModuleConfig", len)?;
         if !self.name.is_empty() {
@@ -216,6 +353,9 @@ impl serde::Serialize for ModuleConfig {
         }
         if let Some(v) = self.config.as_ref() {
             struct_ser.serialize_field("config", v)?;
+        }
+        if !self.golang_bindings.is_empty() {
+            struct_ser.serialize_field("golangBindings", &self.golang_bindings)?;
         }
         struct_ser.end()
     }
@@ -227,12 +367,13 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["name", "config"];
+        const FIELDS: &[&str] = &["name", "config", "golang_bindings", "golangBindings"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Name,
             Config,
+            GolangBindings,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -260,6 +401,9 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
                         match value {
                             "name" => Ok(GeneratedField::Name),
                             "config" => Ok(GeneratedField::Config),
+                            "golangBindings" | "golang_bindings" => {
+                                Ok(GeneratedField::GolangBindings)
+                            }
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -281,6 +425,7 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
             {
                 let mut name__ = None;
                 let mut config__ = None;
+                let mut golang_bindings__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Name => {
@@ -295,11 +440,18 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
                             }
                             config__ = map_.next_value()?;
                         }
+                        GeneratedField::GolangBindings => {
+                            if golang_bindings__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("golangBindings"));
+                            }
+                            golang_bindings__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(ModuleConfig {
                     name: name__.unwrap_or_default(),
                     config: config__,
+                    golang_bindings: golang_bindings__.unwrap_or_default(),
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.rs
@@ -1,0 +1,29 @@
+// @generated
+/// Module is the config object for the auth module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// bech32_prefix is the bech32 account prefix for the app.
+    #[prost(string, tag = "1")]
+    pub bech32_prefix: ::prost::alloc::string::String,
+    /// module_account_permissions are module account permissions.
+    #[prost(message, repeated, tag = "2")]
+    pub module_account_permissions: ::prost::alloc::vec::Vec<ModuleAccountPermission>,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "3")]
+    pub authority: ::prost::alloc::string::String,
+}
+/// ModuleAccountPermission represents permissions for a module account.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModuleAccountPermission {
+    /// account is the name of the module.
+    #[prost(string, tag = "1")]
+    pub account: ::prost::alloc::string::String,
+    /// permissions are the permissions this module has. Currently recognized
+    /// values are minter, burner and staking.
+    #[prost(string, repeated, tag = "2")]
+    pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+include!("cosmos.auth.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.serde.rs
@@ -1,0 +1,258 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.bech32_prefix.is_empty() {
+            len += 1;
+        }
+        if !self.module_account_permissions.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.auth.module.v1.Module", len)?;
+        if !self.bech32_prefix.is_empty() {
+            struct_ser.serialize_field("bech32Prefix", &self.bech32_prefix)?;
+        }
+        if !self.module_account_permissions.is_empty() {
+            struct_ser
+                .serialize_field("moduleAccountPermissions", &self.module_account_permissions)?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "bech32_prefix",
+            "bech32Prefix",
+            "module_account_permissions",
+            "moduleAccountPermissions",
+            "authority",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Bech32Prefix,
+            ModuleAccountPermissions,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "bech32Prefix" | "bech32_prefix" => Ok(GeneratedField::Bech32Prefix),
+                            "moduleAccountPermissions" | "module_account_permissions" => {
+                                Ok(GeneratedField::ModuleAccountPermissions)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut bech32_prefix__ = None;
+                let mut module_account_permissions__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Bech32Prefix => {
+                            if bech32_prefix__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bech32Prefix"));
+                            }
+                            bech32_prefix__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ModuleAccountPermissions => {
+                            if module_account_permissions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "moduleAccountPermissions",
+                                ));
+                            }
+                            module_account_permissions__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    bech32_prefix: bech32_prefix__.unwrap_or_default(),
+                    module_account_permissions: module_account_permissions__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.auth.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ModuleAccountPermission {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.account.is_empty() {
+            len += 1;
+        }
+        if !self.permissions.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.auth.module.v1.ModuleAccountPermission", len)?;
+        if !self.account.is_empty() {
+            struct_ser.serialize_field("account", &self.account)?;
+        }
+        if !self.permissions.is_empty() {
+            struct_ser.serialize_field("permissions", &self.permissions)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ModuleAccountPermission {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["account", "permissions"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Account,
+            Permissions,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "account" => Ok(GeneratedField::Account),
+                            "permissions" => Ok(GeneratedField::Permissions),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ModuleAccountPermission;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.module.v1.ModuleAccountPermission")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<ModuleAccountPermission, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut account__ = None;
+                let mut permissions__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Account => {
+                            if account__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("account"));
+                            }
+                            account__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Permissions => {
+                            if permissions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("permissions"));
+                            }
+                            permissions__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(ModuleAccountPermission {
+                    account: account__.unwrap_or_default(),
+                    permissions: permissions__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.module.v1.ModuleAccountPermission",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.rs
@@ -25,6 +25,20 @@ pub struct ModuleAccount {
     #[prost(string, repeated, tag = "3")]
     pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// ModuleCredential represents a unclaimable pubkey for base accounts controlled by modules.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModuleCredential {
+    /// module_name is the name of the module used for address derivation (passed into address.Module).
+    #[prost(string, tag = "1")]
+    pub module_name: ::prost::alloc::string::String,
+    /// derivation_keys is for deriving a module account address (passed into address.Module)
+    /// adding more keys creates sub-account addresses (passed into address.Derive)
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub derivation_keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
 /// Params defines the parameters for the auth module.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -44,7 +58,7 @@ pub struct Params {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
-    /// params defines all the paramaters of the module.
+    /// params defines all the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// accounts are the accounts present at genesis.
@@ -188,11 +202,19 @@ pub struct AddressStringToBytesResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryAccountAddressByIdRequest {
+    /// Deprecated, use account_id instead
+    ///
     /// id is the account number of the address to be queried. This field
     /// should have been an uint64 (like all account numbers), and will be
     /// updated to uint64 in a future version of the auth query.
+    #[deprecated]
     #[prost(int64, tag = "1")]
     pub id: i64,
+    /// account_id is the account number of the address to be queried.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(uint64, tag = "2")]
+    pub account_id: u64,
 }
 /// QueryAccountAddressByIDResponse is the response type for AccountAddressByID rpc method
 ///
@@ -203,6 +225,48 @@ pub struct QueryAccountAddressByIdResponse {
     #[prost(string, tag = "1")]
     pub account_address: ::prost::alloc::string::String,
 }
+/// QueryAccountInfoRequest is the Query/AccountInfo request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAccountInfoRequest {
+    /// address is the account address string.
+    #[prost(string, tag = "1")]
+    pub address: ::prost::alloc::string::String,
+}
+/// QueryAccountInfoResponse is the Query/AccountInfo response type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryAccountInfoResponse {
+    /// info is the account info which is represented by BaseAccount.
+    #[prost(message, optional, tag = "1")]
+    pub info: ::core::option::Option<BaseAccount>,
+}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/auth parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.auth.v1beta1.serde.rs");
 include!("cosmos.auth.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.serde.rs
@@ -1017,6 +1017,339 @@ impl<'de> serde::Deserialize<'de> for ModuleAccount {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for ModuleCredential {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.module_name.is_empty() {
+            len += 1;
+        }
+        if !self.derivation_keys.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.auth.v1beta1.ModuleCredential", len)?;
+        if !self.module_name.is_empty() {
+            struct_ser.serialize_field("moduleName", &self.module_name)?;
+        }
+        if !self.derivation_keys.is_empty() {
+            struct_ser.serialize_field(
+                "derivationKeys",
+                &self
+                    .derivation_keys
+                    .iter()
+                    .map(pbjson::private::base64::encode)
+                    .collect::<Vec<_>>(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ModuleCredential {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "module_name",
+            "moduleName",
+            "derivation_keys",
+            "derivationKeys",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ModuleName,
+            DerivationKeys,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "moduleName" | "module_name" => Ok(GeneratedField::ModuleName),
+                            "derivationKeys" | "derivation_keys" => {
+                                Ok(GeneratedField::DerivationKeys)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ModuleCredential;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.v1beta1.ModuleCredential")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleCredential, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut module_name__ = None;
+                let mut derivation_keys__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::ModuleName => {
+                            if module_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("moduleName"));
+                            }
+                            module_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DerivationKeys => {
+                            if derivation_keys__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("derivationKeys"));
+                            }
+                            derivation_keys__ = Some(
+                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter()
+                                    .map(|x| x.0)
+                                    .collect(),
+                            );
+                        }
+                    }
+                }
+                Ok(ModuleCredential {
+                    module_name: module_name__.unwrap_or_default(),
+                    derivation_keys: derivation_keys__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.v1beta1.ModuleCredential",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.auth.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.auth.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.v1beta1.MsgUpdateParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -1245,11 +1578,19 @@ impl serde::Serialize for QueryAccountAddressByIdRequest {
         if self.id != 0 {
             len += 1;
         }
+        if self.account_id != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer
             .serialize_struct("cosmos.auth.v1beta1.QueryAccountAddressByIDRequest", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field("id", ToString::to_string(&self.id).as_str())?;
+        }
+        if self.account_id != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser
+                .serialize_field("accountId", ToString::to_string(&self.account_id).as_str())?;
         }
         struct_ser.end()
     }
@@ -1261,11 +1602,12 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["id"];
+        const FIELDS: &[&str] = &["id", "account_id", "accountId"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Id,
+            AccountId,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -1292,6 +1634,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
                     {
                         match value {
                             "id" => Ok(GeneratedField::Id),
+                            "accountId" | "account_id" => Ok(GeneratedField::AccountId),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -1315,6 +1658,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
                 V: serde::de::MapAccess<'de>,
             {
                 let mut id__ = None;
+                let mut account_id__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -1326,10 +1670,20 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
                                     .0,
                             );
                         }
+                        GeneratedField::AccountId => {
+                            if account_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("accountId"));
+                            }
+                            account_id__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
                     }
                 }
                 Ok(QueryAccountAddressByIdRequest {
                     id: id__.unwrap_or_default(),
+                    account_id: account_id__.unwrap_or_default(),
                 })
             }
         }
@@ -1440,6 +1794,210 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.auth.v1beta1.QueryAccountAddressByIDResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryAccountInfoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.address.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.auth.v1beta1.QueryAccountInfoRequest", len)?;
+        if !self.address.is_empty() {
+            struct_ser.serialize_field("address", &self.address)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["address"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Address,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "address" => Ok(GeneratedField::Address),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryAccountInfoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountInfoRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QueryAccountInfoRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Address => {
+                            if address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("address"));
+                            }
+                            address__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(QueryAccountInfoRequest {
+                    address: address__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.v1beta1.QueryAccountInfoRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryAccountInfoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.info.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.auth.v1beta1.QueryAccountInfoResponse", len)?;
+        if let Some(v) = self.info.as_ref() {
+            struct_ser.serialize_field("info", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["info"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Info,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "info" => Ok(GeneratedField::Info),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryAccountInfoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountInfoResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QueryAccountInfoResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut info__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Info => {
+                            if info__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("info"));
+                            }
+                            info__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(QueryAccountInfoResponse { info: info__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.auth.v1beta1.QueryAccountInfoResponse",
             FIELDS,
             GeneratedVisitor,
         )

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
@@ -271,6 +271,25 @@ pub mod query_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn account_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryAccountInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.auth.v1beta1.Query/AccountInfo");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.auth.v1beta1.Query", "AccountInfo"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -323,6 +342,10 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::AddressStringToBytesRequest>,
         ) -> std::result::Result<tonic::Response<super::AddressStringToBytesResponse>, tonic::Status>;
+        async fn account_info(
+            &self,
+            request: tonic::Request<super::QueryAccountInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -756,6 +779,44 @@ pub mod query_server {
                     };
                     Box::pin(fut)
                 }
+                "/cosmos.auth.v1beta1.Query/AccountInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct AccountInfoSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::QueryAccountInfoRequest> for AccountInfoSvc<T> {
+                        type Response = super::QueryAccountInfoResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QueryAccountInfoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).account_info(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = AccountInfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 _ => Box::pin(async move {
                     Ok(http::Response::builder()
                         .status(200)
@@ -791,5 +852,273 @@ pub mod query_server {
     }
     impl<T: Query> tonic::server::NamedService for QueryServer<T> {
         const NAME: &'static str = "cosmos.auth.v1beta1.Query";
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.auth.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.auth.v1beta1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    #[async_trait]
+    pub trait Msg: Send + Sync + 'static {
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct MsgServer<T: Msg> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Msg> MsgServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
+    where
+        T: Msg,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.auth.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Msg> Clone for MsgServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Msg> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
+        const NAME: &'static str = "cosmos.auth.v1beta1.Msg";
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.rs
@@ -1,7 +1,7 @@
 // @generated
-/// Module is the module config object for the cosmos.app v1 app module.
+/// Module is the config object of the authz module.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Module {}
-include!("cosmos.app.module.v1alpha1.serde.rs");
+include!("cosmos.authz.module.v1.serde.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.serde.rs
@@ -1,0 +1,75 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.authz.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.authz.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct("cosmos.authz.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.rs
@@ -173,7 +173,7 @@ pub struct MsgExecResponse {
 pub struct MsgExec {
     #[prost(string, tag = "1")]
     pub grantee: ::prost::alloc::string::String,
-    /// Authorization Msg requests to execute. Each msg must implement Authorization interface
+    /// Execute Msg.
     /// The x/authz will try to find a grant matching (msg.signers\[0\], grantee, MsgTypeURL(msg))
     /// triple and validate it.
     #[prost(message, repeated, tag = "2")]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.rs
@@ -1,0 +1,147 @@
+// @generated
+/// ModuleOptions describes the CLI options for a Cosmos SDK module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModuleOptions {
+    /// tx describes the tx command for the module.
+    #[prost(message, optional, tag = "1")]
+    pub tx: ::core::option::Option<ServiceCommandDescriptor>,
+    /// query describes the tx command for the module.
+    #[prost(message, optional, tag = "2")]
+    pub query: ::core::option::Option<ServiceCommandDescriptor>,
+}
+/// ServiceCommandDescriptor describes a CLI command based on a protobuf service.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServiceCommandDescriptor {
+    /// service is the fully qualified name of the protobuf service to build
+    /// the command from. It can be left empty if sub_commands are used instead
+    /// which may be the case if a module provides multiple tx and/or query services.
+    #[prost(string, tag = "1")]
+    pub service: ::prost::alloc::string::String,
+    /// rpc_command_options are options for commands generated from rpc methods.
+    /// If no options are specified for a given rpc method on the service, a
+    /// command will be generated for that method with the default options.
+    #[prost(message, repeated, tag = "2")]
+    pub rpc_command_options: ::prost::alloc::vec::Vec<RpcCommandOptions>,
+    /// sub_commands is a map of optional sub-commands for this command based on
+    /// different protobuf services. The map key is used as the name of the
+    /// sub-command.
+    #[prost(map = "string, message", tag = "3")]
+    pub sub_commands:
+        ::std::collections::HashMap<::prost::alloc::string::String, ServiceCommandDescriptor>,
+}
+/// RpcCommandOptions specifies options for commands generated from protobuf
+/// rpc methods.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcCommandOptions {
+    /// rpc_method is short name of the protobuf rpc method that this command is
+    /// generated from.
+    #[prost(string, tag = "1")]
+    pub rpc_method: ::prost::alloc::string::String,
+    /// use is the one-line usage method. It also allows specifying an alternate
+    /// name for the command as the first word of the usage text.
+    ///
+    /// By default the name of an rpc command is the kebab-case short name of the
+    /// rpc method.
+    #[prost(string, tag = "2")]
+    pub r#use: ::prost::alloc::string::String,
+    /// long is the long message shown in the 'help <this-command>' output.
+    #[prost(string, tag = "3")]
+    pub long: ::prost::alloc::string::String,
+    /// short is the short description shown in the 'help' output.
+    #[prost(string, tag = "4")]
+    pub short: ::prost::alloc::string::String,
+    /// example is examples of how to use the command.
+    #[prost(string, tag = "5")]
+    pub example: ::prost::alloc::string::String,
+    /// alias is an array of aliases that can be used instead of the first word in Use.
+    #[prost(string, repeated, tag = "6")]
+    pub alias: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// suggest_for is an array of command names for which this command will be suggested -
+    /// similar to aliases but only suggests.
+    #[prost(string, repeated, tag = "7")]
+    pub suggest_for: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// deprecated defines, if this command is deprecated and should print this string when used.
+    #[prost(string, tag = "8")]
+    pub deprecated: ::prost::alloc::string::String,
+    /// version defines the version for this command. If this value is non-empty and the command does not
+    /// define a "version" flag, a "version" boolean flag will be added to the command and, if specified,
+    /// will print content of the "Version" variable. A shorthand "v" flag will also be added if the
+    /// command does not define one.
+    #[prost(string, tag = "9")]
+    pub version: ::prost::alloc::string::String,
+    /// flag_options are options for flags generated from rpc request fields.
+    /// By default all request fields are configured as flags. They can
+    /// also be configured as positional args instead using positional_args.
+    #[prost(map = "string, message", tag = "10")]
+    pub flag_options: ::std::collections::HashMap<::prost::alloc::string::String, FlagOptions>,
+    /// positional_args specifies positional arguments for the command.
+    #[prost(message, repeated, tag = "11")]
+    pub positional_args: ::prost::alloc::vec::Vec<PositionalArgDescriptor>,
+    /// skip specifies whether to skip this rpc method when generating commands.
+    #[prost(bool, tag = "12")]
+    pub skip: bool,
+}
+/// FlagOptions are options for flags generated from rpc request fields.
+/// By default, all request fields are configured as flags based on the
+/// kebab-case name of the field. Fields can be turned into positional arguments
+/// instead by using RpcCommandOptions.positional_args.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlagOptions {
+    /// name is an alternate name to use for the field flag.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// shorthand is a one-letter abbreviated flag.
+    #[prost(string, tag = "2")]
+    pub shorthand: ::prost::alloc::string::String,
+    /// usage is the help message.
+    #[prost(string, tag = "3")]
+    pub usage: ::prost::alloc::string::String,
+    /// default_value is the default value as text.
+    #[prost(string, tag = "4")]
+    pub default_value: ::prost::alloc::string::String,
+    /// default value is the default value as text if the flag is used without any value.
+    #[prost(string, tag = "5")]
+    pub no_opt_default_value: ::prost::alloc::string::String,
+    /// deprecated is the usage text to show if this flag is deprecated.
+    #[prost(string, tag = "6")]
+    pub deprecated: ::prost::alloc::string::String,
+    /// shorthand_deprecated is the usage text to show if the shorthand of this flag is deprecated.
+    #[prost(string, tag = "7")]
+    pub shorthand_deprecated: ::prost::alloc::string::String,
+    /// hidden hides the flag from help/usage text
+    #[prost(bool, tag = "8")]
+    pub hidden: bool,
+}
+/// PositionalArgDescriptor describes a positional argument.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PositionalArgDescriptor {
+    /// proto_field specifies the proto field to use as the positional arg. Any
+    /// fields used as positional args will not have a flag generated.
+    #[prost(string, tag = "1")]
+    pub proto_field: ::prost::alloc::string::String,
+    /// varargs makes a positional parameter a varargs parameter. This can only be
+    /// applied to last positional parameter and the proto_field must a repeated
+    /// field.
+    #[prost(bool, tag = "2")]
+    pub varargs: bool,
+}
+/// AppOptionsRequest is the RemoteInfoService/AppOptions request type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppOptionsRequest {}
+/// AppOptionsResponse is the RemoteInfoService/AppOptions response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppOptionsResponse {
+    /// module_options is a map of module name to autocli module options.
+    #[prost(map = "string, message", tag = "1")]
+    pub module_options: ::std::collections::HashMap<::prost::alloc::string::String, ModuleOptions>,
+}
+include!("cosmos.autocli.v1.serde.rs");
+include!("cosmos.autocli.v1.tonic.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.serde.rs
@@ -1,0 +1,1075 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for AppOptionsRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.autocli.v1.AppOptionsRequest", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AppOptionsRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.AppOptionsRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AppOptionsRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(AppOptionsRequest {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.autocli.v1.AppOptionsRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for AppOptionsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.module_options.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.autocli.v1.AppOptionsResponse", len)?;
+        if !self.module_options.is_empty() {
+            struct_ser.serialize_field("moduleOptions", &self.module_options)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["module_options", "moduleOptions"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ModuleOptions,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "moduleOptions" | "module_options" => Ok(GeneratedField::ModuleOptions),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AppOptionsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.AppOptionsResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AppOptionsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut module_options__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::ModuleOptions => {
+                            if module_options__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("moduleOptions"));
+                            }
+                            module_options__ =
+                                Some(map_.next_value::<std::collections::HashMap<_, _>>()?);
+                        }
+                    }
+                }
+                Ok(AppOptionsResponse {
+                    module_options: module_options__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.autocli.v1.AppOptionsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for FlagOptions {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.name.is_empty() {
+            len += 1;
+        }
+        if !self.shorthand.is_empty() {
+            len += 1;
+        }
+        if !self.usage.is_empty() {
+            len += 1;
+        }
+        if !self.default_value.is_empty() {
+            len += 1;
+        }
+        if !self.no_opt_default_value.is_empty() {
+            len += 1;
+        }
+        if !self.deprecated.is_empty() {
+            len += 1;
+        }
+        if !self.shorthand_deprecated.is_empty() {
+            len += 1;
+        }
+        if self.hidden {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.autocli.v1.FlagOptions", len)?;
+        if !self.name.is_empty() {
+            struct_ser.serialize_field("name", &self.name)?;
+        }
+        if !self.shorthand.is_empty() {
+            struct_ser.serialize_field("shorthand", &self.shorthand)?;
+        }
+        if !self.usage.is_empty() {
+            struct_ser.serialize_field("usage", &self.usage)?;
+        }
+        if !self.default_value.is_empty() {
+            struct_ser.serialize_field("defaultValue", &self.default_value)?;
+        }
+        if !self.no_opt_default_value.is_empty() {
+            struct_ser.serialize_field("noOptDefaultValue", &self.no_opt_default_value)?;
+        }
+        if !self.deprecated.is_empty() {
+            struct_ser.serialize_field("deprecated", &self.deprecated)?;
+        }
+        if !self.shorthand_deprecated.is_empty() {
+            struct_ser.serialize_field("shorthandDeprecated", &self.shorthand_deprecated)?;
+        }
+        if self.hidden {
+            struct_ser.serialize_field("hidden", &self.hidden)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for FlagOptions {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "name",
+            "shorthand",
+            "usage",
+            "default_value",
+            "defaultValue",
+            "no_opt_default_value",
+            "noOptDefaultValue",
+            "deprecated",
+            "shorthand_deprecated",
+            "shorthandDeprecated",
+            "hidden",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Name,
+            Shorthand,
+            Usage,
+            DefaultValue,
+            NoOptDefaultValue,
+            Deprecated,
+            ShorthandDeprecated,
+            Hidden,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "name" => Ok(GeneratedField::Name),
+                            "shorthand" => Ok(GeneratedField::Shorthand),
+                            "usage" => Ok(GeneratedField::Usage),
+                            "defaultValue" | "default_value" => Ok(GeneratedField::DefaultValue),
+                            "noOptDefaultValue" | "no_opt_default_value" => {
+                                Ok(GeneratedField::NoOptDefaultValue)
+                            }
+                            "deprecated" => Ok(GeneratedField::Deprecated),
+                            "shorthandDeprecated" | "shorthand_deprecated" => {
+                                Ok(GeneratedField::ShorthandDeprecated)
+                            }
+                            "hidden" => Ok(GeneratedField::Hidden),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FlagOptions;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.FlagOptions")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FlagOptions, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut name__ = None;
+                let mut shorthand__ = None;
+                let mut usage__ = None;
+                let mut default_value__ = None;
+                let mut no_opt_default_value__ = None;
+                let mut deprecated__ = None;
+                let mut shorthand_deprecated__ = None;
+                let mut hidden__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Name => {
+                            if name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("name"));
+                            }
+                            name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Shorthand => {
+                            if shorthand__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("shorthand"));
+                            }
+                            shorthand__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Usage => {
+                            if usage__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("usage"));
+                            }
+                            usage__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DefaultValue => {
+                            if default_value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("defaultValue"));
+                            }
+                            default_value__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::NoOptDefaultValue => {
+                            if no_opt_default_value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("noOptDefaultValue"));
+                            }
+                            no_opt_default_value__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Deprecated => {
+                            if deprecated__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deprecated"));
+                            }
+                            deprecated__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ShorthandDeprecated => {
+                            if shorthand_deprecated__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "shorthandDeprecated",
+                                ));
+                            }
+                            shorthand_deprecated__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Hidden => {
+                            if hidden__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hidden"));
+                            }
+                            hidden__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(FlagOptions {
+                    name: name__.unwrap_or_default(),
+                    shorthand: shorthand__.unwrap_or_default(),
+                    usage: usage__.unwrap_or_default(),
+                    default_value: default_value__.unwrap_or_default(),
+                    no_opt_default_value: no_opt_default_value__.unwrap_or_default(),
+                    deprecated: deprecated__.unwrap_or_default(),
+                    shorthand_deprecated: shorthand_deprecated__.unwrap_or_default(),
+                    hidden: hidden__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.autocli.v1.FlagOptions", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ModuleOptions {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.tx.is_some() {
+            len += 1;
+        }
+        if self.query.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.autocli.v1.ModuleOptions", len)?;
+        if let Some(v) = self.tx.as_ref() {
+            struct_ser.serialize_field("tx", v)?;
+        }
+        if let Some(v) = self.query.as_ref() {
+            struct_ser.serialize_field("query", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ModuleOptions {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tx", "query"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Tx,
+            Query,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "tx" => Ok(GeneratedField::Tx),
+                            "query" => Ok(GeneratedField::Query),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ModuleOptions;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.ModuleOptions")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleOptions, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut tx__ = None;
+                let mut query__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Tx => {
+                            if tx__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("tx"));
+                            }
+                            tx__ = map_.next_value()?;
+                        }
+                        GeneratedField::Query => {
+                            if query__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("query"));
+                            }
+                            query__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(ModuleOptions {
+                    tx: tx__,
+                    query: query__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.autocli.v1.ModuleOptions", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for PositionalArgDescriptor {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.proto_field.is_empty() {
+            len += 1;
+        }
+        if self.varargs {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.autocli.v1.PositionalArgDescriptor", len)?;
+        if !self.proto_field.is_empty() {
+            struct_ser.serialize_field("protoField", &self.proto_field)?;
+        }
+        if self.varargs {
+            struct_ser.serialize_field("varargs", &self.varargs)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["proto_field", "protoField", "varargs"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ProtoField,
+            Varargs,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "protoField" | "proto_field" => Ok(GeneratedField::ProtoField),
+                            "varargs" => Ok(GeneratedField::Varargs),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PositionalArgDescriptor;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.PositionalArgDescriptor")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<PositionalArgDescriptor, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut proto_field__ = None;
+                let mut varargs__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::ProtoField => {
+                            if proto_field__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("protoField"));
+                            }
+                            proto_field__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Varargs => {
+                            if varargs__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("varargs"));
+                            }
+                            varargs__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(PositionalArgDescriptor {
+                    proto_field: proto_field__.unwrap_or_default(),
+                    varargs: varargs__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.autocli.v1.PositionalArgDescriptor",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for RpcCommandOptions {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.rpc_method.is_empty() {
+            len += 1;
+        }
+        if !self.r#use.is_empty() {
+            len += 1;
+        }
+        if !self.long.is_empty() {
+            len += 1;
+        }
+        if !self.short.is_empty() {
+            len += 1;
+        }
+        if !self.example.is_empty() {
+            len += 1;
+        }
+        if !self.alias.is_empty() {
+            len += 1;
+        }
+        if !self.suggest_for.is_empty() {
+            len += 1;
+        }
+        if !self.deprecated.is_empty() {
+            len += 1;
+        }
+        if !self.version.is_empty() {
+            len += 1;
+        }
+        if !self.flag_options.is_empty() {
+            len += 1;
+        }
+        if !self.positional_args.is_empty() {
+            len += 1;
+        }
+        if self.skip {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.autocli.v1.RpcCommandOptions", len)?;
+        if !self.rpc_method.is_empty() {
+            struct_ser.serialize_field("rpcMethod", &self.rpc_method)?;
+        }
+        if !self.r#use.is_empty() {
+            struct_ser.serialize_field("use", &self.r#use)?;
+        }
+        if !self.long.is_empty() {
+            struct_ser.serialize_field("long", &self.long)?;
+        }
+        if !self.short.is_empty() {
+            struct_ser.serialize_field("short", &self.short)?;
+        }
+        if !self.example.is_empty() {
+            struct_ser.serialize_field("example", &self.example)?;
+        }
+        if !self.alias.is_empty() {
+            struct_ser.serialize_field("alias", &self.alias)?;
+        }
+        if !self.suggest_for.is_empty() {
+            struct_ser.serialize_field("suggestFor", &self.suggest_for)?;
+        }
+        if !self.deprecated.is_empty() {
+            struct_ser.serialize_field("deprecated", &self.deprecated)?;
+        }
+        if !self.version.is_empty() {
+            struct_ser.serialize_field("version", &self.version)?;
+        }
+        if !self.flag_options.is_empty() {
+            struct_ser.serialize_field("flagOptions", &self.flag_options)?;
+        }
+        if !self.positional_args.is_empty() {
+            struct_ser.serialize_field("positionalArgs", &self.positional_args)?;
+        }
+        if self.skip {
+            struct_ser.serialize_field("skip", &self.skip)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rpc_method",
+            "rpcMethod",
+            "use",
+            "long",
+            "short",
+            "example",
+            "alias",
+            "suggest_for",
+            "suggestFor",
+            "deprecated",
+            "version",
+            "flag_options",
+            "flagOptions",
+            "positional_args",
+            "positionalArgs",
+            "skip",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RpcMethod,
+            Use,
+            Long,
+            Short,
+            Example,
+            Alias,
+            SuggestFor,
+            Deprecated,
+            Version,
+            FlagOptions,
+            PositionalArgs,
+            Skip,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rpcMethod" | "rpc_method" => Ok(GeneratedField::RpcMethod),
+                            "use" => Ok(GeneratedField::Use),
+                            "long" => Ok(GeneratedField::Long),
+                            "short" => Ok(GeneratedField::Short),
+                            "example" => Ok(GeneratedField::Example),
+                            "alias" => Ok(GeneratedField::Alias),
+                            "suggestFor" | "suggest_for" => Ok(GeneratedField::SuggestFor),
+                            "deprecated" => Ok(GeneratedField::Deprecated),
+                            "version" => Ok(GeneratedField::Version),
+                            "flagOptions" | "flag_options" => Ok(GeneratedField::FlagOptions),
+                            "positionalArgs" | "positional_args" => {
+                                Ok(GeneratedField::PositionalArgs)
+                            }
+                            "skip" => Ok(GeneratedField::Skip),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = RpcCommandOptions;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.RpcCommandOptions")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<RpcCommandOptions, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut rpc_method__ = None;
+                let mut r#use__ = None;
+                let mut long__ = None;
+                let mut short__ = None;
+                let mut example__ = None;
+                let mut alias__ = None;
+                let mut suggest_for__ = None;
+                let mut deprecated__ = None;
+                let mut version__ = None;
+                let mut flag_options__ = None;
+                let mut positional_args__ = None;
+                let mut skip__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RpcMethod => {
+                            if rpc_method__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rpcMethod"));
+                            }
+                            rpc_method__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Use => {
+                            if r#use__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("use"));
+                            }
+                            r#use__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Long => {
+                            if long__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("long"));
+                            }
+                            long__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Short => {
+                            if short__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("short"));
+                            }
+                            short__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Example => {
+                            if example__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("example"));
+                            }
+                            example__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Alias => {
+                            if alias__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("alias"));
+                            }
+                            alias__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SuggestFor => {
+                            if suggest_for__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("suggestFor"));
+                            }
+                            suggest_for__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Deprecated => {
+                            if deprecated__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deprecated"));
+                            }
+                            deprecated__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Version => {
+                            if version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("version"));
+                            }
+                            version__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::FlagOptions => {
+                            if flag_options__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("flagOptions"));
+                            }
+                            flag_options__ =
+                                Some(map_.next_value::<std::collections::HashMap<_, _>>()?);
+                        }
+                        GeneratedField::PositionalArgs => {
+                            if positional_args__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("positionalArgs"));
+                            }
+                            positional_args__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Skip => {
+                            if skip__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("skip"));
+                            }
+                            skip__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(RpcCommandOptions {
+                    rpc_method: rpc_method__.unwrap_or_default(),
+                    r#use: r#use__.unwrap_or_default(),
+                    long: long__.unwrap_or_default(),
+                    short: short__.unwrap_or_default(),
+                    example: example__.unwrap_or_default(),
+                    alias: alias__.unwrap_or_default(),
+                    suggest_for: suggest_for__.unwrap_or_default(),
+                    deprecated: deprecated__.unwrap_or_default(),
+                    version: version__.unwrap_or_default(),
+                    flag_options: flag_options__.unwrap_or_default(),
+                    positional_args: positional_args__.unwrap_or_default(),
+                    skip: skip__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.autocli.v1.RpcCommandOptions",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ServiceCommandDescriptor {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.service.is_empty() {
+            len += 1;
+        }
+        if !self.rpc_command_options.is_empty() {
+            len += 1;
+        }
+        if !self.sub_commands.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.autocli.v1.ServiceCommandDescriptor", len)?;
+        if !self.service.is_empty() {
+            struct_ser.serialize_field("service", &self.service)?;
+        }
+        if !self.rpc_command_options.is_empty() {
+            struct_ser.serialize_field("rpcCommandOptions", &self.rpc_command_options)?;
+        }
+        if !self.sub_commands.is_empty() {
+            struct_ser.serialize_field("subCommands", &self.sub_commands)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ServiceCommandDescriptor {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "service",
+            "rpc_command_options",
+            "rpcCommandOptions",
+            "sub_commands",
+            "subCommands",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Service,
+            RpcCommandOptions,
+            SubCommands,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "service" => Ok(GeneratedField::Service),
+                            "rpcCommandOptions" | "rpc_command_options" => {
+                                Ok(GeneratedField::RpcCommandOptions)
+                            }
+                            "subCommands" | "sub_commands" => Ok(GeneratedField::SubCommands),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ServiceCommandDescriptor;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.autocli.v1.ServiceCommandDescriptor")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<ServiceCommandDescriptor, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut service__ = None;
+                let mut rpc_command_options__ = None;
+                let mut sub_commands__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Service => {
+                            if service__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("service"));
+                            }
+                            service__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::RpcCommandOptions => {
+                            if rpc_command_options__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rpcCommandOptions"));
+                            }
+                            rpc_command_options__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SubCommands => {
+                            if sub_commands__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("subCommands"));
+                            }
+                            sub_commands__ =
+                                Some(map_.next_value::<std::collections::HashMap<_, _>>()?);
+                        }
+                    }
+                }
+                Ok(ServiceCommandDescriptor {
+                    service: service__.unwrap_or_default(),
+                    rpc_command_options: rpc_command_options__.unwrap_or_default(),
+                    sub_commands: sub_commands__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.autocli.v1.ServiceCommandDescriptor",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.tonic.rs
@@ -1,0 +1,271 @@
+// @generated
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl QueryClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QueryClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            QueryClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn app_options(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AppOptionsRequest>,
+        ) -> std::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.autocli.v1.Query/AppOptions");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.autocli.v1.Query", "AppOptions"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod query_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    #[async_trait]
+    pub trait Query: Send + Sync + 'static {
+        async fn app_options(
+            &self,
+            request: tonic::Request<super::AppOptionsRequest>,
+        ) -> std::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct QueryServer<T: Query> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Query> QueryServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
+    where
+        T: Query,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.autocli.v1.Query/AppOptions" => {
+                    #[allow(non_camel_case_types)]
+                    struct AppOptionsSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::AppOptionsRequest> for AppOptionsSvc<T> {
+                        type Response = super::AppOptionsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AppOptionsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).app_options(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = AppOptionsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Query> Clone for QueryServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Query> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
+        const NAME: &'static str = "cosmos.autocli.v1.Query";
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.rs
@@ -1,0 +1,16 @@
+// @generated
+/// Module is the config object of the bank module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// blocked_module_accounts configures exceptional module accounts which should be blocked from receiving funds.
+    /// If left empty it defaults to the list of account names supplied in the auth module configuration as
+    /// module_account_permissions
+    #[prost(string, repeated, tag = "1")]
+    pub blocked_module_accounts_override: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.bank.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.serde.rs
@@ -1,0 +1,125 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.blocked_module_accounts_override.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.bank.module.v1.Module", len)?;
+        if !self.blocked_module_accounts_override.is_empty() {
+            struct_ser.serialize_field(
+                "blockedModuleAccountsOverride",
+                &self.blocked_module_accounts_override,
+            )?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "blocked_module_accounts_override",
+            "blockedModuleAccountsOverride",
+            "authority",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockedModuleAccountsOverride,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockedModuleAccountsOverride"
+                            | "blocked_module_accounts_override" => {
+                                Ok(GeneratedField::BlockedModuleAccountsOverride)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut blocked_module_accounts_override__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockedModuleAccountsOverride => {
+                            if blocked_module_accounts_override__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "blockedModuleAccountsOverride",
+                                ));
+                            }
+                            blocked_module_accounts_override__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    blocked_module_accounts_override: blocked_module_accounts_override__
+                        .unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.bank.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.rs
@@ -8,11 +8,23 @@
 pub struct SendAuthorization {
     #[prost(message, repeated, tag = "1")]
     pub spend_limit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// allow_list specifies an optional list of addresses to whom the grantee can send tokens on behalf of the
+    /// granter. If omitted, any recipient is allowed.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, repeated, tag = "2")]
+    pub allow_list: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Params defines the parameters for the bank module.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
+    /// Deprecated: Use of SendEnabled in params is deprecated.
+    /// For genesis, use the newly added send_enabled field in the genesis object.
+    /// Storage, lookup, and manipulation of this information is now in the keeper.
+    ///
+    /// As of cosmos-sdk 0.47, this only exists for backwards compatibility of genesis files.
+    #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub send_enabled: ::prost::alloc::vec::Vec<SendEnabled>,
     #[prost(bool, tag = "2")]
@@ -118,7 +130,7 @@ pub struct Metadata {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
-    /// params defines all the paramaters of the module.
+    /// params defines all the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// balances is an array containing the balances of all the accounts.
@@ -128,9 +140,14 @@ pub struct GenesisState {
     /// balances. Otherwise, it will be used to validate that the sum of the balances equals this amount.
     #[prost(message, repeated, tag = "3")]
     pub supply: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    /// denom_metadata defines the metadata of the differents coins.
+    /// denom_metadata defines the metadata of the different coins.
     #[prost(message, repeated, tag = "4")]
     pub denom_metadata: ::prost::alloc::vec::Vec<Metadata>,
+    /// send_enabled defines the denoms where send is enabled or disabled.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(message, repeated, tag = "5")]
+    pub send_enabled: ::prost::alloc::vec::Vec<SendEnabled>,
 }
 /// Balance defines an account address and balance pair used in the bank module's
 /// genesis state.
@@ -213,6 +230,31 @@ pub struct QuerySpendableBalancesResponse {
     /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QuerySpendableBalanceByDenomRequest defines the gRPC request structure for
+/// querying an account's spendable balance for a specific denom.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySpendableBalanceByDenomRequest {
+    /// address is the address to query balances for.
+    #[prost(string, tag = "1")]
+    pub address: ::prost::alloc::string::String,
+    /// denom is the coin denom to query balances for.
+    #[prost(string, tag = "2")]
+    pub denom: ::prost::alloc::string::String,
+}
+/// QuerySpendableBalanceByDenomResponse defines the gRPC response structure for
+/// querying an account's spendable balance for a specific denom.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySpendableBalanceByDenomResponse {
+    /// balance is the balance of the coin.
+    #[prost(message, optional, tag = "1")]
+    pub balance: ::core::option::Option<super::super::base::v1beta1::Coin>,
 }
 /// QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
 /// method.
@@ -343,6 +385,33 @@ pub struct QueryDenomOwnersResponse {
     #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
+/// QuerySendEnabledRequest defines the RPC request for looking up SendEnabled entries.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySendEnabledRequest {
+    /// denoms is the specific denoms you want look up. Leave empty to get all entries.
+    #[prost(string, repeated, tag = "1")]
+    pub denoms: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// pagination defines an optional pagination for the request. This field is
+    /// only read if the denoms field is empty.
+    #[prost(message, optional, tag = "99")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QuerySendEnabledResponse defines the RPC response of a SendEnable query.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuerySendEnabledResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub send_enabled: ::prost::alloc::vec::Vec<SendEnabled>,
+    /// pagination defines the pagination in the response. This field is only
+    /// populated if the denoms field in the request is empty.
+    #[prost(message, optional, tag = "99")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
 /// MsgSend represents a message to send coins from one account to another.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -362,6 +431,8 @@ pub struct MsgSendResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgMultiSend {
+    /// Inputs, despite being `repeated`, only allows one sender input. This is
+    /// checked in MsgMultiSend's ValidateBasic.
     #[prost(message, repeated, tag = "1")]
     pub inputs: ::prost::alloc::vec::Vec<Input>,
     #[prost(message, repeated, tag = "2")]
@@ -371,6 +442,56 @@ pub struct MsgMultiSend {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgMultiSendResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/bank parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
+/// MsgSetSendEnabled is the Msg/SetSendEnabled request type.
+///
+/// Only entries to add/update/delete need to be included.
+/// Existing SendEnabled entries that are not included in this
+/// message are left unchanged.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetSendEnabled {
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// send_enabled is the list of entries to add or update.
+    #[prost(message, repeated, tag = "2")]
+    pub send_enabled: ::prost::alloc::vec::Vec<SendEnabled>,
+    /// use_default_for is a list of denoms that should use the params.default_send_enabled value.
+    /// Denoms listed here will have their SendEnabled entries deleted.
+    /// If a denom is included that doesn't have a SendEnabled entry,
+    /// it will be ignored.
+    #[prost(string, repeated, tag = "3")]
+    pub use_default_for: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// MsgSetSendEnabledResponse defines the Msg/SetSendEnabled response type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgSetSendEnabledResponse {}
 include!("cosmos.bank.v1beta1.serde.rs");
 include!("cosmos.bank.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.serde.rs
@@ -372,6 +372,9 @@ impl serde::Serialize for GenesisState {
         if !self.denom_metadata.is_empty() {
             len += 1;
         }
+        if !self.send_enabled.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.bank.v1beta1.GenesisState", len)?;
         if let Some(v) = self.params.as_ref() {
@@ -385,6 +388,9 @@ impl serde::Serialize for GenesisState {
         }
         if !self.denom_metadata.is_empty() {
             struct_ser.serialize_field("denomMetadata", &self.denom_metadata)?;
+        }
+        if !self.send_enabled.is_empty() {
+            struct_ser.serialize_field("sendEnabled", &self.send_enabled)?;
         }
         struct_ser.end()
     }
@@ -402,6 +408,8 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
             "supply",
             "denom_metadata",
             "denomMetadata",
+            "send_enabled",
+            "sendEnabled",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -410,6 +418,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
             Balances,
             Supply,
             DenomMetadata,
+            SendEnabled,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -439,6 +448,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                             "balances" => Ok(GeneratedField::Balances),
                             "supply" => Ok(GeneratedField::Supply),
                             "denomMetadata" | "denom_metadata" => Ok(GeneratedField::DenomMetadata),
+                            "sendEnabled" | "send_enabled" => Ok(GeneratedField::SendEnabled),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -462,6 +472,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                 let mut balances__ = None;
                 let mut supply__ = None;
                 let mut denom_metadata__ = None;
+                let mut send_enabled__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Params => {
@@ -488,6 +499,12 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                             }
                             denom_metadata__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::SendEnabled => {
+                            if send_enabled__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sendEnabled"));
+                            }
+                            send_enabled__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(GenesisState {
@@ -495,6 +512,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                     balances: balances__.unwrap_or_default(),
                     supply: supply__.unwrap_or_default(),
                     denom_metadata: denom_metadata__.unwrap_or_default(),
+                    send_enabled: send_enabled__.unwrap_or_default(),
                 })
             }
         }
@@ -1238,6 +1256,426 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.bank.v1beta1.MsgSendResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgSetSendEnabled {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if !self.send_enabled.is_empty() {
+            len += 1;
+        }
+        if !self.use_default_for.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.MsgSetSendEnabled", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if !self.send_enabled.is_empty() {
+            struct_ser.serialize_field("sendEnabled", &self.send_enabled)?;
+        }
+        if !self.use_default_for.is_empty() {
+            struct_ser.serialize_field("useDefaultFor", &self.use_default_for)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "authority",
+            "send_enabled",
+            "sendEnabled",
+            "use_default_for",
+            "useDefaultFor",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            SendEnabled,
+            UseDefaultFor,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "sendEnabled" | "send_enabled" => Ok(GeneratedField::SendEnabled),
+                            "useDefaultFor" | "use_default_for" => {
+                                Ok(GeneratedField::UseDefaultFor)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgSetSendEnabled;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.MsgSetSendEnabled")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSetSendEnabled, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut send_enabled__ = None;
+                let mut use_default_for__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SendEnabled => {
+                            if send_enabled__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sendEnabled"));
+                            }
+                            send_enabled__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::UseDefaultFor => {
+                            if use_default_for__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("useDefaultFor"));
+                            }
+                            use_default_for__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(MsgSetSendEnabled {
+                    authority: authority__.unwrap_or_default(),
+                    send_enabled: send_enabled__.unwrap_or_default(),
+                    use_default_for: use_default_for__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.MsgSetSendEnabled",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgSetSendEnabledResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.MsgSetSendEnabledResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgSetSendEnabledResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.MsgSetSendEnabledResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgSetSendEnabledResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgSetSendEnabledResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.MsgSetSendEnabledResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.MsgUpdateParamsResponse",
             FIELDS,
             GeneratedVisitor,
         )
@@ -2773,6 +3211,470 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for QuerySendEnabledRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.denoms.is_empty() {
+            len += 1;
+        }
+        if self.pagination.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.QuerySendEnabledRequest", len)?;
+        if !self.denoms.is_empty() {
+            struct_ser.serialize_field("denoms", &self.denoms)?;
+        }
+        if let Some(v) = self.pagination.as_ref() {
+            struct_ser.serialize_field("pagination", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["denoms", "pagination"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Denoms,
+            Pagination,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "denoms" => Ok(GeneratedField::Denoms),
+                            "pagination" => Ok(GeneratedField::Pagination),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QuerySendEnabledRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.QuerySendEnabledRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QuerySendEnabledRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut denoms__ = None;
+                let mut pagination__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Denoms => {
+                            if denoms__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denoms"));
+                            }
+                            denoms__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Pagination => {
+                            if pagination__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pagination"));
+                            }
+                            pagination__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(QuerySendEnabledRequest {
+                    denoms: denoms__.unwrap_or_default(),
+                    pagination: pagination__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.QuerySendEnabledRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QuerySendEnabledResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.send_enabled.is_empty() {
+            len += 1;
+        }
+        if self.pagination.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.bank.v1beta1.QuerySendEnabledResponse", len)?;
+        if !self.send_enabled.is_empty() {
+            struct_ser.serialize_field("sendEnabled", &self.send_enabled)?;
+        }
+        if let Some(v) = self.pagination.as_ref() {
+            struct_ser.serialize_field("pagination", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["send_enabled", "sendEnabled", "pagination"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SendEnabled,
+            Pagination,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "sendEnabled" | "send_enabled" => Ok(GeneratedField::SendEnabled),
+                            "pagination" => Ok(GeneratedField::Pagination),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QuerySendEnabledResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.bank.v1beta1.QuerySendEnabledResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QuerySendEnabledResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut send_enabled__ = None;
+                let mut pagination__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SendEnabled => {
+                            if send_enabled__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sendEnabled"));
+                            }
+                            send_enabled__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Pagination => {
+                            if pagination__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pagination"));
+                            }
+                            pagination__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(QuerySendEnabledResponse {
+                    send_enabled: send_enabled__.unwrap_or_default(),
+                    pagination: pagination__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.QuerySendEnabledResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QuerySpendableBalanceByDenomRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.address.is_empty() {
+            len += 1;
+        }
+        if !self.denom.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct(
+            "cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest",
+            len,
+        )?;
+        if !self.address.is_empty() {
+            struct_ser.serialize_field("address", &self.address)?;
+        }
+        if !self.denom.is_empty() {
+            struct_ser.serialize_field("denom", &self.denom)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["address", "denom"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Address,
+            Denom,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "address" => Ok(GeneratedField::Address),
+                            "denom" => Ok(GeneratedField::Denom),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QuerySpendableBalanceByDenomRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter
+                    .write_str("struct cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QuerySpendableBalanceByDenomRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut address__ = None;
+                let mut denom__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Address => {
+                            if address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("address"));
+                            }
+                            address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Denom => {
+                            if denom__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denom"));
+                            }
+                            denom__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(QuerySpendableBalanceByDenomRequest {
+                    address: address__.unwrap_or_default(),
+                    denom: denom__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QuerySpendableBalanceByDenomResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.balance.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct(
+            "cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse",
+            len,
+        )?;
+        if let Some(v) = self.balance.as_ref() {
+            struct_ser.serialize_field("balance", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["balance"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Balance,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "balance" => Ok(GeneratedField::Balance),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QuerySpendableBalanceByDenomResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter
+                    .write_str("struct cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QuerySpendableBalanceByDenomResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut balance__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Balance => {
+                            if balance__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("balance"));
+                            }
+                            balance__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(QuerySpendableBalanceByDenomResponse { balance: balance__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for QuerySpendableBalancesRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -3448,10 +4350,16 @@ impl serde::Serialize for SendAuthorization {
         if !self.spend_limit.is_empty() {
             len += 1;
         }
+        if !self.allow_list.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.bank.v1beta1.SendAuthorization", len)?;
         if !self.spend_limit.is_empty() {
             struct_ser.serialize_field("spendLimit", &self.spend_limit)?;
+        }
+        if !self.allow_list.is_empty() {
+            struct_ser.serialize_field("allowList", &self.allow_list)?;
         }
         struct_ser.end()
     }
@@ -3463,11 +4371,12 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["spend_limit", "spendLimit"];
+        const FIELDS: &[&str] = &["spend_limit", "spendLimit", "allow_list", "allowList"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             SpendLimit,
+            AllowList,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -3494,6 +4403,7 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
                     {
                         match value {
                             "spendLimit" | "spend_limit" => Ok(GeneratedField::SpendLimit),
+                            "allowList" | "allow_list" => Ok(GeneratedField::AllowList),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -3514,6 +4424,7 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
                 V: serde::de::MapAccess<'de>,
             {
                 let mut spend_limit__ = None;
+                let mut allow_list__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::SpendLimit => {
@@ -3522,10 +4433,17 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
                             }
                             spend_limit__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::AllowList => {
+                            if allow_list__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("allowList"));
+                            }
+                            allow_list__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(SendAuthorization {
                     spend_limit: spend_limit__.unwrap_or_default(),
+                    allow_list: allow_list__.unwrap_or_default(),
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
@@ -146,6 +146,30 @@ pub mod query_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn spendable_balance_by_denom(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QuerySpendableBalanceByDenomRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::QuerySpendableBalanceByDenomResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.bank.v1beta1.Query/SpendableBalanceByDenom",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.bank.v1beta1.Query",
+                "SpendableBalanceByDenom",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn total_supply(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryTotalSupplyRequest>,
@@ -262,6 +286,25 @@ pub mod query_client {
                 .insert(GrpcMethod::new("cosmos.bank.v1beta1.Query", "DenomOwners"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn send_enabled(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QuerySendEnabledRequest>,
+        ) -> std::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.bank.v1beta1.Query/SendEnabled");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.bank.v1beta1.Query", "SendEnabled"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -285,6 +328,13 @@ pub mod query_server {
             request: tonic::Request<super::QuerySpendableBalancesRequest>,
         ) -> std::result::Result<
             tonic::Response<super::QuerySpendableBalancesResponse>,
+            tonic::Status,
+        >;
+        async fn spendable_balance_by_denom(
+            &self,
+            request: tonic::Request<super::QuerySpendableBalanceByDenomRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::QuerySpendableBalanceByDenomResponse>,
             tonic::Status,
         >;
         async fn total_supply(
@@ -311,6 +361,10 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryDenomOwnersRequest>,
         ) -> std::result::Result<tonic::Response<super::QueryDenomOwnersResponse>, tonic::Status>;
+        async fn send_enabled(
+            &self,
+            request: tonic::Request<super::QuerySendEnabledRequest>,
+        ) -> std::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -489,6 +543,48 @@ pub mod query_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = SpendableBalancesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.bank.v1beta1.Query/SpendableBalanceByDenom" => {
+                    #[allow(non_camel_case_types)]
+                    struct SpendableBalanceByDenomSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query>
+                        tonic::server::UnaryService<super::QuerySpendableBalanceByDenomRequest>
+                        for SpendableBalanceByDenomSvc<T>
+                    {
+                        type Response = super::QuerySpendableBalanceByDenomResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QuerySpendableBalanceByDenomRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut =
+                                async move { (*inner).spendable_balance_by_denom(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SpendableBalanceByDenomSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -736,6 +832,44 @@ pub mod query_server {
                     };
                     Box::pin(fut)
                 }
+                "/cosmos.bank.v1beta1.Query/SendEnabled" => {
+                    #[allow(non_camel_case_types)]
+                    struct SendEnabledSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::QuerySendEnabledRequest> for SendEnabledSvc<T> {
+                        type Response = super::QuerySendEnabledResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QuerySendEnabledRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).send_enabled(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SendEnabledSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 _ => Box::pin(async move {
                     Ok(http::Response::builder()
                         .status(200)
@@ -891,6 +1025,44 @@ pub mod msg_client {
                 .insert(GrpcMethod::new("cosmos.bank.v1beta1.Msg", "MultiSend"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.bank.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.bank.v1beta1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn set_send_enabled(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgSetSendEnabled>,
+        ) -> std::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.bank.v1beta1.Msg/SetSendEnabled");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.bank.v1beta1.Msg", "SetSendEnabled"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -909,6 +1081,14 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgMultiSend>,
         ) -> std::result::Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status>;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        async fn set_send_enabled(
+            &self,
+            request: tonic::Request<super::MsgSetSendEnabled>,
+        ) -> std::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1047,6 +1227,82 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = MultiSendSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.bank.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.bank.v1beta1.Msg/SetSendEnabled" => {
+                    #[allow(non_camel_case_types)]
+                    struct SetSendEnabledSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgSetSendEnabled> for SetSendEnabledSvc<T> {
+                        type Response = super::MsgSetSendEnabledResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgSetSendEnabled>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).set_send_enabled(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SetSendEnabledSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.snapshots.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.snapshots.v1beta1.rs
@@ -101,6 +101,7 @@ pub struct SnapshotExtensionPayload {
 /// SnapshotKVItem is an exported Key/Value Pair
 ///
 /// Since: cosmos-sdk 0.46
+/// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotKvItem {
@@ -112,6 +113,7 @@ pub struct SnapshotKvItem {
 /// SnapshotSchema is an exported schema of smt store
 ///
 /// Since: cosmos-sdk 0.46
+/// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnapshotSchema {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.rs
@@ -8,6 +8,8 @@ pub struct CommitInfo {
     pub version: i64,
     #[prost(message, repeated, tag = "2")]
     pub store_infos: ::prost::alloc::vec::Vec<StoreInfo>,
+    #[prost(message, optional, tag = "3")]
+    pub timestamp: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
 }
 /// StoreInfo defines store-specific commit information. It contains a reference
 /// between a store name and the commit ID.
@@ -19,7 +21,7 @@ pub struct StoreInfo {
     #[prost(message, optional, tag = "2")]
     pub commit_id: ::core::option::Option<CommitId>,
 }
-/// CommitID defines the committment information when a specific store is
+/// CommitID defines the commitment information when a specific store is
 /// committed.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.store.v1beta1.serde.rs
@@ -463,6 +463,9 @@ impl serde::Serialize for CommitInfo {
         if !self.store_infos.is_empty() {
             len += 1;
         }
+        if self.timestamp.is_some() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.base.store.v1beta1.CommitInfo", len)?;
         if self.version != 0 {
@@ -471,6 +474,9 @@ impl serde::Serialize for CommitInfo {
         }
         if !self.store_infos.is_empty() {
             struct_ser.serialize_field("storeInfos", &self.store_infos)?;
+        }
+        if let Some(v) = self.timestamp.as_ref() {
+            struct_ser.serialize_field("timestamp", v)?;
         }
         struct_ser.end()
     }
@@ -482,12 +488,13 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["version", "store_infos", "storeInfos"];
+        const FIELDS: &[&str] = &["version", "store_infos", "storeInfos", "timestamp"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Version,
             StoreInfos,
+            Timestamp,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -515,6 +522,7 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
                         match value {
                             "version" => Ok(GeneratedField::Version),
                             "storeInfos" | "store_infos" => Ok(GeneratedField::StoreInfos),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -536,6 +544,7 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
             {
                 let mut version__ = None;
                 let mut store_infos__ = None;
+                let mut timestamp__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Version => {
@@ -553,11 +562,18 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
                             }
                             store_infos__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Timestamp => {
+                            if timestamp__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            timestamp__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(CommitInfo {
                     version: version__.unwrap_or_default(),
                     store_infos: store_infos__.unwrap_or_default(),
+                    timestamp: timestamp__,
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.rs
@@ -67,8 +67,7 @@ pub struct Header {
     #[prost(string, tag = "14")]
     pub proposer_address: ::prost::alloc::string::String,
 }
-/// GetValidatorSetByHeightRequest is the request type for the
-/// Query/GetValidatorSetByHeight RPC method.
+/// GetValidatorSetByHeightRequest is the request type for the Query/GetValidatorSetByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetValidatorSetByHeightRequest {
@@ -78,8 +77,7 @@ pub struct GetValidatorSetByHeightRequest {
     #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::query::v1beta1::PageRequest>,
 }
-/// GetValidatorSetByHeightResponse is the response type for the
-/// Query/GetValidatorSetByHeight RPC method.
+/// GetValidatorSetByHeightResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetValidatorSetByHeightResponse {
@@ -91,8 +89,7 @@ pub struct GetValidatorSetByHeightResponse {
     #[prost(message, optional, tag = "3")]
     pub pagination: ::core::option::Option<super::super::query::v1beta1::PageResponse>,
 }
-/// GetLatestValidatorSetRequest is the request type for the
-/// Query/GetValidatorSetByHeight RPC method.
+/// GetLatestValidatorSetRequest is the request type for the Query/GetValidatorSetByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestValidatorSetRequest {
@@ -100,8 +97,7 @@ pub struct GetLatestValidatorSetRequest {
     #[prost(message, optional, tag = "1")]
     pub pagination: ::core::option::Option<super::super::query::v1beta1::PageRequest>,
 }
-/// GetLatestValidatorSetResponse is the response type for the
-/// Query/GetValidatorSetByHeight RPC method.
+/// GetLatestValidatorSetResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestValidatorSetResponse {
@@ -126,16 +122,14 @@ pub struct Validator {
     #[prost(int64, tag = "4")]
     pub proposer_priority: i64,
 }
-/// GetBlockByHeightRequest is the request type for the Query/GetBlockByHeight
-/// RPC method.
+/// GetBlockByHeightRequest is the request type for the Query/GetBlockByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockByHeightRequest {
     #[prost(int64, tag = "1")]
     pub height: i64,
 }
-/// GetBlockByHeightResponse is the response type for the Query/GetBlockByHeight
-/// RPC method.
+/// GetBlockByHeightResponse is the response type for the Query/GetBlockByHeight RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockByHeightResponse {
@@ -148,13 +142,11 @@ pub struct GetBlockByHeightResponse {
     #[prost(message, optional, tag = "3")]
     pub sdk_block: ::core::option::Option<Block>,
 }
-/// GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC
-/// method.
+/// GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestBlockRequest {}
-/// GetLatestBlockResponse is the response type for the Query/GetLatestBlock RPC
-/// method.
+/// GetLatestBlockResponse is the response type for the Query/GetLatestBlock RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestBlockResponse {
@@ -182,8 +174,7 @@ pub struct GetSyncingResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoRequest {}
-/// GetNodeInfoResponse is the response type for the Query/GetNodeInfo RPC
-/// method.
+/// GetNodeInfoResponse is the response type for the Query/GetNodeInfo RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoResponse {
@@ -241,8 +232,7 @@ pub struct AbciQueryRequest {
     #[prost(bool, tag = "4")]
     pub prove: bool,
 }
-/// ABCIQueryResponse defines the response structure for the ABCIQuery gRPC
-/// query.
+/// ABCIQueryResponse defines the response structure for the ABCIQuery gRPC query.
 ///
 /// Note: This type is a duplicate of the ResponseQuery proto type defined in
 /// Tendermint.
@@ -271,11 +261,10 @@ pub struct AbciQueryResponse {
     pub codespace: ::prost::alloc::string::String,
 }
 /// ProofOp defines an operation used for calculating Merkle root. The data could
-/// be arbitrary format, providing nessecary data for example neighbouring node
+/// be arbitrary format, providing necessary data for example neighbouring node
 /// hash.
 ///
-/// Note: This type is a duplicate of the ProofOp proto type defined in
-/// Tendermint.
+/// Note: This type is a duplicate of the ProofOp proto type defined in Tendermint.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofOp {
@@ -288,8 +277,7 @@ pub struct ProofOp {
 }
 /// ProofOps is Merkle proof defined by the list of ProofOps.
 ///
-/// Note: This type is a duplicate of the ProofOps proto type defined in
-/// Tendermint.
+/// Note: This type is a duplicate of the ProofOps proto type defined in Tendermint.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofOps {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.capability.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.capability.module.v1.rs
@@ -1,0 +1,12 @@
+// @generated
+/// Module is the config object of the capability module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// seal_keeper defines if keeper.Seal() will run on BeginBlock() to prevent further modules from creating a scoped
+    /// keeper. For more details check x/capability/keeper.go.
+    #[prost(bool, tag = "1")]
+    pub seal_keeper: bool,
+}
+include!("cosmos.capability.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.capability.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.capability.module.v1.serde.rs
@@ -1,0 +1,101 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.seal_keeper {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.capability.module.v1.Module", len)?;
+        if self.seal_keeper {
+            struct_ser.serialize_field("sealKeeper", &self.seal_keeper)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["seal_keeper", "sealKeeper"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SealKeeper,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "sealKeeper" | "seal_keeper" => Ok(GeneratedField::SealKeeper),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.capability.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut seal_keeper__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SealKeeper => {
+                            if seal_keeper__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sealKeeper"));
+                            }
+                            seal_keeper__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    seal_keeper: seal_keeper__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.capability.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.rs
@@ -1,0 +1,11 @@
+// @generated
+/// Module is the config object of the consensus module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.consensus.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.serde.rs
@@ -1,0 +1,101 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.consensus.module.v1.Module", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.consensus.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.consensus.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.rs
@@ -1,0 +1,42 @@
+// @generated
+/// QueryParamsRequest defines the request type for querying x/consensus parameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsRequest {}
+/// QueryParamsResponse defines the response type for querying x/consensus parameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryParamsResponse {
+    /// params are the tendermint consensus params stored in the consensus module.
+    /// Please note that `params.version` is not populated in this response, it is
+    /// tracked separately in the x/upgrade module.
+    #[prost(message, optional, tag = "1")]
+    pub params: ::core::option::Option<::tendermint_proto::v0_34::types::ConsensusParams>,
+}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/consensus parameters to update.
+    /// VersionsParams is not included in this Msg because it is tracked
+    /// separarately in x/upgrade.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub block: ::core::option::Option<::tendermint_proto::v0_34::types::BlockParams>,
+    #[prost(message, optional, tag = "3")]
+    pub evidence: ::core::option::Option<::tendermint_proto::v0_34::types::EvidenceParams>,
+    #[prost(message, optional, tag = "4")]
+    pub validator: ::core::option::Option<::tendermint_proto::v0_34::types::ValidatorParams>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
+include!("cosmos.consensus.v1.serde.rs");
+include!("cosmos.consensus.v1.tonic.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.serde.rs
@@ -1,0 +1,408 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.block.is_some() {
+            len += 1;
+        }
+        if self.evidence.is_some() {
+            len += 1;
+        }
+        if self.validator.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.consensus.v1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.block.as_ref() {
+            struct_ser.serialize_field("block", v)?;
+        }
+        if let Some(v) = self.evidence.as_ref() {
+            struct_ser.serialize_field("evidence", v)?;
+        }
+        if let Some(v) = self.validator.as_ref() {
+            struct_ser.serialize_field("validator", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "block", "evidence", "validator"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Block,
+            Evidence,
+            Validator,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "block" => Ok(GeneratedField::Block),
+                            "evidence" => Ok(GeneratedField::Evidence),
+                            "validator" => Ok(GeneratedField::Validator),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.consensus.v1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut block__ = None;
+                let mut evidence__ = None;
+                let mut validator__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = map_.next_value()?;
+                        }
+                        GeneratedField::Evidence => {
+                            if evidence__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("evidence"));
+                            }
+                            evidence__ = map_.next_value()?;
+                        }
+                        GeneratedField::Validator => {
+                            if validator__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validator"));
+                            }
+                            validator__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    block: block__,
+                    evidence: evidence__,
+                    validator: validator__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.consensus.v1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.consensus.v1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.consensus.v1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.consensus.v1.MsgUpdateParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryParamsRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.consensus.v1.QueryParamsRequest", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryParamsRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.consensus.v1.QueryParamsRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(QueryParamsRequest {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.consensus.v1.QueryParamsRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.consensus.v1.QueryParamsResponse", len)?;
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.consensus.v1.QueryParamsResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(QueryParamsResponse { params: params__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.consensus.v1.QueryParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.tonic.rs
@@ -1,0 +1,539 @@
+// @generated
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl QueryClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QueryClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            QueryClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryParamsRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.consensus.v1.Query/Params");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.consensus.v1.Query", "Params"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod query_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    #[async_trait]
+    pub trait Query: Send + Sync + 'static {
+        async fn params(
+            &self,
+            request: tonic::Request<super::QueryParamsRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct QueryServer<T: Query> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Query> QueryServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
+    where
+        T: Query,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.consensus.v1.Query/Params" => {
+                    #[allow(non_camel_case_types)]
+                    struct ParamsSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::QueryParamsRequest> for ParamsSvc<T> {
+                        type Response = super::QueryParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QueryParamsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Query> Clone for QueryServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Query> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
+        const NAME: &'static str = "cosmos.consensus.v1.Query";
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.consensus.v1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.consensus.v1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    #[async_trait]
+    pub trait Msg: Send + Sync + 'static {
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct MsgServer<T: Msg> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Msg> MsgServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
+    where
+        T: Msg,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.consensus.v1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Msg> Clone for MsgServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Msg> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
+        const NAME: &'static str = "cosmos.consensus.v1.Msg";
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.rs
@@ -1,0 +1,14 @@
+// @generated
+/// Module is the config object of the crisis module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// fee_collector_name is the name of the FeeCollector ModuleAccount.
+    #[prost(string, tag = "1")]
+    pub fee_collector_name: ::prost::alloc::string::String,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.crisis.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.serde.rs
@@ -1,0 +1,114 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.fee_collector_name.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.crisis.module.v1.Module", len)?;
+        if !self.fee_collector_name.is_empty() {
+            struct_ser.serialize_field("feeCollectorName", &self.fee_collector_name)?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["fee_collector_name", "feeCollectorName", "authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            FeeCollectorName,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "feeCollectorName" | "fee_collector_name" => {
+                                Ok(GeneratedField::FeeCollectorName)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.crisis.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut fee_collector_name__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::FeeCollectorName => {
+                            if fee_collector_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeCollectorName"));
+                            }
+                            fee_collector_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    fee_collector_name: fee_collector_name__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.crisis.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.rs
@@ -12,10 +12,13 @@ pub struct GenesisState {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVerifyInvariant {
+    /// sender is the account address of private key to send coins to fee collector account.
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
+    /// name of the invariant module.
     #[prost(string, tag = "2")]
     pub invariant_module_name: ::prost::alloc::string::String,
+    /// invariant_route is the msg's invariant route.
     #[prost(string, tag = "3")]
     pub invariant_route: ::prost::alloc::string::String,
 }
@@ -23,6 +26,26 @@ pub struct MsgVerifyInvariant {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVerifyInvariantResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// constant_fee defines the x/crisis parameter.
+    #[prost(message, optional, tag = "2")]
+    pub constant_fee: ::core::option::Option<super::super::base::v1beta1::Coin>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.crisis.v1beta1.serde.rs");
 include!("cosmos.crisis.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.serde.rs
@@ -100,6 +100,204 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.constant_fee.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.crisis.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.constant_fee.as_ref() {
+            struct_ser.serialize_field("constantFee", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "constant_fee", "constantFee"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            ConstantFee,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "constantFee" | "constant_fee" => Ok(GeneratedField::ConstantFee),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.crisis.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut constant_fee__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ConstantFee => {
+                            if constant_fee__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("constantFee"));
+                            }
+                            constant_fee__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    constant_fee: constant_fee__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.crisis.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.crisis.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.crisis.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.crisis.v1beta1.MsgUpdateParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for MsgVerifyInvariant {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
@@ -103,6 +103,25 @@ pub mod msg_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.crisis.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.crisis.v1beta1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -117,6 +136,10 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgVerifyInvariant>,
         ) -> std::result::Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status>;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -217,6 +240,44 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = VerifyInvariantSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.crisis.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.rs
@@ -1,0 +1,13 @@
+// @generated
+/// Module is the config object of the distribution module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    #[prost(string, tag = "1")]
+    pub fee_collector_name: ::prost::alloc::string::String,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.distribution.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.serde.rs
@@ -1,0 +1,119 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.fee_collector_name.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.distribution.module.v1.Module", len)?;
+        if !self.fee_collector_name.is_empty() {
+            struct_ser.serialize_field("feeCollectorName", &self.fee_collector_name)?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["fee_collector_name", "feeCollectorName", "authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            FeeCollectorName,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "feeCollectorName" | "fee_collector_name" => {
+                                Ok(GeneratedField::FeeCollectorName)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.distribution.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut fee_collector_name__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::FeeCollectorName => {
+                            if fee_collector_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeCollectorName"));
+                            }
+                            fee_collector_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    fee_collector_name: fee_collector_name__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.rs
@@ -5,8 +5,14 @@
 pub struct Params {
     #[prost(string, tag = "1")]
     pub community_tax: ::prost::alloc::string::String,
+    /// Deprecated: The base_proposer_reward field is deprecated and is no longer used
+    /// in the x/distribution module's reward mechanism.
+    #[deprecated]
     #[prost(string, tag = "2")]
     pub base_proposer_reward: ::prost::alloc::string::String,
+    /// Deprecated: The bonus_proposer_reward field is deprecated and is no longer used
+    /// in the x/distribution module's reward mechanism.
+    #[deprecated]
     #[prost(string, tag = "3")]
     pub bonus_proposer_reward: ::prost::alloc::string::String,
     #[prost(bool, tag = "4")]
@@ -88,6 +94,11 @@ pub struct FeePool {
 /// CommunityPoolSpendProposal details a proposal for use of community funds,
 /// together with how many coins are proposed to be spent, and to which
 /// recipient account.
+///
+/// Deprecated: Do not use. As of the Cosmos SDK release v0.47.x, there is no
+/// longer a need for an explicit CommunityPoolSpendProposal. To spend community
+/// pool funds, a simple MsgCommunityPoolSpend can be invoked from the x/gov
+/// module via a v1 governance proposal.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommunityPoolSpendProposal {
@@ -162,7 +173,7 @@ pub struct ValidatorOutstandingRewardsRecord {
     /// validator_address is the address of the validator.
     #[prost(string, tag = "1")]
     pub validator_address: ::prost::alloc::string::String,
-    /// outstanding_rewards represents the oustanding rewards of a validator.
+    /// outstanding_rewards represents the outstanding rewards of a validator.
     #[prost(message, repeated, tag = "2")]
     pub outstanding_rewards: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
 }
@@ -225,7 +236,7 @@ pub struct ValidatorSlashEventRecord {
     /// validator_address is the address of the validator.
     #[prost(string, tag = "1")]
     pub validator_address: ::prost::alloc::string::String,
-    /// height defines the block height at which the slash event occured.
+    /// height defines the block height at which the slash event occurred.
     #[prost(uint64, tag = "2")]
     pub height: u64,
     /// period is the period of the slash event.
@@ -239,7 +250,7 @@ pub struct ValidatorSlashEventRecord {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
-    /// params defines all the paramaters of the module.
+    /// params defines all the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// fee_pool defines the fee pool at genesis.
@@ -254,7 +265,7 @@ pub struct GenesisState {
     /// fee_pool defines the outstanding rewards of all validators at genesis.
     #[prost(message, repeated, tag = "5")]
     pub outstanding_rewards: ::prost::alloc::vec::Vec<ValidatorOutstandingRewardsRecord>,
-    /// fee_pool defines the accumulated commisions of all validators at genesis.
+    /// fee_pool defines the accumulated commissions of all validators at genesis.
     #[prost(message, repeated, tag = "6")]
     pub validator_accumulated_commissions:
         ::prost::alloc::vec::Vec<ValidatorAccumulatedCommissionRecord>,
@@ -282,6 +293,28 @@ pub struct QueryParamsResponse {
     /// params defines the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
+}
+/// QueryValidatorDistributionInfoRequest is the request type for the Query/ValidatorDistributionInfo RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorDistributionInfoRequest {
+    /// validator_address defines the validator address to query for.
+    #[prost(string, tag = "1")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+/// QueryValidatorDistributionInfoResponse is the response type for the Query/ValidatorDistributionInfo RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryValidatorDistributionInfoResponse {
+    /// operator_address defines the validator operator address.
+    #[prost(string, tag = "1")]
+    pub operator_address: ::prost::alloc::string::String,
+    /// self_bond_rewards defines the self delegations rewards.
+    #[prost(message, repeated, tag = "2")]
+    pub self_bond_rewards: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
+    /// commission defines the commission the validator received.
+    #[prost(message, repeated, tag = "3")]
+    pub commission: ::prost::alloc::vec::Vec<super::super::base::v1beta1::DecCoin>,
 }
 /// QueryValidatorOutstandingRewardsRequest is the request type for the
 /// Query/ValidatorOutstandingRewards RPC method.
@@ -314,7 +347,7 @@ pub struct QueryValidatorCommissionRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryValidatorCommissionResponse {
-    /// commission defines the commision the validator received.
+    /// commission defines the commission the validator received.
     #[prost(message, optional, tag = "1")]
     pub commission: ::core::option::Option<ValidatorAccumulatedCommission>,
 }
@@ -450,7 +483,8 @@ pub struct MsgSetWithdrawAddress {
     #[prost(string, tag = "2")]
     pub withdraw_address: ::prost::alloc::string::String,
 }
-/// MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response type.
+/// MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response
+/// type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSetWithdrawAddressResponse {}
@@ -464,7 +498,8 @@ pub struct MsgWithdrawDelegatorReward {
     #[prost(string, tag = "2")]
     pub validator_address: ::prost::alloc::string::String,
 }
-/// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
+/// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward
+/// response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgWithdrawDelegatorRewardResponse {
@@ -480,7 +515,8 @@ pub struct MsgWithdrawValidatorCommission {
     #[prost(string, tag = "1")]
     pub validator_address: ::prost::alloc::string::String,
 }
-/// MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
+/// MsgWithdrawValidatorCommissionResponse defines the
+/// Msg/WithdrawValidatorCommission response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgWithdrawValidatorCommissionResponse {
@@ -502,6 +538,51 @@ pub struct MsgFundCommunityPool {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgFundCommunityPoolResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/distribution parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
+/// MsgCommunityPoolSpend defines a message for sending tokens from the community
+/// pool to another account. This message is typically executed via a governance
+/// proposal with the governance module being the executing authority.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCommunityPoolSpend {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub recipient: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgCommunityPoolSpendResponse defines the response to executing a
+/// MsgCommunityPoolSpend message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgCommunityPoolSpendResponse {}
 include!("cosmos.distribution.v1beta1.serde.rs");
 include!("cosmos.distribution.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.serde.rs
@@ -1274,6 +1274,226 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for MsgCommunityPoolSpend {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if !self.recipient.is_empty() {
+            len += 1;
+        }
+        if !self.amount.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer
+            .serialize_struct("cosmos.distribution.v1beta1.MsgCommunityPoolSpend", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if !self.recipient.is_empty() {
+            struct_ser.serialize_field("recipient", &self.recipient)?;
+        }
+        if !self.amount.is_empty() {
+            struct_ser.serialize_field("amount", &self.amount)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "recipient", "amount"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Recipient,
+            Amount,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "recipient" => Ok(GeneratedField::Recipient),
+                            "amount" => Ok(GeneratedField::Amount),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgCommunityPoolSpend;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.distribution.v1beta1.MsgCommunityPoolSpend")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgCommunityPoolSpend, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut recipient__ = None;
+                let mut amount__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Recipient => {
+                            if recipient__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("recipient"));
+                            }
+                            recipient__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Amount => {
+                            if amount__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("amount"));
+                            }
+                            amount__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(MsgCommunityPoolSpend {
+                    authority: authority__.unwrap_or_default(),
+                    recipient: recipient__.unwrap_or_default(),
+                    amount: amount__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.MsgCommunityPoolSpend",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgCommunityPoolSpendResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct(
+            "cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse",
+            len,
+        )?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgCommunityPoolSpendResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter
+                    .write_str("struct cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgCommunityPoolSpendResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgCommunityPoolSpendResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for MsgFundCommunityPool {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -1685,6 +1905,204 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.distribution.v1beta1.MsgSetWithdrawAddressResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.distribution.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.distribution.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer
+            .serialize_struct("cosmos.distribution.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.distribution.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.MsgUpdateParamsResponse",
             FIELDS,
             GeneratedVisitor,
         )
@@ -3787,6 +4205,264 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.distribution.v1beta1.QueryValidatorCommissionResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryValidatorDistributionInfoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.validator_address.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct(
+            "cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest",
+            len,
+        )?;
+        if !self.validator_address.is_empty() {
+            struct_ser.serialize_field("validatorAddress", &self.validator_address)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["validator_address", "validatorAddress"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ValidatorAddress,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "validatorAddress" | "validator_address" => {
+                                Ok(GeneratedField::ValidatorAddress)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryValidatorDistributionInfoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "struct cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest",
+                )
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QueryValidatorDistributionInfoRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut validator_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::ValidatorAddress => {
+                            if validator_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validatorAddress"));
+                            }
+                            validator_address__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(QueryValidatorDistributionInfoRequest {
+                    validator_address: validator_address__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for QueryValidatorDistributionInfoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.operator_address.is_empty() {
+            len += 1;
+        }
+        if !self.self_bond_rewards.is_empty() {
+            len += 1;
+        }
+        if !self.commission.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct(
+            "cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse",
+            len,
+        )?;
+        if !self.operator_address.is_empty() {
+            struct_ser.serialize_field("operatorAddress", &self.operator_address)?;
+        }
+        if !self.self_bond_rewards.is_empty() {
+            struct_ser.serialize_field("selfBondRewards", &self.self_bond_rewards)?;
+        }
+        if !self.commission.is_empty() {
+            struct_ser.serialize_field("commission", &self.commission)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "operator_address",
+            "operatorAddress",
+            "self_bond_rewards",
+            "selfBondRewards",
+            "commission",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            OperatorAddress,
+            SelfBondRewards,
+            Commission,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "operatorAddress" | "operator_address" => {
+                                Ok(GeneratedField::OperatorAddress)
+                            }
+                            "selfBondRewards" | "self_bond_rewards" => {
+                                Ok(GeneratedField::SelfBondRewards)
+                            }
+                            "commission" => Ok(GeneratedField::Commission),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = QueryValidatorDistributionInfoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "struct cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse",
+                )
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<QueryValidatorDistributionInfoResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut operator_address__ = None;
+                let mut self_bond_rewards__ = None;
+                let mut commission__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::OperatorAddress => {
+                            if operator_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("operatorAddress"));
+                            }
+                            operator_address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SelfBondRewards => {
+                            if self_bond_rewards__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("selfBondRewards"));
+                            }
+                            self_bond_rewards__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Commission => {
+                            if commission__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("commission"));
+                            }
+                            commission__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(QueryValidatorDistributionInfoResponse {
+                    operator_address: operator_address__.unwrap_or_default(),
+                    self_bond_rewards: self_bond_rewards__.unwrap_or_default(),
+                    commission: commission__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse",
             FIELDS,
             GeneratedVisitor,
         )

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
@@ -106,6 +106,30 @@ pub mod query_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn validator_distribution_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::QueryValidatorDistributionInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::QueryValidatorDistributionInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Query/ValidatorDistributionInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.distribution.v1beta1.Query",
+                "ValidatorDistributionInfo",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn validator_outstanding_rewards(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorOutstandingRewardsRequest>,
@@ -308,6 +332,13 @@ pub mod query_server {
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
         ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        async fn validator_distribution_info(
+            &self,
+            request: tonic::Request<super::QueryValidatorDistributionInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::QueryValidatorDistributionInfoResponse>,
+            tonic::Status,
+        >;
         async fn validator_outstanding_rewards(
             &self,
             request: tonic::Request<super::QueryValidatorOutstandingRewardsRequest>,
@@ -458,6 +489,48 @@ pub mod query_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = ParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.distribution.v1beta1.Query/ValidatorDistributionInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct ValidatorDistributionInfoSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query>
+                        tonic::server::UnaryService<super::QueryValidatorDistributionInfoRequest>
+                        for ValidatorDistributionInfoSvc<T>
+                    {
+                        type Response = super::QueryValidatorDistributionInfoResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::QueryValidatorDistributionInfoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut =
+                                async move { (*inner).validator_distribution_info(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ValidatorDistributionInfoSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -1014,6 +1087,50 @@ pub mod msg_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/UpdateParams",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.distribution.v1beta1.Msg",
+                "UpdateParams",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn community_pool_spend(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgCommunityPoolSpend>,
+        ) -> std::result::Result<tonic::Response<super::MsgCommunityPoolSpendResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.distribution.v1beta1.Msg/CommunityPoolSpend",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.distribution.v1beta1.Msg",
+                "CommunityPoolSpend",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1046,6 +1163,14 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgFundCommunityPool>,
         ) -> std::result::Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status>;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        async fn community_pool_spend(
+            &self,
+            request: tonic::Request<super::MsgCommunityPoolSpend>,
+        ) -> std::result::Result<tonic::Response<super::MsgCommunityPoolSpendResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1269,6 +1394,84 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = FundCommunityPoolSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.distribution.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.distribution.v1beta1.Msg/CommunityPoolSpend" => {
+                    #[allow(non_camel_case_types)]
+                    struct CommunityPoolSpendSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgCommunityPoolSpend>
+                        for CommunityPoolSpendSvc<T>
+                    {
+                        type Response = super::MsgCommunityPoolSpendResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgCommunityPoolSpend>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).community_pool_spend(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CommunityPoolSpendSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object of the evidence module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.evidence.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.serde.rs
@@ -1,0 +1,79 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.evidence.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.evidence.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.evidence.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.rs
@@ -4,12 +4,16 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Equivocation {
+    /// height is the equivocation height.
     #[prost(int64, tag = "1")]
     pub height: i64,
+    /// time is the equivocation time.
     #[prost(message, optional, tag = "2")]
     pub time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// power is the equivocation validator power.
     #[prost(int64, tag = "3")]
     pub power: i64,
+    /// consensus_address is the equivocation validator consensus address.
     #[prost(string, tag = "4")]
     pub consensus_address: ::prost::alloc::string::String,
 }
@@ -26,8 +30,15 @@ pub struct GenesisState {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryEvidenceRequest {
     /// evidence_hash defines the hash of the requested evidence.
+    /// Deprecated: Use hash, a HEX encoded string, instead.
+    #[deprecated]
     #[prost(bytes = "vec", tag = "1")]
     pub evidence_hash: ::prost::alloc::vec::Vec<u8>,
+    /// hash defines the evidence hash of the requested evidence.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "2")]
+    pub hash: ::prost::alloc::string::String,
 }
 /// QueryEvidenceResponse is the response type for the Query/Evidence RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -63,8 +74,10 @@ pub struct QueryAllEvidenceResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitEvidence {
+    /// submitter is the signer account address of evidence.
     #[prost(string, tag = "1")]
     pub submitter: ::prost::alloc::string::String,
+    /// evidence defines the evidence of misbehavior.
     #[prost(message, optional, tag = "2")]
     pub evidence: ::core::option::Option<::tendermint_proto::google::protobuf::Any>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.serde.rs
@@ -721,6 +721,9 @@ impl serde::Serialize for QueryEvidenceRequest {
         if !self.evidence_hash.is_empty() {
             len += 1;
         }
+        if !self.hash.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.evidence.v1beta1.QueryEvidenceRequest", len)?;
         if !self.evidence_hash.is_empty() {
@@ -729,6 +732,9 @@ impl serde::Serialize for QueryEvidenceRequest {
                 "evidenceHash",
                 pbjson::private::base64::encode(&self.evidence_hash).as_str(),
             )?;
+        }
+        if !self.hash.is_empty() {
+            struct_ser.serialize_field("hash", &self.hash)?;
         }
         struct_ser.end()
     }
@@ -740,11 +746,12 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
     where
         D: serde::Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["evidence_hash", "evidenceHash"];
+        const FIELDS: &[&str] = &["evidence_hash", "evidenceHash", "hash"];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             EvidenceHash,
+            Hash,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -771,6 +778,7 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
                     {
                         match value {
                             "evidenceHash" | "evidence_hash" => Ok(GeneratedField::EvidenceHash),
+                            "hash" => Ok(GeneratedField::Hash),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -794,6 +802,7 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
                 V: serde::de::MapAccess<'de>,
             {
                 let mut evidence_hash__ = None;
+                let mut hash__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::EvidenceHash => {
@@ -805,10 +814,17 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
                                     .0,
                             );
                         }
+                        GeneratedField::Hash => {
+                            if hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hash"));
+                            }
+                            hash__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(QueryEvidenceRequest {
                     evidence_hash: evidence_hash__.unwrap_or_default(),
+                    hash: hash__.unwrap_or_default(),
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object of the feegrant module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.feegrant.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.serde.rs
@@ -1,0 +1,79 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.feegrant.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.feegrant.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.feegrant.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object for the genutil module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.genutil.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.serde.rs
@@ -8,7 +8,7 @@ impl serde::Serialize for Module {
     {
         use serde::ser::SerializeStruct;
         let len = 0;
-        let struct_ser = serializer.serialize_struct("cosmos.app.module.v1alpha1.Module", len)?;
+        let struct_ser = serializer.serialize_struct("cosmos.genutil.module.v1.Module", len)?;
         struct_ser.end()
     }
 }
@@ -57,7 +57,7 @@ impl<'de> serde::Deserialize<'de> for Module {
             type Value = Module;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct cosmos.app.module.v1alpha1.Module")
+                formatter.write_str("struct cosmos.genutil.module.v1.Module")
             }
 
             fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
@@ -70,10 +70,6 @@ impl<'de> serde::Deserialize<'de> for Module {
                 Ok(Module {})
             }
         }
-        deserializer.deserialize_struct(
-            "cosmos.app.module.v1alpha1.Module",
-            FIELDS,
-            GeneratedVisitor,
-        )
+        deserializer.deserialize_struct("cosmos.genutil.module.v1.Module", FIELDS, GeneratedVisitor)
     }
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.rs
@@ -1,0 +1,15 @@
+// @generated
+/// Module is the config object of the gov module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// max_metadata_len defines the maximum proposal metadata length.
+    /// Defaults to 255 if not explicitly set.
+    #[prost(uint64, tag = "1")]
+    pub max_metadata_len: u64,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.gov.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.serde.rs
@@ -1,0 +1,121 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.max_metadata_len != 0 {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.gov.module.v1.Module", len)?;
+        if self.max_metadata_len != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "maxMetadataLen",
+                ToString::to_string(&self.max_metadata_len).as_str(),
+            )?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["max_metadata_len", "maxMetadataLen", "authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            MaxMetadataLen,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "maxMetadataLen" | "max_metadata_len" => {
+                                Ok(GeneratedField::MaxMetadataLen)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.gov.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut max_metadata_len__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::MaxMetadataLen => {
+                            if max_metadata_len__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("maxMetadataLen"));
+                            }
+                            max_metadata_len__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    max_metadata_len: max_metadata_len__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.gov.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.rs
@@ -3,8 +3,10 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WeightedVoteOption {
+    /// option defines the valid vote options, it must not contain duplicate vote options.
     #[prost(enumeration = "VoteOption", tag = "1")]
     pub option: i32,
+    /// weight is the vote weight associated with the vote option.
     #[prost(string, tag = "2")]
     pub weight: ::prost::alloc::string::String,
 }
@@ -13,10 +15,13 @@ pub struct WeightedVoteOption {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Deposit {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
     #[prost(string, tag = "2")]
     pub depositor: ::prost::alloc::string::String,
+    /// amount to be deposited by depositor.
     #[prost(message, repeated, tag = "3")]
     pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
@@ -24,10 +29,13 @@ pub struct Deposit {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proposal {
+    /// id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub id: u64,
+    /// messages are the arbitrary messages to be executed if the proposal passes.
     #[prost(message, repeated, tag = "2")]
     pub messages: ::prost::alloc::vec::Vec<::tendermint_proto::google::protobuf::Any>,
+    /// status defines the proposal status.
     #[prost(enumeration = "ProposalStatus", tag = "3")]
     pub status: i32,
     /// final_tally_result is the final tally result of the proposal. When
@@ -35,30 +43,54 @@ pub struct Proposal {
     /// proposal's voting period has ended.
     #[prost(message, optional, tag = "4")]
     pub final_tally_result: ::core::option::Option<TallyResult>,
+    /// submit_time is the time of proposal submission.
     #[prost(message, optional, tag = "5")]
     pub submit_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// deposit_end_time is the end time for deposition.
     #[prost(message, optional, tag = "6")]
     pub deposit_end_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// total_deposit is the total deposit on the proposal.
     #[prost(message, repeated, tag = "7")]
     pub total_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// voting_start_time is the starting time to vote on a proposal.
     #[prost(message, optional, tag = "8")]
     pub voting_start_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// voting_end_time is the end time of voting on a proposal.
     #[prost(message, optional, tag = "9")]
     pub voting_end_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
     /// metadata is any arbitrary metadata attached to the proposal.
     #[prost(string, tag = "10")]
     pub metadata: ::prost::alloc::string::String,
+    /// title is the title of the proposal
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "11")]
+    pub title: ::prost::alloc::string::String,
+    /// summary is a short summary of the proposal
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "12")]
+    pub summary: ::prost::alloc::string::String,
+    /// Proposer is the address of the proposal sumbitter
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "13")]
+    pub proposer: ::prost::alloc::string::String,
 }
 /// TallyResult defines a standard tally for a governance proposal.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TallyResult {
+    /// yes_count is the number of yes votes on a proposal.
     #[prost(string, tag = "1")]
     pub yes_count: ::prost::alloc::string::String,
+    /// abstain_count is the number of abstain votes on a proposal.
     #[prost(string, tag = "2")]
     pub abstain_count: ::prost::alloc::string::String,
+    /// no_count is the number of no votes on a proposal.
     #[prost(string, tag = "3")]
     pub no_count: ::prost::alloc::string::String,
+    /// no_with_veto_count is the number of no with veto votes on a proposal.
     #[prost(string, tag = "4")]
     pub no_with_veto_count: ::prost::alloc::string::String,
 }
@@ -67,10 +99,13 @@ pub struct TallyResult {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vote {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address of the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
+    /// options is the weighted vote options.
     #[prost(message, repeated, tag = "4")]
     pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
     /// metadata is any  arbitrary metadata to attached to the vote.
@@ -81,11 +116,11 @@ pub struct Vote {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DepositParams {
-    ///   Minimum deposit for a proposal to enter voting period.
+    /// Minimum deposit for a proposal to enter voting period.
     #[prost(message, repeated, tag = "1")]
     pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    ///   Maximum period for Atom holders to deposit on a proposal. Initial value: 2
-    ///   months.
+    /// Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    /// months.
     #[prost(message, optional, tag = "2")]
     pub max_deposit_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
 }
@@ -93,7 +128,7 @@ pub struct DepositParams {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VotingParams {
-    ///   Length of the voting period.
+    /// Duration of the voting period.
     #[prost(message, optional, tag = "1")]
     pub voting_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
 }
@@ -101,17 +136,57 @@ pub struct VotingParams {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TallyParams {
-    ///   Minimum percentage of total stake needed to vote for a result to be
-    ///   considered valid.
+    /// Minimum percentage of total stake needed to vote for a result to be
+    /// considered valid.
     #[prost(string, tag = "1")]
     pub quorum: ::prost::alloc::string::String,
-    ///   Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    /// Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
     #[prost(string, tag = "2")]
+    pub threshold: ::prost::alloc::string::String,
+    /// Minimum value of Veto votes to Total votes ratio for proposal to be
+    /// vetoed. Default value: 1/3.
+    #[prost(string, tag = "3")]
+    pub veto_threshold: ::prost::alloc::string::String,
+}
+/// Params defines the parameters for the x/gov module.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Params {
+    /// Minimum deposit for a proposal to enter voting period.
+    #[prost(message, repeated, tag = "1")]
+    pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    /// months.
+    #[prost(message, optional, tag = "2")]
+    pub max_deposit_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
+    /// Duration of the voting period.
+    #[prost(message, optional, tag = "3")]
+    pub voting_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
+    ///   Minimum percentage of total stake needed to vote for a result to be
+    ///   considered valid.
+    #[prost(string, tag = "4")]
+    pub quorum: ::prost::alloc::string::String,
+    ///   Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    #[prost(string, tag = "5")]
     pub threshold: ::prost::alloc::string::String,
     ///   Minimum value of Veto votes to Total votes ratio for proposal to be
     ///   vetoed. Default value: 1/3.
-    #[prost(string, tag = "3")]
+    #[prost(string, tag = "6")]
     pub veto_threshold: ::prost::alloc::string::String,
+    ///   The ratio representing the proportion of the deposit value that must be paid at proposal submission.
+    #[prost(string, tag = "7")]
+    pub min_initial_deposit_ratio: ::prost::alloc::string::String,
+    /// burn deposits if a proposal does not meet quorum
+    #[prost(bool, tag = "13")]
+    pub burn_vote_quorum: bool,
+    /// burn deposits if the proposal does not enter voting period
+    #[prost(bool, tag = "14")]
+    pub burn_proposal_deposit_prevote: bool,
+    /// burn deposits if quorum with vote type no_veto is met
+    #[prost(bool, tag = "15")]
+    pub burn_vote_veto: bool,
 }
 /// VoteOption enumerates the valid vote options for a given governance proposal.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -220,15 +295,26 @@ pub struct GenesisState {
     /// proposals defines all the proposals present at genesis.
     #[prost(message, repeated, tag = "4")]
     pub proposals: ::prost::alloc::vec::Vec<Proposal>,
-    /// params defines all the paramaters of related to deposit.
+    /// Deprecated: Prefer to use `params` instead.
+    /// deposit_params defines all the paramaters of related to deposit.
+    #[deprecated]
     #[prost(message, optional, tag = "5")]
     pub deposit_params: ::core::option::Option<DepositParams>,
-    /// params defines all the paramaters of related to voting.
+    /// Deprecated: Prefer to use `params` instead.
+    /// voting_params defines all the paramaters of related to voting.
+    #[deprecated]
     #[prost(message, optional, tag = "6")]
     pub voting_params: ::core::option::Option<VotingParams>,
-    /// params defines all the paramaters of related to tally.
+    /// Deprecated: Prefer to use `params` instead.
+    /// tally_params defines all the paramaters of related to tally.
+    #[deprecated]
     #[prost(message, optional, tag = "7")]
     pub tally_params: ::core::option::Option<TallyParams>,
+    /// params defines all the paramaters of x/gov module.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(message, optional, tag = "8")]
+    pub params: ::core::option::Option<Params>,
 }
 /// QueryProposalRequest is the request type for the Query/Proposal RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -242,6 +328,7 @@ pub struct QueryProposalRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryProposalResponse {
+    /// proposal is the requested governance proposal.
     #[prost(message, optional, tag = "1")]
     pub proposal: ::core::option::Option<Proposal>,
 }
@@ -267,6 +354,7 @@ pub struct QueryProposalsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryProposalsResponse {
+    /// proposals defines all the requested governance proposals.
     #[prost(message, repeated, tag = "1")]
     pub proposals: ::prost::alloc::vec::Vec<Proposal>,
     /// pagination defines the pagination in the response.
@@ -288,7 +376,7 @@ pub struct QueryVoteRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryVoteResponse {
-    /// vote defined the queried vote.
+    /// vote defines the queried vote.
     #[prost(message, optional, tag = "1")]
     pub vote: ::core::option::Option<Vote>,
 }
@@ -307,7 +395,7 @@ pub struct QueryVotesRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryVotesResponse {
-    /// votes defined the queried votes.
+    /// votes defines the queried votes.
     #[prost(message, repeated, tag = "1")]
     pub votes: ::prost::alloc::vec::Vec<Vote>,
     /// pagination defines the pagination in the response.
@@ -327,15 +415,26 @@ pub struct QueryParamsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamsResponse {
+    /// Deprecated: Prefer to use `params` instead.
     /// voting_params defines the parameters related to voting.
+    #[deprecated]
     #[prost(message, optional, tag = "1")]
     pub voting_params: ::core::option::Option<VotingParams>,
+    /// Deprecated: Prefer to use `params` instead.
     /// deposit_params defines the parameters related to deposit.
+    #[deprecated]
     #[prost(message, optional, tag = "2")]
     pub deposit_params: ::core::option::Option<DepositParams>,
+    /// Deprecated: Prefer to use `params` instead.
     /// tally_params defines the parameters related to tally.
+    #[deprecated]
     #[prost(message, optional, tag = "3")]
     pub tally_params: ::core::option::Option<TallyParams>,
+    /// params defines all the paramaters of x/gov module.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(message, optional, tag = "4")]
+    pub params: ::core::option::Option<Params>,
 }
 /// QueryDepositRequest is the request type for the Query/Deposit RPC method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -371,6 +470,7 @@ pub struct QueryDepositsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDepositsResponse {
+    /// deposits defines the requested deposits.
     #[prost(message, repeated, tag = "1")]
     pub deposits: ::prost::alloc::vec::Vec<Deposit>,
     /// pagination defines the pagination in the response.
@@ -398,20 +498,34 @@ pub struct QueryTallyResultResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitProposal {
+    /// messages are the arbitrary messages to be executed if proposal passes.
     #[prost(message, repeated, tag = "1")]
     pub messages: ::prost::alloc::vec::Vec<::tendermint_proto::google::protobuf::Any>,
+    /// initial_deposit is the deposit value that must be paid at proposal submission.
     #[prost(message, repeated, tag = "2")]
     pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// proposer is the account address of the proposer.
     #[prost(string, tag = "3")]
     pub proposer: ::prost::alloc::string::String,
     /// metadata is any arbitrary metadata attached to the proposal.
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
+    /// title is the title of the proposal.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "5")]
+    pub title: ::prost::alloc::string::String,
+    /// summary is the summary of the proposal
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "6")]
+    pub summary: ::prost::alloc::string::String,
 }
 /// MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitProposalResponse {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
 }
@@ -435,12 +549,16 @@ pub struct MsgExecLegacyContentResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVote {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address for the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
+    /// option defines the vote option.
     #[prost(enumeration = "VoteOption", tag = "3")]
     pub option: i32,
+    /// metadata is any arbitrary metadata attached to the Vote.
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
 }
@@ -452,12 +570,16 @@ pub struct MsgVoteResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVoteWeighted {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address for the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
+    /// options defines the weighted vote options.
     #[prost(message, repeated, tag = "3")]
     pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
+    /// metadata is any arbitrary metadata attached to the VoteWeighted.
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
 }
@@ -469,10 +591,13 @@ pub struct MsgVoteWeightedResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgDeposit {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
     #[prost(string, tag = "2")]
     pub depositor: ::prost::alloc::string::String,
+    /// amount to be deposited by depositor.
     #[prost(message, repeated, tag = "3")]
     pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
@@ -480,6 +605,28 @@ pub struct MsgDeposit {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgDepositResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/gov parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.gov.v1.serde.rs");
 include!("cosmos.gov.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.serde.rs
@@ -281,6 +281,9 @@ impl serde::Serialize for GenesisState {
         if self.tally_params.is_some() {
             len += 1;
         }
+        if self.params.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.GenesisState", len)?;
         if self.starting_proposal_id != 0 {
             #[allow(clippy::needless_borrow)]
@@ -307,6 +310,9 @@ impl serde::Serialize for GenesisState {
         if let Some(v) = self.tally_params.as_ref() {
             struct_ser.serialize_field("tallyParams", v)?;
         }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
         struct_ser.end()
     }
 }
@@ -329,6 +335,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
             "votingParams",
             "tally_params",
             "tallyParams",
+            "params",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -340,6 +347,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
             DepositParams,
             VotingParams,
             TallyParams,
+            Params,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -374,6 +382,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                             "depositParams" | "deposit_params" => Ok(GeneratedField::DepositParams),
                             "votingParams" | "voting_params" => Ok(GeneratedField::VotingParams),
                             "tallyParams" | "tally_params" => Ok(GeneratedField::TallyParams),
+                            "params" => Ok(GeneratedField::Params),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -400,6 +409,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                 let mut deposit_params__ = None;
                 let mut voting_params__ = None;
                 let mut tally_params__ = None;
+                let mut params__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::StartingProposalId => {
@@ -449,6 +459,12 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                             }
                             tally_params__ = map_.next_value()?;
                         }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(GenesisState {
@@ -459,6 +475,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                     deposit_params: deposit_params__,
                     voting_params: voting_params__,
                     tally_params: tally_params__,
+                    params: params__,
                 })
             }
         }
@@ -899,6 +916,12 @@ impl serde::Serialize for MsgSubmitProposal {
         if !self.metadata.is_empty() {
             len += 1;
         }
+        if !self.title.is_empty() {
+            len += 1;
+        }
+        if !self.summary.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.MsgSubmitProposal", len)?;
         if !self.messages.is_empty() {
             struct_ser.serialize_field("messages", &self.messages)?;
@@ -911,6 +934,12 @@ impl serde::Serialize for MsgSubmitProposal {
         }
         if !self.metadata.is_empty() {
             struct_ser.serialize_field("metadata", &self.metadata)?;
+        }
+        if !self.title.is_empty() {
+            struct_ser.serialize_field("title", &self.title)?;
+        }
+        if !self.summary.is_empty() {
+            struct_ser.serialize_field("summary", &self.summary)?;
         }
         struct_ser.end()
     }
@@ -928,6 +957,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
             "initialDeposit",
             "proposer",
             "metadata",
+            "title",
+            "summary",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -936,6 +967,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
             InitialDeposit,
             Proposer,
             Metadata,
+            Title,
+            Summary,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -967,6 +1000,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                             }
                             "proposer" => Ok(GeneratedField::Proposer),
                             "metadata" => Ok(GeneratedField::Metadata),
+                            "title" => Ok(GeneratedField::Title),
+                            "summary" => Ok(GeneratedField::Summary),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -990,6 +1025,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                 let mut initial_deposit__ = None;
                 let mut proposer__ = None;
                 let mut metadata__ = None;
+                let mut title__ = None;
+                let mut summary__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Messages => {
@@ -1016,6 +1053,18 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                             }
                             metadata__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Title => {
+                            if title__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("title"));
+                            }
+                            title__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Summary => {
+                            if summary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("summary"));
+                            }
+                            summary__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(MsgSubmitProposal {
@@ -1023,6 +1072,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                     initial_deposit: initial_deposit__.unwrap_or_default(),
                     proposer: proposer__.unwrap_or_default(),
                     metadata: metadata__.unwrap_or_default(),
+                    title: title__.unwrap_or_default(),
+                    summary: summary__.unwrap_or_default(),
                 })
             }
         }
@@ -1134,6 +1185,199 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.gov.v1.MsgSubmitProposalResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.gov.v1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.gov.v1.MsgUpdateParams", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.gov.v1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.gov.v1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.gov.v1.MsgUpdateParamsResponse",
             FIELDS,
             GeneratedVisitor,
         )
@@ -1599,6 +1843,281 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for Params {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.min_deposit.is_empty() {
+            len += 1;
+        }
+        if self.max_deposit_period.is_some() {
+            len += 1;
+        }
+        if self.voting_period.is_some() {
+            len += 1;
+        }
+        if !self.quorum.is_empty() {
+            len += 1;
+        }
+        if !self.threshold.is_empty() {
+            len += 1;
+        }
+        if !self.veto_threshold.is_empty() {
+            len += 1;
+        }
+        if !self.min_initial_deposit_ratio.is_empty() {
+            len += 1;
+        }
+        if self.burn_vote_quorum {
+            len += 1;
+        }
+        if self.burn_proposal_deposit_prevote {
+            len += 1;
+        }
+        if self.burn_vote_veto {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.Params", len)?;
+        if !self.min_deposit.is_empty() {
+            struct_ser.serialize_field("minDeposit", &self.min_deposit)?;
+        }
+        if let Some(v) = self.max_deposit_period.as_ref() {
+            struct_ser.serialize_field("maxDepositPeriod", v)?;
+        }
+        if let Some(v) = self.voting_period.as_ref() {
+            struct_ser.serialize_field("votingPeriod", v)?;
+        }
+        if !self.quorum.is_empty() {
+            struct_ser.serialize_field("quorum", &self.quorum)?;
+        }
+        if !self.threshold.is_empty() {
+            struct_ser.serialize_field("threshold", &self.threshold)?;
+        }
+        if !self.veto_threshold.is_empty() {
+            struct_ser.serialize_field("vetoThreshold", &self.veto_threshold)?;
+        }
+        if !self.min_initial_deposit_ratio.is_empty() {
+            struct_ser
+                .serialize_field("minInitialDepositRatio", &self.min_initial_deposit_ratio)?;
+        }
+        if self.burn_vote_quorum {
+            struct_ser.serialize_field("burnVoteQuorum", &self.burn_vote_quorum)?;
+        }
+        if self.burn_proposal_deposit_prevote {
+            struct_ser.serialize_field(
+                "burnProposalDepositPrevote",
+                &self.burn_proposal_deposit_prevote,
+            )?;
+        }
+        if self.burn_vote_veto {
+            struct_ser.serialize_field("burnVoteVeto", &self.burn_vote_veto)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Params {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "min_deposit",
+            "minDeposit",
+            "max_deposit_period",
+            "maxDepositPeriod",
+            "voting_period",
+            "votingPeriod",
+            "quorum",
+            "threshold",
+            "veto_threshold",
+            "vetoThreshold",
+            "min_initial_deposit_ratio",
+            "minInitialDepositRatio",
+            "burn_vote_quorum",
+            "burnVoteQuorum",
+            "burn_proposal_deposit_prevote",
+            "burnProposalDepositPrevote",
+            "burn_vote_veto",
+            "burnVoteVeto",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            MinDeposit,
+            MaxDepositPeriod,
+            VotingPeriod,
+            Quorum,
+            Threshold,
+            VetoThreshold,
+            MinInitialDepositRatio,
+            BurnVoteQuorum,
+            BurnProposalDepositPrevote,
+            BurnVoteVeto,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "minDeposit" | "min_deposit" => Ok(GeneratedField::MinDeposit),
+                            "maxDepositPeriod" | "max_deposit_period" => {
+                                Ok(GeneratedField::MaxDepositPeriod)
+                            }
+                            "votingPeriod" | "voting_period" => Ok(GeneratedField::VotingPeriod),
+                            "quorum" => Ok(GeneratedField::Quorum),
+                            "threshold" => Ok(GeneratedField::Threshold),
+                            "vetoThreshold" | "veto_threshold" => Ok(GeneratedField::VetoThreshold),
+                            "minInitialDepositRatio" | "min_initial_deposit_ratio" => {
+                                Ok(GeneratedField::MinInitialDepositRatio)
+                            }
+                            "burnVoteQuorum" | "burn_vote_quorum" => {
+                                Ok(GeneratedField::BurnVoteQuorum)
+                            }
+                            "burnProposalDepositPrevote" | "burn_proposal_deposit_prevote" => {
+                                Ok(GeneratedField::BurnProposalDepositPrevote)
+                            }
+                            "burnVoteVeto" | "burn_vote_veto" => Ok(GeneratedField::BurnVoteVeto),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Params;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.gov.v1.Params")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut min_deposit__ = None;
+                let mut max_deposit_period__ = None;
+                let mut voting_period__ = None;
+                let mut quorum__ = None;
+                let mut threshold__ = None;
+                let mut veto_threshold__ = None;
+                let mut min_initial_deposit_ratio__ = None;
+                let mut burn_vote_quorum__ = None;
+                let mut burn_proposal_deposit_prevote__ = None;
+                let mut burn_vote_veto__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::MinDeposit => {
+                            if min_deposit__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("minDeposit"));
+                            }
+                            min_deposit__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::MaxDepositPeriod => {
+                            if max_deposit_period__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("maxDepositPeriod"));
+                            }
+                            max_deposit_period__ = map_.next_value()?;
+                        }
+                        GeneratedField::VotingPeriod => {
+                            if voting_period__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("votingPeriod"));
+                            }
+                            voting_period__ = map_.next_value()?;
+                        }
+                        GeneratedField::Quorum => {
+                            if quorum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("quorum"));
+                            }
+                            quorum__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Threshold => {
+                            if threshold__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("threshold"));
+                            }
+                            threshold__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::VetoThreshold => {
+                            if veto_threshold__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("vetoThreshold"));
+                            }
+                            veto_threshold__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::MinInitialDepositRatio => {
+                            if min_initial_deposit_ratio__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "minInitialDepositRatio",
+                                ));
+                            }
+                            min_initial_deposit_ratio__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BurnVoteQuorum => {
+                            if burn_vote_quorum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("burnVoteQuorum"));
+                            }
+                            burn_vote_quorum__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BurnProposalDepositPrevote => {
+                            if burn_proposal_deposit_prevote__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "burnProposalDepositPrevote",
+                                ));
+                            }
+                            burn_proposal_deposit_prevote__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BurnVoteVeto => {
+                            if burn_vote_veto__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("burnVoteVeto"));
+                            }
+                            burn_vote_veto__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Params {
+                    min_deposit: min_deposit__.unwrap_or_default(),
+                    max_deposit_period: max_deposit_period__,
+                    voting_period: voting_period__,
+                    quorum: quorum__.unwrap_or_default(),
+                    threshold: threshold__.unwrap_or_default(),
+                    veto_threshold: veto_threshold__.unwrap_or_default(),
+                    min_initial_deposit_ratio: min_initial_deposit_ratio__.unwrap_or_default(),
+                    burn_vote_quorum: burn_vote_quorum__.unwrap_or_default(),
+                    burn_proposal_deposit_prevote: burn_proposal_deposit_prevote__
+                        .unwrap_or_default(),
+                    burn_vote_veto: burn_vote_veto__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.gov.v1.Params", FIELDS, GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for Proposal {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -1637,6 +2156,15 @@ impl serde::Serialize for Proposal {
         if !self.metadata.is_empty() {
             len += 1;
         }
+        if !self.title.is_empty() {
+            len += 1;
+        }
+        if !self.summary.is_empty() {
+            len += 1;
+        }
+        if !self.proposer.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.Proposal", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
@@ -1672,6 +2200,15 @@ impl serde::Serialize for Proposal {
         if !self.metadata.is_empty() {
             struct_ser.serialize_field("metadata", &self.metadata)?;
         }
+        if !self.title.is_empty() {
+            struct_ser.serialize_field("title", &self.title)?;
+        }
+        if !self.summary.is_empty() {
+            struct_ser.serialize_field("summary", &self.summary)?;
+        }
+        if !self.proposer.is_empty() {
+            struct_ser.serialize_field("proposer", &self.proposer)?;
+        }
         struct_ser.end()
     }
 }
@@ -1699,6 +2236,9 @@ impl<'de> serde::Deserialize<'de> for Proposal {
             "voting_end_time",
             "votingEndTime",
             "metadata",
+            "title",
+            "summary",
+            "proposer",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -1713,6 +2253,9 @@ impl<'de> serde::Deserialize<'de> for Proposal {
             VotingStartTime,
             VotingEndTime,
             Metadata,
+            Title,
+            Summary,
+            Proposer,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -1756,6 +2299,9 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                                 Ok(GeneratedField::VotingEndTime)
                             }
                             "metadata" => Ok(GeneratedField::Metadata),
+                            "title" => Ok(GeneratedField::Title),
+                            "summary" => Ok(GeneratedField::Summary),
+                            "proposer" => Ok(GeneratedField::Proposer),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -1785,6 +2331,9 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                 let mut voting_start_time__ = None;
                 let mut voting_end_time__ = None;
                 let mut metadata__ = None;
+                let mut title__ = None;
+                let mut summary__ = None;
+                let mut proposer__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -1850,6 +2399,24 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                             }
                             metadata__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Title => {
+                            if title__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("title"));
+                            }
+                            title__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Summary => {
+                            if summary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("summary"));
+                            }
+                            summary__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Proposer => {
+                            if proposer__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("proposer"));
+                            }
+                            proposer__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(Proposal {
@@ -1863,6 +2430,9 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                     voting_start_time: voting_start_time__,
                     voting_end_time: voting_end_time__,
                     metadata: metadata__.unwrap_or_default(),
+                    title: title__.unwrap_or_default(),
+                    summary: summary__.unwrap_or_default(),
+                    proposer: proposer__.unwrap_or_default(),
                 })
             }
         }
@@ -2541,6 +3111,9 @@ impl serde::Serialize for QueryParamsResponse {
         if self.tally_params.is_some() {
             len += 1;
         }
+        if self.params.is_some() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.gov.v1.QueryParamsResponse", len)?;
         if let Some(v) = self.voting_params.as_ref() {
@@ -2551,6 +3124,9 @@ impl serde::Serialize for QueryParamsResponse {
         }
         if let Some(v) = self.tally_params.as_ref() {
             struct_ser.serialize_field("tallyParams", v)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
         }
         struct_ser.end()
     }
@@ -2569,6 +3145,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
             "depositParams",
             "tally_params",
             "tallyParams",
+            "params",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2576,6 +3153,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
             VotingParams,
             DepositParams,
             TallyParams,
+            Params,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -2604,6 +3182,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
                             "votingParams" | "voting_params" => Ok(GeneratedField::VotingParams),
                             "depositParams" | "deposit_params" => Ok(GeneratedField::DepositParams),
                             "tallyParams" | "tally_params" => Ok(GeneratedField::TallyParams),
+                            "params" => Ok(GeneratedField::Params),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2626,6 +3205,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
                 let mut voting_params__ = None;
                 let mut deposit_params__ = None;
                 let mut tally_params__ = None;
+                let mut params__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::VotingParams => {
@@ -2646,12 +3226,19 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
                             }
                             tally_params__ = map_.next_value()?;
                         }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(QueryParamsResponse {
                     voting_params: voting_params__,
                     deposit_params: deposit_params__,
                     tally_params: tally_params__,
+                    params: params__,
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
@@ -860,6 +860,24 @@ pub mod msg_client {
                 .insert(GrpcMethod::new("cosmos.gov.v1.Msg", "Deposit"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.gov.v1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.gov.v1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -890,6 +908,10 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgDeposit>,
         ) -> std::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1142,6 +1164,44 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = DepositSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.gov.v1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.rs
@@ -5,8 +5,10 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WeightedVoteOption {
+    /// option defines the valid vote options, it must not contain duplicate vote options.
     #[prost(enumeration = "VoteOption", tag = "1")]
     pub option: i32,
+    /// weight is the vote weight associated with the vote option.
     #[prost(string, tag = "2")]
     pub weight: ::prost::alloc::string::String,
 }
@@ -15,8 +17,10 @@ pub struct WeightedVoteOption {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TextProposal {
+    /// title of the proposal.
     #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
+    /// description associated with the proposal.
     #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
 }
@@ -25,10 +29,13 @@ pub struct TextProposal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Deposit {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
     #[prost(string, tag = "2")]
     pub depositor: ::prost::alloc::string::String,
+    /// amount to be deposited by depositor.
     #[prost(message, repeated, tag = "3")]
     pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }
@@ -36,10 +43,13 @@ pub struct Deposit {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proposal {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// content is the proposal's content.
     #[prost(message, optional, tag = "2")]
     pub content: ::core::option::Option<::tendermint_proto::google::protobuf::Any>,
+    /// status defines the proposal status.
     #[prost(enumeration = "ProposalStatus", tag = "3")]
     pub status: i32,
     /// final_tally_result is the final tally result of the proposal. When
@@ -47,14 +57,19 @@ pub struct Proposal {
     /// proposal's voting period has ended.
     #[prost(message, optional, tag = "4")]
     pub final_tally_result: ::core::option::Option<TallyResult>,
+    /// submit_time is the time of proposal submission.
     #[prost(message, optional, tag = "5")]
     pub submit_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// deposit_end_time is the end time for deposition.
     #[prost(message, optional, tag = "6")]
     pub deposit_end_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// total_deposit is the total deposit on the proposal.
     #[prost(message, repeated, tag = "7")]
     pub total_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// voting_start_time is the starting time to vote on a proposal.
     #[prost(message, optional, tag = "8")]
     pub voting_start_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
+    /// voting_end_time is the end time of voting on a proposal.
     #[prost(message, optional, tag = "9")]
     pub voting_end_time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
 }
@@ -62,12 +77,16 @@ pub struct Proposal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TallyResult {
+    /// yes is the number of yes votes on a proposal.
     #[prost(string, tag = "1")]
     pub yes: ::prost::alloc::string::String,
+    /// abstain is the number of abstain votes on a proposal.
     #[prost(string, tag = "2")]
     pub abstain: ::prost::alloc::string::String,
+    /// no is the number of no votes on a proposal.
     #[prost(string, tag = "3")]
     pub no: ::prost::alloc::string::String,
+    /// no_with_veto is the number of no with veto votes on a proposal.
     #[prost(string, tag = "4")]
     pub no_with_veto: ::prost::alloc::string::String,
 }
@@ -76,8 +95,10 @@ pub struct TallyResult {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vote {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address of the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
     /// Deprecated: Prefer to use `options` instead. This field is set in queries
@@ -86,6 +107,8 @@ pub struct Vote {
     #[deprecated]
     #[prost(enumeration = "VoteOption", tag = "3")]
     pub option: i32,
+    /// options is the weighted vote options.
+    ///
     /// Since: cosmos-sdk 0.43
     #[prost(message, repeated, tag = "4")]
     pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
@@ -94,11 +117,11 @@ pub struct Vote {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DepositParams {
-    ///   Minimum deposit for a proposal to enter voting period.
+    /// Minimum deposit for a proposal to enter voting period.
     #[prost(message, repeated, tag = "1")]
     pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
-    ///   Maximum period for Atom holders to deposit on a proposal. Initial value: 2
-    ///   months.
+    /// Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    /// months.
     #[prost(message, optional, tag = "2")]
     pub max_deposit_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
 }
@@ -106,7 +129,7 @@ pub struct DepositParams {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VotingParams {
-    ///   Length of the voting period.
+    /// Duration of the voting period.
     #[prost(message, optional, tag = "1")]
     pub voting_period: ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
 }
@@ -114,15 +137,15 @@ pub struct VotingParams {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TallyParams {
-    ///   Minimum percentage of total stake needed to vote for a result to be
-    ///   considered valid.
+    /// Minimum percentage of total stake needed to vote for a result to be
+    /// considered valid.
     #[prost(bytes = "vec", tag = "1")]
     pub quorum: ::prost::alloc::vec::Vec<u8>,
-    ///   Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    /// Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
     #[prost(bytes = "vec", tag = "2")]
     pub threshold: ::prost::alloc::vec::Vec<u8>,
-    ///   Minimum value of Veto votes to Total votes ratio for proposal to be
-    ///   vetoed. Default value: 1/3.
+    /// Minimum value of Veto votes to Total votes ratio for proposal to be
+    /// vetoed. Default value: 1/3.
     #[prost(bytes = "vec", tag = "3")]
     pub veto_threshold: ::prost::alloc::vec::Vec<u8>,
 }
@@ -233,13 +256,13 @@ pub struct GenesisState {
     /// proposals defines all the proposals present at genesis.
     #[prost(message, repeated, tag = "4")]
     pub proposals: ::prost::alloc::vec::Vec<Proposal>,
-    /// params defines all the paramaters of related to deposit.
+    /// params defines all the parameters of related to deposit.
     #[prost(message, optional, tag = "5")]
     pub deposit_params: ::core::option::Option<DepositParams>,
-    /// params defines all the paramaters of related to voting.
+    /// params defines all the parameters of related to voting.
     #[prost(message, optional, tag = "6")]
     pub voting_params: ::core::option::Option<VotingParams>,
-    /// params defines all the paramaters of related to tally.
+    /// params defines all the parameters of related to tally.
     #[prost(message, optional, tag = "7")]
     pub tally_params: ::core::option::Option<TallyParams>,
 }
@@ -280,6 +303,7 @@ pub struct QueryProposalsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryProposalsResponse {
+    /// proposals defines all the requested governance proposals.
     #[prost(message, repeated, tag = "1")]
     pub proposals: ::prost::alloc::vec::Vec<Proposal>,
     /// pagination defines the pagination in the response.
@@ -301,7 +325,7 @@ pub struct QueryVoteRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryVoteResponse {
-    /// vote defined the queried vote.
+    /// vote defines the queried vote.
     #[prost(message, optional, tag = "1")]
     pub vote: ::core::option::Option<Vote>,
 }
@@ -320,7 +344,7 @@ pub struct QueryVotesRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryVotesResponse {
-    /// votes defined the queried votes.
+    /// votes defines the queried votes.
     #[prost(message, repeated, tag = "1")]
     pub votes: ::prost::alloc::vec::Vec<Vote>,
     /// pagination defines the pagination in the response.
@@ -384,6 +408,7 @@ pub struct QueryDepositsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDepositsResponse {
+    /// deposits defines the requested deposits.
     #[prost(message, repeated, tag = "1")]
     pub deposits: ::prost::alloc::vec::Vec<Deposit>,
     /// pagination defines the pagination in the response.
@@ -411,10 +436,13 @@ pub struct QueryTallyResultResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitProposal {
+    /// content is the proposal's content.
     #[prost(message, optional, tag = "1")]
     pub content: ::core::option::Option<::tendermint_proto::google::protobuf::Any>,
+    /// initial_deposit is the deposit value that must be paid at proposal submission.
     #[prost(message, repeated, tag = "2")]
     pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    /// proposer is the account address of the proposer.
     #[prost(string, tag = "3")]
     pub proposer: ::prost::alloc::string::String,
 }
@@ -422,6 +450,7 @@ pub struct MsgSubmitProposal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSubmitProposalResponse {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
 }
@@ -429,10 +458,13 @@ pub struct MsgSubmitProposalResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVote {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address for the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
+    /// option defines the vote option.
     #[prost(enumeration = "VoteOption", tag = "3")]
     pub option: i32,
 }
@@ -446,10 +478,13 @@ pub struct MsgVoteResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgVoteWeighted {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// voter is the voter address for the proposal.
     #[prost(string, tag = "2")]
     pub voter: ::prost::alloc::string::String,
+    /// options defines the weighted vote options.
     #[prost(message, repeated, tag = "3")]
     pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
 }
@@ -463,10 +498,13 @@ pub struct MsgVoteWeightedResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgDeposit {
+    /// proposal_id defines the unique id of the proposal.
     #[prost(uint64, tag = "1")]
     pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
     #[prost(string, tag = "2")]
     pub depositor: ::prost::alloc::string::String,
+    /// amount to be deposited by depositor.
     #[prost(message, repeated, tag = "3")]
     pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.rs
@@ -1,0 +1,17 @@
+// @generated
+/// Module is the config object of the group module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// max_execution_period defines the max duration after a proposal's voting period ends that members can send a MsgExec
+    /// to execute the proposal.
+    #[prost(message, optional, tag = "1")]
+    pub max_execution_period:
+        ::core::option::Option<::tendermint_proto::google::protobuf::Duration>,
+    /// max_metadata_len defines the max length of the metadata bytes field for various entities within the group module.
+    /// Defaults to 255 if not explicitly set.
+    #[prost(uint64, tag = "2")]
+    pub max_metadata_len: u64,
+}
+include!("cosmos.group.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.serde.rs
@@ -1,0 +1,130 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.max_execution_period.is_some() {
+            len += 1;
+        }
+        if self.max_metadata_len != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.group.module.v1.Module", len)?;
+        if let Some(v) = self.max_execution_period.as_ref() {
+            struct_ser.serialize_field("maxExecutionPeriod", v)?;
+        }
+        if self.max_metadata_len != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "maxMetadataLen",
+                ToString::to_string(&self.max_metadata_len).as_str(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "max_execution_period",
+            "maxExecutionPeriod",
+            "max_metadata_len",
+            "maxMetadataLen",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            MaxExecutionPeriod,
+            MaxMetadataLen,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "maxExecutionPeriod" | "max_execution_period" => {
+                                Ok(GeneratedField::MaxExecutionPeriod)
+                            }
+                            "maxMetadataLen" | "max_metadata_len" => {
+                                Ok(GeneratedField::MaxMetadataLen)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.group.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut max_execution_period__ = None;
+                let mut max_metadata_len__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::MaxExecutionPeriod => {
+                            if max_execution_period__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "maxExecutionPeriod",
+                                ));
+                            }
+                            max_execution_period__ = map_.next_value()?;
+                        }
+                        GeneratedField::MaxMetadataLen => {
+                            if max_metadata_len__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("maxMetadataLen"));
+                            }
+                            max_metadata_len__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                    }
+                }
+                Ok(Module {
+                    max_execution_period: max_execution_period__,
+                    max_metadata_len: max_metadata_len__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.group.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.rs
@@ -35,7 +35,7 @@ pub struct MemberRequest {
 }
 /// ThresholdDecisionPolicy is a decision policy where a proposal passes when it
 /// satisfies the two following conditions:
-/// 1. The sum of all `YES` voters' weights is greater or equal than the defined
+/// 1. The sum of all `YES` voter's weights is greater or equal than the defined
 ///     `threshold`.
 /// 2. The voting and execution periods of the proposal respect the parameters
 ///     given by `windows`.
@@ -59,7 +59,7 @@ pub struct ThresholdDecisionPolicy {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PercentageDecisionPolicy {
-    /// percentage is the minimum percentage the weighted sum of `YES` votes must
+    /// percentage is the minimum percentage of the weighted sum of `YES` votes must
     /// meet for a proposal to succeed.
     #[prost(string, tag = "1")]
     pub percentage: ::prost::alloc::string::String,
@@ -144,7 +144,9 @@ pub struct GroupPolicyInfo {
     /// admin is the account address of the group admin.
     #[prost(string, tag = "3")]
     pub admin: ::prost::alloc::string::String,
-    /// metadata is any arbitrary metadata to attached to the group policy.
+    /// metadata is any arbitrary metadata attached to the group policy.
+    /// the recommended format of the metadata is to be found here:
+    /// <https://docs.cosmos.network/v0.47/modules/group#decision-policy-1>
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
     /// version is used to track changes to a group's GroupPolicyInfo structure that
@@ -171,7 +173,9 @@ pub struct Proposal {
     /// group_policy_address is the account address of group policy.
     #[prost(string, tag = "2")]
     pub group_policy_address: ::prost::alloc::string::String,
-    /// metadata is any arbitrary metadata to attached to the proposal.
+    /// metadata is any arbitrary metadata attached to the proposal.
+    /// the recommended format of the metadata is to be found here:
+    /// <https://docs.cosmos.network/v0.47/modules/group#proposal-4>
     #[prost(string, tag = "3")]
     pub metadata: ::prost::alloc::string::String,
     /// proposers are the account addresses of the proposers.
@@ -200,7 +204,7 @@ pub struct Proposal {
     #[prost(message, optional, tag = "9")]
     pub final_tally_result: ::core::option::Option<TallyResult>,
     /// voting_period_end is the timestamp before which voting must be done.
-    /// Unless a successfull MsgExec is called before (to execute a proposal whose
+    /// Unless a successful MsgExec is called before (to execute a proposal whose
     /// tally is successful before the voting period ends), tallying will be done
     /// at this point, and the `final_tally_result`and `status` fields will be
     /// accordingly updated.
@@ -212,6 +216,16 @@ pub struct Proposal {
     /// messages is a list of `sdk.Msg`s that will be executed if the proposal passes.
     #[prost(message, repeated, tag = "12")]
     pub messages: ::prost::alloc::vec::Vec<::tendermint_proto::google::protobuf::Any>,
+    /// title is the title of the proposal
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "13")]
+    pub title: ::prost::alloc::string::String,
+    /// summary is a short summary of the proposal
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "14")]
+    pub summary: ::prost::alloc::string::String,
 }
 /// TallyResult represents the sum of weighted votes for each vote option.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -243,7 +257,7 @@ pub struct Vote {
     /// option is the voter's choice on the proposal.
     #[prost(enumeration = "VoteOption", tag = "3")]
     pub option: i32,
-    /// metadata is any arbitrary metadata to attached to the vote.
+    /// metadata is any arbitrary metadata attached to the vote.
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
     /// submit_time is the timestamp when the vote was submitted.
@@ -517,7 +531,7 @@ pub struct QueryGroupInfoRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryGroupInfoResponse {
-    /// info is the GroupInfo for the group.
+    /// info is the GroupInfo of the group.
     #[prost(message, optional, tag = "1")]
     pub info: ::core::option::Option<GroupInfo>,
 }
@@ -533,7 +547,7 @@ pub struct QueryGroupPolicyInfoRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryGroupPolicyInfoResponse {
-    /// info is the GroupPolicyInfo for the group policy.
+    /// info is the GroupPolicyInfo of the group policy.
     #[prost(message, optional, tag = "1")]
     pub info: ::core::option::Option<GroupPolicyInfo>,
 }
@@ -911,6 +925,10 @@ pub struct MsgUpdateGroupPolicyAdmin {
     #[prost(string, tag = "3")]
     pub new_admin: ::prost::alloc::string::String,
 }
+/// MsgUpdateGroupPolicyAdminResponse is the Msg/UpdateGroupPolicyAdmin response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateGroupPolicyAdminResponse {}
 /// MsgCreateGroupWithPolicy is the Msg/CreateGroupWithPolicy request type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -946,10 +964,6 @@ pub struct MsgCreateGroupWithPolicyResponse {
     #[prost(string, tag = "2")]
     pub group_policy_address: ::prost::alloc::string::String,
 }
-/// MsgUpdateGroupPolicyAdminResponse is the Msg/UpdateGroupPolicyAdmin response type.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgUpdateGroupPolicyAdminResponse {}
 /// MsgUpdateGroupPolicyDecisionPolicy is the Msg/UpdateGroupPolicyDecisionPolicy request type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -978,7 +992,7 @@ pub struct MsgUpdateGroupPolicyMetadata {
     /// group_policy_address is the account address of group policy.
     #[prost(string, tag = "2")]
     pub group_policy_address: ::prost::alloc::string::String,
-    /// metadata is the updated group policy metadata.
+    /// metadata is the group policy metadata to be updated.
     #[prost(string, tag = "3")]
     pub metadata: ::prost::alloc::string::String,
 }
@@ -997,7 +1011,7 @@ pub struct MsgSubmitProposal {
     /// Proposers signatures will be counted as yes votes.
     #[prost(string, repeated, tag = "2")]
     pub proposers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// metadata is any arbitrary metadata to attached to the proposal.
+    /// metadata is any arbitrary metadata attached to the proposal.
     #[prost(string, tag = "3")]
     pub metadata: ::prost::alloc::string::String,
     /// messages is a list of `sdk.Msg`s that will be executed if the proposal passes.
@@ -1008,6 +1022,16 @@ pub struct MsgSubmitProposal {
     /// If so, proposers signatures are considered as Yes votes.
     #[prost(enumeration = "Exec", tag = "5")]
     pub exec: i32,
+    /// title is the title of the proposal.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "6")]
+    pub title: ::prost::alloc::string::String,
+    /// summary is the summary of the proposal.
+    ///
+    /// Since: cosmos-sdk 0.47
+    #[prost(string, tag = "7")]
+    pub summary: ::prost::alloc::string::String,
 }
 /// MsgSubmitProposalResponse is the Msg/SubmitProposal response type.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1045,7 +1069,7 @@ pub struct MsgVote {
     /// option is the voter's choice on the proposal.
     #[prost(enumeration = "VoteOption", tag = "3")]
     pub option: i32,
-    /// metadata is any arbitrary metadata to attached to the vote.
+    /// metadata is any arbitrary metadata attached to the vote.
     #[prost(string, tag = "4")]
     pub metadata: ::prost::alloc::string::String,
     /// exec defines whether the proposal should be executed

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.serde.rs
@@ -3635,6 +3635,12 @@ impl serde::Serialize for MsgSubmitProposal {
         if self.exec != 0 {
             len += 1;
         }
+        if !self.title.is_empty() {
+            len += 1;
+        }
+        if !self.summary.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.group.v1.MsgSubmitProposal", len)?;
         if !self.group_policy_address.is_empty() {
@@ -3654,6 +3660,12 @@ impl serde::Serialize for MsgSubmitProposal {
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.exec)))?;
             struct_ser.serialize_field("exec", &v)?;
         }
+        if !self.title.is_empty() {
+            struct_ser.serialize_field("title", &self.title)?;
+        }
+        if !self.summary.is_empty() {
+            struct_ser.serialize_field("summary", &self.summary)?;
+        }
         struct_ser.end()
     }
 }
@@ -3671,6 +3683,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
             "metadata",
             "messages",
             "exec",
+            "title",
+            "summary",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -3680,6 +3694,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
             Metadata,
             Messages,
             Exec,
+            Title,
+            Summary,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -3712,6 +3728,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                             "metadata" => Ok(GeneratedField::Metadata),
                             "messages" => Ok(GeneratedField::Messages),
                             "exec" => Ok(GeneratedField::Exec),
+                            "title" => Ok(GeneratedField::Title),
+                            "summary" => Ok(GeneratedField::Summary),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -3736,6 +3754,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                 let mut metadata__ = None;
                 let mut messages__ = None;
                 let mut exec__ = None;
+                let mut title__ = None;
+                let mut summary__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::GroupPolicyAddress => {
@@ -3770,6 +3790,18 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                             }
                             exec__ = Some(map_.next_value::<Exec>()? as i32);
                         }
+                        GeneratedField::Title => {
+                            if title__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("title"));
+                            }
+                            title__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Summary => {
+                            if summary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("summary"));
+                            }
+                            summary__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(MsgSubmitProposal {
@@ -3778,6 +3810,8 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
                     metadata: metadata__.unwrap_or_default(),
                     messages: messages__.unwrap_or_default(),
                     exec: exec__.unwrap_or_default(),
+                    title: title__.unwrap_or_default(),
+                    summary: summary__.unwrap_or_default(),
                 })
             }
         }
@@ -5870,6 +5904,12 @@ impl serde::Serialize for Proposal {
         if !self.messages.is_empty() {
             len += 1;
         }
+        if !self.title.is_empty() {
+            len += 1;
+        }
+        if !self.summary.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.Proposal", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
@@ -5922,6 +5962,12 @@ impl serde::Serialize for Proposal {
         if !self.messages.is_empty() {
             struct_ser.serialize_field("messages", &self.messages)?;
         }
+        if !self.title.is_empty() {
+            struct_ser.serialize_field("title", &self.title)?;
+        }
+        if !self.summary.is_empty() {
+            struct_ser.serialize_field("summary", &self.summary)?;
+        }
         struct_ser.end()
     }
 }
@@ -5952,6 +5998,8 @@ impl<'de> serde::Deserialize<'de> for Proposal {
             "executor_result",
             "executorResult",
             "messages",
+            "title",
+            "summary",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -5968,6 +6016,8 @@ impl<'de> serde::Deserialize<'de> for Proposal {
             VotingPeriodEnd,
             ExecutorResult,
             Messages,
+            Title,
+            Summary,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -6015,6 +6065,8 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                                 Ok(GeneratedField::ExecutorResult)
                             }
                             "messages" => Ok(GeneratedField::Messages),
+                            "title" => Ok(GeneratedField::Title),
+                            "summary" => Ok(GeneratedField::Summary),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -6046,6 +6098,8 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                 let mut voting_period_end__ = None;
                 let mut executor_result__ = None;
                 let mut messages__ = None;
+                let mut title__ = None;
+                let mut summary__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -6134,6 +6188,18 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                             }
                             messages__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Title => {
+                            if title__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("title"));
+                            }
+                            title__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Summary => {
+                            if summary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("summary"));
+                            }
+                            summary__ = Some(map_.next_value()?);
+                        }
                     }
                 }
                 Ok(Proposal {
@@ -6149,6 +6215,8 @@ impl<'de> serde::Deserialize<'de> for Proposal {
                     voting_period_end: voting_period_end__,
                     executor_result: executor_result__.unwrap_or_default(),
                     messages: messages__.unwrap_or_default(),
+                    title: title__.unwrap_or_default(),
+                    summary: summary__.unwrap_or_default(),
                 })
             }
         }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.rs
@@ -1,0 +1,13 @@
+// @generated
+/// Module is the config object of the mint module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    #[prost(string, tag = "1")]
+    pub fee_collector_name: ::prost::alloc::string::String,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.mint.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.serde.rs
@@ -1,0 +1,114 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.fee_collector_name.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.mint.module.v1.Module", len)?;
+        if !self.fee_collector_name.is_empty() {
+            struct_ser.serialize_field("feeCollectorName", &self.fee_collector_name)?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["fee_collector_name", "feeCollectorName", "authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            FeeCollectorName,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "feeCollectorName" | "fee_collector_name" => {
+                                Ok(GeneratedField::FeeCollectorName)
+                            }
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.mint.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut fee_collector_name__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::FeeCollectorName => {
+                            if fee_collector_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeCollectorName"));
+                            }
+                            fee_collector_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    fee_collector_name: fee_collector_name__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.mint.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.rs
@@ -10,7 +10,7 @@ pub struct Minter {
     #[prost(string, tag = "2")]
     pub annual_provisions: ::prost::alloc::string::String,
 }
-/// Params holds parameters for the mint module.
+/// Params defines the parameters for the x/mint module.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
@@ -40,7 +40,7 @@ pub struct GenesisState {
     /// minter is a space for holding current inflation information.
     #[prost(message, optional, tag = "1")]
     pub minter: ::core::option::Option<Minter>,
-    /// params defines all the paramaters of the module.
+    /// params defines all the parameters of the module.
     #[prost(message, optional, tag = "2")]
     pub params: ::core::option::Option<Params>,
 }
@@ -83,6 +83,28 @@ pub struct QueryAnnualProvisionsResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub annual_provisions: ::prost::alloc::vec::Vec<u8>,
 }
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/mint parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.mint.v1beta1.serde.rs");
 include!("cosmos.mint.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.serde.rs
@@ -229,6 +229,204 @@ impl<'de> serde::Deserialize<'de> for Minter {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.mint.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.mint.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.mint.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.mint.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.mint.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.mint.v1beta1.MsgUpdateParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
@@ -394,3 +394,271 @@ pub mod query_server {
         const NAME: &'static str = "cosmos.mint.v1beta1.Query";
     }
 }
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct MsgClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl MsgClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MsgClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> MsgClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            MsgClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.mint.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.mint.v1beta1.Msg", "UpdateParams"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod msg_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with MsgServer.
+    #[async_trait]
+    pub trait Msg: Send + Sync + 'static {
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct MsgServer<T: Msg> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Msg> MsgServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for MsgServer<T>
+    where
+        T: Msg,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.mint.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Msg> Clone for MsgServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Msg> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Msg> tonic::server::NamedService for MsgServer<T> {
+        const NAME: &'static str = "cosmos.mint.v1beta1.Msg";
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object of the nft module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.nft.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.serde.rs
@@ -1,0 +1,75 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.nft.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.nft.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct("cosmos.nft.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.rs
@@ -3,12 +3,16 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventSend {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// id is a unique identifier of the nft
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
+    /// sender is the address of the owner of nft
     #[prost(string, tag = "3")]
     pub sender: ::prost::alloc::string::String,
+    /// receiver is the receiver address of nft
     #[prost(string, tag = "4")]
     pub receiver: ::prost::alloc::string::String,
 }
@@ -16,10 +20,13 @@ pub struct EventSend {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventMint {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// id is a unique identifier of the nft
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
+    /// owner is the owner address of the nft
     #[prost(string, tag = "3")]
     pub owner: ::prost::alloc::string::String,
 }
@@ -27,10 +34,13 @@ pub struct EventMint {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventBurn {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// id is a unique identifier of the nft
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
+    /// owner is the owner address of the nft
     #[prost(string, tag = "3")]
     pub owner: ::prost::alloc::string::String,
 }
@@ -87,6 +97,7 @@ pub struct GenesisState {
     /// class defines the class of the nft type.
     #[prost(message, repeated, tag = "1")]
     pub classes: ::prost::alloc::vec::Vec<Class>,
+    /// entry defines all nft owned by a person.
     #[prost(message, repeated, tag = "2")]
     pub entries: ::prost::alloc::vec::Vec<Entry>,
 }
@@ -105,8 +116,10 @@ pub struct Entry {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBalanceRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// owner is the owner address of the nft
     #[prost(string, tag = "2")]
     pub owner: ::prost::alloc::string::String,
 }
@@ -114,6 +127,7 @@ pub struct QueryBalanceRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryBalanceResponse {
+    /// amount is the number of all NFTs of a given class owned by the owner
     #[prost(uint64, tag = "1")]
     pub amount: u64,
 }
@@ -121,8 +135,10 @@ pub struct QueryBalanceResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryOwnerRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// id is a unique identifier of the NFT
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
 }
@@ -130,6 +146,7 @@ pub struct QueryOwnerRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryOwnerResponse {
+    /// owner is the owner address of the nft
     #[prost(string, tag = "1")]
     pub owner: ::prost::alloc::string::String,
 }
@@ -137,6 +154,7 @@ pub struct QueryOwnerResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuerySupplyRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
 }
@@ -144,6 +162,7 @@ pub struct QuerySupplyRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuerySupplyResponse {
+    /// amount is the number of all NFTs from the given class
     #[prost(uint64, tag = "1")]
     pub amount: u64,
 }
@@ -151,10 +170,13 @@ pub struct QuerySupplyResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryNfTsRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// owner is the owner address of the nft
     #[prost(string, tag = "2")]
     pub owner: ::prost::alloc::string::String,
+    /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag = "3")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
 }
@@ -162,8 +184,10 @@ pub struct QueryNfTsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryNfTsResponse {
+    /// NFT defines the NFT
     #[prost(message, repeated, tag = "1")]
     pub nfts: ::prost::alloc::vec::Vec<Nft>,
+    /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
@@ -171,8 +195,10 @@ pub struct QueryNfTsResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryNftRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
+    /// id is a unique identifier of the NFT
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
 }
@@ -180,6 +206,7 @@ pub struct QueryNftRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryNftResponse {
+    /// owner is the owner address of the nft
     #[prost(message, optional, tag = "1")]
     pub nft: ::core::option::Option<Nft>,
 }
@@ -187,6 +214,7 @@ pub struct QueryNftResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryClassRequest {
+    /// class_id associated with the nft
     #[prost(string, tag = "1")]
     pub class_id: ::prost::alloc::string::String,
 }
@@ -194,6 +222,7 @@ pub struct QueryClassRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryClassResponse {
+    /// class defines the class of the nft type.
     #[prost(message, optional, tag = "1")]
     pub class: ::core::option::Option<Class>,
 }
@@ -209,8 +238,10 @@ pub struct QueryClassesRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryClassesResponse {
+    /// class defines the class of the nft type.
     #[prost(message, repeated, tag = "1")]
     pub classes: ::prost::alloc::vec::Vec<Class>,
+    /// pagination defines the pagination in the response.
     #[prost(message, optional, tag = "2")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.rs
@@ -1,0 +1,145 @@
+// @generated
+/// GetRequest is the Query/Get request type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRequest {
+    /// message_name is the fully-qualified message name of the ORM table being queried.
+    #[prost(string, tag = "1")]
+    pub message_name: ::prost::alloc::string::String,
+    /// index is the index fields expression used in orm definitions. If it
+    /// is empty, the table's primary key is assumed. If it is non-empty, it must
+    /// refer to an unique index.
+    #[prost(string, tag = "2")]
+    pub index: ::prost::alloc::string::String,
+    /// values are the values of the fields corresponding to the requested index.
+    /// There must be as many values provided as there are fields in the index and
+    /// these values must correspond to the index field types.
+    #[prost(message, repeated, tag = "3")]
+    pub values: ::prost::alloc::vec::Vec<IndexValue>,
+}
+/// GetResponse is the Query/Get response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetResponse {
+    /// result is the result of the get query. If no value is found, the gRPC
+    /// status code NOT_FOUND will be returned.
+    #[prost(message, optional, tag = "1")]
+    pub result: ::core::option::Option<::tendermint_proto::google::protobuf::Any>,
+}
+/// ListRequest is the Query/List request type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListRequest {
+    /// message_name is the fully-qualified message name of the ORM table being queried.
+    #[prost(string, tag = "1")]
+    pub message_name: ::prost::alloc::string::String,
+    /// index is the index fields expression used in orm definitions. If it
+    /// is empty, the table's primary key is assumed.
+    #[prost(string, tag = "2")]
+    pub index: ::prost::alloc::string::String,
+    /// pagination is the pagination request.
+    #[prost(message, optional, tag = "5")]
+    pub pagination: ::core::option::Option<super::super::super::base::query::v1beta1::PageRequest>,
+    /// query is the query expression corresponding to the provided index. If
+    /// neither prefix nor range is specified, the query will list all the fields
+    /// in the index.
+    #[prost(oneof = "list_request::Query", tags = "3, 4")]
+    pub query: ::core::option::Option<list_request::Query>,
+}
+/// Nested message and enum types in `ListRequest`.
+pub mod list_request {
+    /// Prefix specifies the arguments to a prefix query.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Prefix {
+        /// values specifies the index values for the prefix query.
+        /// It is valid to special a partial prefix with fewer values than
+        /// the number of fields in the index.
+        #[prost(message, repeated, tag = "1")]
+        pub values: ::prost::alloc::vec::Vec<super::IndexValue>,
+    }
+    /// Range specifies the arguments to a range query.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Range {
+        /// start specifies the starting index values for the range query.
+        /// It is valid to provide fewer values than the number of fields in the
+        /// index.
+        #[prost(message, repeated, tag = "1")]
+        pub start: ::prost::alloc::vec::Vec<super::IndexValue>,
+        /// end specifies the inclusive ending index values for the range query.
+        /// It is valid to provide fewer values than the number of fields in the
+        /// index.
+        #[prost(message, repeated, tag = "2")]
+        pub end: ::prost::alloc::vec::Vec<super::IndexValue>,
+    }
+    /// query is the query expression corresponding to the provided index. If
+    /// neither prefix nor range is specified, the query will list all the fields
+    /// in the index.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Query {
+        /// prefix defines a prefix query.
+        #[prost(message, tag = "3")]
+        Prefix(Prefix),
+        /// range defines a range query.
+        #[prost(message, tag = "4")]
+        Range(Range),
+    }
+}
+/// ListResponse is the Query/List response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListResponse {
+    /// results are the results of the query.
+    #[prost(message, repeated, tag = "1")]
+    pub results: ::prost::alloc::vec::Vec<::tendermint_proto::google::protobuf::Any>,
+    /// pagination is the pagination response.
+    #[prost(message, optional, tag = "5")]
+    pub pagination: ::core::option::Option<super::super::super::base::query::v1beta1::PageResponse>,
+}
+/// IndexValue represents the value of a field in an ORM index expression.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IndexValue {
+    /// value specifies the index value
+    #[prost(oneof = "index_value::Value", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
+    pub value: ::core::option::Option<index_value::Value>,
+}
+/// Nested message and enum types in `IndexValue`.
+pub mod index_value {
+    /// value specifies the index value
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        /// uint specifies a value for an uint32, fixed32, uint64, or fixed64
+        /// index field.
+        #[prost(uint64, tag = "1")]
+        Uint(u64),
+        /// int64 specifies a value for an int32, sfixed32, int64, or sfixed64
+        /// index field.
+        #[prost(int64, tag = "2")]
+        Int(i64),
+        /// str specifies a value for a string index field.
+        #[prost(string, tag = "3")]
+        Str(::prost::alloc::string::String),
+        /// bytes specifies a value for a bytes index field.
+        #[prost(bytes, tag = "4")]
+        Bytes(::prost::alloc::vec::Vec<u8>),
+        /// enum specifies a value for an enum index field.
+        #[prost(string, tag = "5")]
+        Enum(::prost::alloc::string::String),
+        /// bool specifies a value for a bool index field.
+        #[prost(bool, tag = "6")]
+        Bool(bool),
+        /// timestamp specifies a value for a timestamp index field.
+        #[prost(message, tag = "7")]
+        Timestamp(::tendermint_proto::google::protobuf::Timestamp),
+        /// duration specifies a value for a duration index field.
+        #[prost(message, tag = "8")]
+        Duration(::tendermint_proto::google::protobuf::Duration),
+    }
+}
+include!("cosmos.orm.query.v1alpha1.serde.rs");
+include!("cosmos.orm.query.v1alpha1.tonic.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.serde.rs
@@ -1,0 +1,942 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for GetRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.message_name.is_empty() {
+            len += 1;
+        }
+        if !self.index.is_empty() {
+            len += 1;
+        }
+        if !self.values.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.GetRequest", len)?;
+        if !self.message_name.is_empty() {
+            struct_ser.serialize_field("messageName", &self.message_name)?;
+        }
+        if !self.index.is_empty() {
+            struct_ser.serialize_field("index", &self.index)?;
+        }
+        if !self.values.is_empty() {
+            struct_ser.serialize_field("values", &self.values)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for GetRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["message_name", "messageName", "index", "values"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            MessageName,
+            Index,
+            Values,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "messageName" | "message_name" => Ok(GeneratedField::MessageName),
+                            "index" => Ok(GeneratedField::Index),
+                            "values" => Ok(GeneratedField::Values),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.GetRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut message_name__ = None;
+                let mut index__ = None;
+                let mut values__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::MessageName => {
+                            if message_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("messageName"));
+                            }
+                            message_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Index => {
+                            if index__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("index"));
+                            }
+                            index__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Values => {
+                            if values__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("values"));
+                            }
+                            values__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(GetRequest {
+                    message_name: message_name__.unwrap_or_default(),
+                    index: index__.unwrap_or_default(),
+                    values: values__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.GetRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for GetResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.result.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.GetResponse", len)?;
+        if let Some(v) = self.result.as_ref() {
+            struct_ser.serialize_field("result", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for GetResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["result"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Result,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "result" => Ok(GeneratedField::Result),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.GetResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut result__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Result => {
+                            if result__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("result"));
+                            }
+                            result__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetResponse { result: result__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.GetResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for IndexValue {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.IndexValue", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                index_value::Value::Uint(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser.serialize_field("uint", ToString::to_string(&v).as_str())?;
+                }
+                index_value::Value::Int(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser.serialize_field("int", ToString::to_string(&v).as_str())?;
+                }
+                index_value::Value::Str(v) => {
+                    struct_ser.serialize_field("str", v)?;
+                }
+                index_value::Value::Bytes(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser
+                        .serialize_field("bytes", pbjson::private::base64::encode(&v).as_str())?;
+                }
+                index_value::Value::Enum(v) => {
+                    struct_ser.serialize_field("enum", v)?;
+                }
+                index_value::Value::Bool(v) => {
+                    struct_ser.serialize_field("bool", v)?;
+                }
+                index_value::Value::Timestamp(v) => {
+                    struct_ser.serialize_field("timestamp", v)?;
+                }
+                index_value::Value::Duration(v) => {
+                    struct_ser.serialize_field("duration", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for IndexValue {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "uint",
+            "int",
+            "str",
+            "bytes",
+            "enum",
+            "bool",
+            "timestamp",
+            "duration",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Uint,
+            Int,
+            Str,
+            Bytes,
+            Enum,
+            Bool,
+            Timestamp,
+            Duration,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "uint" => Ok(GeneratedField::Uint),
+                            "int" => Ok(GeneratedField::Int),
+                            "str" => Ok(GeneratedField::Str),
+                            "bytes" => Ok(GeneratedField::Bytes),
+                            "enum" => Ok(GeneratedField::Enum),
+                            "bool" => Ok(GeneratedField::Bool),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
+                            "duration" => Ok(GeneratedField::Duration),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = IndexValue;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.IndexValue")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IndexValue, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Uint => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("uint"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| index_value::Value::Uint(x.0));
+                        }
+                        GeneratedField::Int => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("int"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| index_value::Value::Int(x.0));
+                        }
+                        GeneratedField::Str => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("str"));
+                            }
+                            value__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(index_value::Value::Str);
+                        }
+                        GeneratedField::Bytes => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bytes"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| index_value::Value::Bytes(x.0));
+                        }
+                        GeneratedField::Enum => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("enum"));
+                            }
+                            value__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(index_value::Value::Enum);
+                        }
+                        GeneratedField::Bool => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bool"));
+                            }
+                            value__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(index_value::Value::Bool);
+                        }
+                        GeneratedField::Timestamp => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            value__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(index_value::Value::Timestamp);
+                        }
+                        GeneratedField::Duration => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("duration"));
+                            }
+                            value__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(index_value::Value::Duration);
+                        }
+                    }
+                }
+                Ok(IndexValue { value: value__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.IndexValue",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ListRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.message_name.is_empty() {
+            len += 1;
+        }
+        if !self.index.is_empty() {
+            len += 1;
+        }
+        if self.pagination.is_some() {
+            len += 1;
+        }
+        if self.query.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.ListRequest", len)?;
+        if !self.message_name.is_empty() {
+            struct_ser.serialize_field("messageName", &self.message_name)?;
+        }
+        if !self.index.is_empty() {
+            struct_ser.serialize_field("index", &self.index)?;
+        }
+        if let Some(v) = self.pagination.as_ref() {
+            struct_ser.serialize_field("pagination", v)?;
+        }
+        if let Some(v) = self.query.as_ref() {
+            match v {
+                list_request::Query::Prefix(v) => {
+                    struct_ser.serialize_field("prefix", v)?;
+                }
+                list_request::Query::Range(v) => {
+                    struct_ser.serialize_field("range", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ListRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "message_name",
+            "messageName",
+            "index",
+            "pagination",
+            "prefix",
+            "range",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            MessageName,
+            Index,
+            Pagination,
+            Prefix,
+            Range,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "messageName" | "message_name" => Ok(GeneratedField::MessageName),
+                            "index" => Ok(GeneratedField::Index),
+                            "pagination" => Ok(GeneratedField::Pagination),
+                            "prefix" => Ok(GeneratedField::Prefix),
+                            "range" => Ok(GeneratedField::Range),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ListRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ListRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut message_name__ = None;
+                let mut index__ = None;
+                let mut pagination__ = None;
+                let mut query__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::MessageName => {
+                            if message_name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("messageName"));
+                            }
+                            message_name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Index => {
+                            if index__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("index"));
+                            }
+                            index__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Pagination => {
+                            if pagination__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pagination"));
+                            }
+                            pagination__ = map_.next_value()?;
+                        }
+                        GeneratedField::Prefix => {
+                            if query__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("prefix"));
+                            }
+                            query__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(list_request::Query::Prefix);
+                        }
+                        GeneratedField::Range => {
+                            if query__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("range"));
+                            }
+                            query__ = map_
+                                .next_value::<::std::option::Option<_>>()?
+                                .map(list_request::Query::Range);
+                        }
+                    }
+                }
+                Ok(ListRequest {
+                    message_name: message_name__.unwrap_or_default(),
+                    index: index__.unwrap_or_default(),
+                    pagination: pagination__,
+                    query: query__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.ListRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for list_request::Prefix {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.values.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.ListRequest.Prefix", len)?;
+        if !self.values.is_empty() {
+            struct_ser.serialize_field("values", &self.values)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for list_request::Prefix {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["values"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Values,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "values" => Ok(GeneratedField::Values),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = list_request::Prefix;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest.Prefix")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<list_request::Prefix, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut values__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Values => {
+                            if values__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("values"));
+                            }
+                            values__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(list_request::Prefix {
+                    values: values__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.ListRequest.Prefix",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for list_request::Range {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.start.is_empty() {
+            len += 1;
+        }
+        if !self.end.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.ListRequest.Range", len)?;
+        if !self.start.is_empty() {
+            struct_ser.serialize_field("start", &self.start)?;
+        }
+        if !self.end.is_empty() {
+            struct_ser.serialize_field("end", &self.end)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for list_request::Range {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["start", "end"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Start,
+            End,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "start" => Ok(GeneratedField::Start),
+                            "end" => Ok(GeneratedField::End),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = list_request::Range;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest.Range")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<list_request::Range, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut start__ = None;
+                let mut end__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Start => {
+                            if start__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("start"));
+                            }
+                            start__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::End => {
+                            if end__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("end"));
+                            }
+                            end__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(list_request::Range {
+                    start: start__.unwrap_or_default(),
+                    end: end__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.ListRequest.Range",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ListResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.results.is_empty() {
+            len += 1;
+        }
+        if self.pagination.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.orm.query.v1alpha1.ListResponse", len)?;
+        if !self.results.is_empty() {
+            struct_ser.serialize_field("results", &self.results)?;
+        }
+        if let Some(v) = self.pagination.as_ref() {
+            struct_ser.serialize_field("pagination", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ListResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["results", "pagination"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Results,
+            Pagination,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "results" => Ok(GeneratedField::Results),
+                            "pagination" => Ok(GeneratedField::Pagination),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ListResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.orm.query.v1alpha1.ListResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ListResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut results__ = None;
+                let mut pagination__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Results => {
+                            if results__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("results"));
+                            }
+                            results__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Pagination => {
+                            if pagination__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pagination"));
+                            }
+                            pagination__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(ListResponse {
+                    results: results__.unwrap_or_default(),
+                    pagination: pagination__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.orm.query.v1alpha1.ListResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.tonic.rs
@@ -1,0 +1,330 @@
+// @generated
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod query_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct QueryClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl QueryClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> QueryClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> QueryClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            QueryClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn get(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.orm.query.v1alpha1.Query/Get");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.orm.query.v1alpha1.Query", "Get"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn list(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.orm.query.v1alpha1.Query/List");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.orm.query.v1alpha1.Query", "List"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod query_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with QueryServer.
+    #[async_trait]
+    pub trait Query: Send + Sync + 'static {
+        async fn get(
+            &self,
+            request: tonic::Request<super::GetRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
+        async fn list(
+            &self,
+            request: tonic::Request<super::ListRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct QueryServer<T: Query> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Query> QueryServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServer<T>
+    where
+        T: Query,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.orm.query.v1alpha1.Query/Get" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::GetRequest> for GetSvc<T> {
+                        type Response = super::GetResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).get(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.orm.query.v1alpha1.Query/List" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListSvc<T: Query>(pub Arc<T>);
+                    impl<T: Query> tonic::server::UnaryService<super::ListRequest> for ListSvc<T> {
+                        type Response = super::ListResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).list(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ListSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Query> Clone for QueryServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Query> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Query> tonic::server::NamedService for QueryServer<T> {
+        const NAME: &'static str = "cosmos.orm.query.v1alpha1.Query";
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object of the params module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.params.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.serde.rs
@@ -1,0 +1,75 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.params.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.params.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct("cosmos.params.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.query.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.query.v1.rs
@@ -1,0 +1,2 @@
+// @generated
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.rs
@@ -1,0 +1,16 @@
+// @generated
+/// FileDescriptorsRequest is the Query/FileDescriptors request type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorsRequest {}
+/// FileDescriptorsResponse is the Query/FileDescriptors response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorsResponse {
+    /// files is the file descriptors.
+    #[prost(message, repeated, tag = "1")]
+    pub files: ::prost::alloc::vec::Vec<::tendermint_proto::google::protobuf::FileDescriptorProto>,
+}
+include!("cosmos.reflection.v1.serde.rs");
+include!("cosmos.reflection.v1.tonic.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.serde.rs
@@ -1,0 +1,186 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for FileDescriptorsRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.reflection.v1.FileDescriptorsRequest", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FileDescriptorsRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.reflection.v1.FileDescriptorsRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<FileDescriptorsRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(FileDescriptorsRequest {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.reflection.v1.FileDescriptorsRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for FileDescriptorsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.files.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.reflection.v1.FileDescriptorsResponse", len)?;
+        if !self.files.is_empty() {
+            struct_ser.serialize_field("files", &self.files)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for FileDescriptorsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["files"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Files,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "files" => Ok(GeneratedField::Files),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FileDescriptorsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.reflection.v1.FileDescriptorsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<FileDescriptorsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut files__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Files => {
+                            if files__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("files"));
+                            }
+                            files__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(FileDescriptorsResponse {
+                    files: files__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.reflection.v1.FileDescriptorsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.tonic.rs
@@ -1,0 +1,290 @@
+// @generated
+/// Generated client implementations.
+#[cfg(feature = "grpc")]
+pub mod reflection_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    /** Package cosmos.reflection.v1 provides support for inspecting protobuf
+     file descriptors.
+    */
+    #[derive(Debug, Clone)]
+    pub struct ReflectionServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    #[cfg(feature = "grpc-transport")]
+    impl ReflectionServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ReflectionServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ReflectionServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            ReflectionServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /** FileDescriptors queries all the file descriptors in the app in order
+         to enable easier generation of dynamic clients.
+        */
+        pub async fn file_descriptors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FileDescriptorsRequest>,
+        ) -> std::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/cosmos.reflection.v1.ReflectionService/FileDescriptors",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.reflection.v1.ReflectionService",
+                "FileDescriptors",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "grpc")]
+pub mod reflection_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ReflectionServiceServer.
+    #[async_trait]
+    pub trait ReflectionService: Send + Sync + 'static {
+        /** FileDescriptors queries all the file descriptors in the app in order
+         to enable easier generation of dynamic clients.
+        */
+        async fn file_descriptors(
+            &self,
+            request: tonic::Request<super::FileDescriptorsRequest>,
+        ) -> std::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>;
+    }
+    /** Package cosmos.reflection.v1 provides support for inspecting protobuf
+     file descriptors.
+    */
+    #[derive(Debug)]
+    pub struct ReflectionServiceServer<T: ReflectionService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: ReflectionService> ReflectionServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ReflectionServiceServer<T>
+    where
+        T: ReflectionService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/cosmos.reflection.v1.ReflectionService/FileDescriptors" => {
+                    #[allow(non_camel_case_types)]
+                    struct FileDescriptorsSvc<T: ReflectionService>(pub Arc<T>);
+                    impl<T: ReflectionService>
+                        tonic::server::UnaryService<super::FileDescriptorsRequest>
+                        for FileDescriptorsSvc<T>
+                    {
+                        type Response = super::FileDescriptorsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FileDescriptorsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).file_descriptors(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FileDescriptorsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: ReflectionService> Clone for ReflectionServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: ReflectionService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: ReflectionService> tonic::server::NamedService for ReflectionServiceServer<T> {
+        const NAME: &'static str = "cosmos.reflection.v1.ReflectionService";
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.rs
@@ -1,0 +1,11 @@
+// @generated
+/// Module is the config object of the slashing module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.slashing.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.serde.rs
@@ -1,0 +1,101 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.slashing.module.v1.Module", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.slashing.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.slashing.module.v1.Module",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.rs
@@ -46,7 +46,7 @@ pub struct Params {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
-    /// params defines all the paramaters of related to deposit.
+    /// params defines all the parameters of the module.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// signing_infos represents a map between validator addresses and their
@@ -151,6 +151,28 @@ pub struct MsgUnjail {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgUnjailResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/slashing parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.slashing.v1beta1.serde.rs");
 include!("cosmos.slashing.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.serde.rs
@@ -437,6 +437,204 @@ impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.slashing.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.slashing.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.slashing.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.slashing.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.slashing.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.slashing.v1beta1.MsgUpdateParamsResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
@@ -496,6 +496,27 @@ pub mod msg_client {
                 .insert(GrpcMethod::new("cosmos.slashing.v1beta1.Msg", "Unjail"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.slashing.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.slashing.v1beta1.Msg",
+                "UpdateParams",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -510,6 +531,10 @@ pub mod msg_server {
             &self,
             request: tonic::Request<super::MsgUnjail>,
         ) -> std::result::Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status>;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -610,6 +635,44 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UnjailSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.slashing.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.rs
@@ -1,0 +1,16 @@
+// @generated
+/// Module is the config object of the staking module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// hooks_order specifies the order of staking hooks and should be a list
+    /// of module names which provide a staking hooks instance. If no order is
+    /// provided, then hooks will be applied in alphabetical order of module names.
+    #[prost(string, repeated, tag = "1")]
+    pub hooks_order: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "2")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.staking.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.serde.rs
@@ -1,0 +1,112 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.hooks_order.is_empty() {
+            len += 1;
+        }
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.staking.module.v1.Module", len)?;
+        if !self.hooks_order.is_empty() {
+            struct_ser.serialize_field("hooksOrder", &self.hooks_order)?;
+        }
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["hooks_order", "hooksOrder", "authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            HooksOrder,
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "hooksOrder" | "hooks_order" => Ok(GeneratedField::HooksOrder),
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.staking.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut hooks_order__ = None;
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::HooksOrder => {
+                            if hooks_order__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hooksOrder"));
+                            }
+                            hooks_order__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    hooks_order: hooks_order__.unwrap_or_default(),
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.staking.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.rs
@@ -181,6 +181,12 @@ pub struct Validator {
     /// Since: cosmos-sdk 0.46
     #[prost(string, tag = "11")]
     pub min_self_delegation: ::prost::alloc::string::String,
+    /// strictly positive if this validator's unbonding has been stopped by external modules
+    #[prost(int64, tag = "12")]
+    pub unbonding_on_hold_ref_count: i64,
+    /// list of unbonding ids, each uniquely identifing an unbonding of this validator
+    #[prost(uint64, repeated, tag = "13")]
+    pub unbonding_ids: ::prost::alloc::vec::Vec<u64>,
 }
 /// ValAddresses defines a repeated set of validator addresses.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -277,6 +283,12 @@ pub struct UnbondingDelegationEntry {
     /// balance defines the tokens to receive at completion.
     #[prost(string, tag = "4")]
     pub balance: ::prost::alloc::string::String,
+    /// Incrementing id that uniquely identifies this entry
+    #[prost(uint64, tag = "5")]
+    pub unbonding_id: u64,
+    /// Strictly positive if this entry's unbonding has been stopped by external modules
+    #[prost(int64, tag = "6")]
+    pub unbonding_on_hold_ref_count: i64,
 }
 /// RedelegationEntry defines a redelegation object with relevant metadata.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -294,6 +306,12 @@ pub struct RedelegationEntry {
     /// shares_dst is the amount of destination-validator shares created by redelegation.
     #[prost(string, tag = "4")]
     pub shares_dst: ::prost::alloc::string::String,
+    /// Incrementing id that uniquely identifies this entry
+    #[prost(uint64, tag = "5")]
+    pub unbonding_id: u64,
+    /// Strictly positive if this entry's unbonding has been stopped by external modules
+    #[prost(int64, tag = "6")]
+    pub unbonding_on_hold_ref_count: i64,
 }
 /// Redelegation contains the list of a particular delegator's redelegating bonds
 /// from a particular source validator to a particular destination validator.
@@ -315,7 +333,7 @@ pub struct Redelegation {
     #[prost(message, repeated, tag = "4")]
     pub entries: ::prost::alloc::vec::Vec<RedelegationEntry>,
 }
-/// Params defines the parameters for the staking module.
+/// Params defines the parameters for the x/staking module.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
@@ -380,6 +398,14 @@ pub struct Pool {
     #[prost(string, tag = "2")]
     pub bonded_tokens: ::prost::alloc::string::String,
 }
+/// ValidatorUpdates defines an array of abci.ValidatorUpdate objects.
+/// TODO: explore moving this to proto/cosmos/base to separate modules from tendermint dependence
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorUpdates {
+    #[prost(message, repeated, tag = "1")]
+    pub updates: ::prost::alloc::vec::Vec<::tendermint_proto::v0_34::abci::ValidatorUpdate>,
+}
 /// BondStatus is the status of a validator.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -417,11 +443,44 @@ impl BondStatus {
         }
     }
 }
+/// Infraction indicates the infraction a validator commited.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Infraction {
+    /// UNSPECIFIED defines an empty infraction.
+    Unspecified = 0,
+    /// DOUBLE_SIGN defines a validator that double-signs a block.
+    DoubleSign = 1,
+    /// DOWNTIME defines a validator that missed signing too many blocks.
+    Downtime = 2,
+}
+impl Infraction {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Infraction::Unspecified => "INFRACTION_UNSPECIFIED",
+            Infraction::DoubleSign => "INFRACTION_DOUBLE_SIGN",
+            Infraction::Downtime => "INFRACTION_DOWNTIME",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "INFRACTION_UNSPECIFIED" => Some(Self::Unspecified),
+            "INFRACTION_DOUBLE_SIGN" => Some(Self::DoubleSign),
+            "INFRACTION_DOWNTIME" => Some(Self::Downtime),
+            _ => None,
+        }
+    }
+}
 /// GenesisState defines the staking module's genesis state.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisState {
-    /// params defines all the paramaters of related to deposit.
+    /// params defines all the parameters of related to deposit.
     #[prost(message, optional, tag = "1")]
     pub params: ::core::option::Option<Params>,
     /// last_total_power tracks the total amounts of bonded tokens recorded during
@@ -868,6 +927,28 @@ pub struct MsgCancelUnbondingDelegation {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCancelUnbondingDelegationResponse {}
+/// MsgUpdateParams is the Msg/UpdateParams request type.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParams {
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+    /// params defines the x/staking parameters to update.
+    ///
+    /// NOTE: All parameters must be supplied.
+    #[prost(message, optional, tag = "2")]
+    pub params: ::core::option::Option<Params>,
+}
+/// MsgUpdateParamsResponse defines the response structure for executing a
+/// MsgUpdateParams message.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MsgUpdateParamsResponse {}
 include!("cosmos.staking.v1beta1.serde.rs");
 include!("cosmos.staking.v1beta1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.serde.rs
@@ -1673,6 +1673,82 @@ impl<'de> serde::Deserialize<'de> for HistoricalInfo {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for Infraction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let variant = match self {
+            Self::Unspecified => "INFRACTION_UNSPECIFIED",
+            Self::DoubleSign => "INFRACTION_DOUBLE_SIGN",
+            Self::Downtime => "INFRACTION_DOWNTIME",
+        };
+        serializer.serialize_str(variant)
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Infraction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "INFRACTION_UNSPECIFIED",
+            "INFRACTION_DOUBLE_SIGN",
+            "INFRACTION_DOWNTIME",
+        ];
+
+        struct GeneratedVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Infraction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "expected one of: {:?}", &FIELDS)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Signed(v), &self)
+                    })
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Unsigned(v), &self)
+                    })
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "INFRACTION_UNSPECIFIED" => Ok(Infraction::Unspecified),
+                    "INFRACTION_DOUBLE_SIGN" => Ok(Infraction::DoubleSign),
+                    "INFRACTION_DOWNTIME" => Ok(Infraction::Downtime),
+                    _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
+                }
+            }
+        }
+        deserializer.deserialize_any(GeneratedVisitor)
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for LastValidatorPower {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -3322,6 +3398,204 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
         }
         deserializer.deserialize_struct(
             "cosmos.staking.v1beta1.MsgUndelegateResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.staking.v1beta1.MsgUpdateParams", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority", "params"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+            Params,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.staking.v1beta1.MsgUpdateParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(MsgUpdateParams {
+                    authority: authority__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.staking.v1beta1.MsgUpdateParams",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser =
+            serializer.serialize_struct("cosmos.staking.v1beta1.MsgUpdateParamsResponse", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MsgUpdateParamsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.staking.v1beta1.MsgUpdateParamsResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MsgUpdateParamsResponse {})
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.staking.v1beta1.MsgUpdateParamsResponse",
             FIELDS,
             GeneratedVisitor,
         )
@@ -7058,6 +7332,12 @@ impl serde::Serialize for RedelegationEntry {
         if !self.shares_dst.is_empty() {
             len += 1;
         }
+        if self.unbonding_id != 0 {
+            len += 1;
+        }
+        if self.unbonding_on_hold_ref_count != 0 {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.staking.v1beta1.RedelegationEntry", len)?;
         if self.creation_height != 0 {
@@ -7075,6 +7355,20 @@ impl serde::Serialize for RedelegationEntry {
         }
         if !self.shares_dst.is_empty() {
             struct_ser.serialize_field("sharesDst", &self.shares_dst)?;
+        }
+        if self.unbonding_id != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "unbondingId",
+                ToString::to_string(&self.unbonding_id).as_str(),
+            )?;
+        }
+        if self.unbonding_on_hold_ref_count != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "unbondingOnHoldRefCount",
+                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -7095,6 +7389,10 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
             "initialBalance",
             "shares_dst",
             "sharesDst",
+            "unbonding_id",
+            "unbondingId",
+            "unbonding_on_hold_ref_count",
+            "unbondingOnHoldRefCount",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -7103,6 +7401,8 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
             CompletionTime,
             InitialBalance,
             SharesDst,
+            UnbondingId,
+            UnbondingOnHoldRefCount,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -7138,6 +7438,10 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
                                 Ok(GeneratedField::InitialBalance)
                             }
                             "sharesDst" | "shares_dst" => Ok(GeneratedField::SharesDst),
+                            "unbondingId" | "unbonding_id" => Ok(GeneratedField::UnbondingId),
+                            "unbondingOnHoldRefCount" | "unbonding_on_hold_ref_count" => {
+                                Ok(GeneratedField::UnbondingOnHoldRefCount)
+                            }
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -7161,6 +7465,8 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
                 let mut completion_time__ = None;
                 let mut initial_balance__ = None;
                 let mut shares_dst__ = None;
+                let mut unbonding_id__ = None;
+                let mut unbonding_on_hold_ref_count__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::CreationHeight => {
@@ -7190,6 +7496,26 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
                             }
                             shares_dst__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::UnbondingId => {
+                            if unbonding_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("unbondingId"));
+                            }
+                            unbonding_id__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                        GeneratedField::UnbondingOnHoldRefCount => {
+                            if unbonding_on_hold_ref_count__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "unbondingOnHoldRefCount",
+                                ));
+                            }
+                            unbonding_on_hold_ref_count__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
                     }
                 }
                 Ok(RedelegationEntry {
@@ -7197,6 +7523,8 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
                     completion_time: completion_time__,
                     initial_balance: initial_balance__.unwrap_or_default(),
                     shares_dst: shares_dst__.unwrap_or_default(),
+                    unbonding_id: unbonding_id__.unwrap_or_default(),
+                    unbonding_on_hold_ref_count: unbonding_on_hold_ref_count__.unwrap_or_default(),
                 })
             }
         }
@@ -7879,6 +8207,12 @@ impl serde::Serialize for UnbondingDelegationEntry {
         if !self.balance.is_empty() {
             len += 1;
         }
+        if self.unbonding_id != 0 {
+            len += 1;
+        }
+        if self.unbonding_on_hold_ref_count != 0 {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.staking.v1beta1.UnbondingDelegationEntry", len)?;
         if self.creation_height != 0 {
@@ -7896,6 +8230,20 @@ impl serde::Serialize for UnbondingDelegationEntry {
         }
         if !self.balance.is_empty() {
             struct_ser.serialize_field("balance", &self.balance)?;
+        }
+        if self.unbonding_id != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "unbondingId",
+                ToString::to_string(&self.unbonding_id).as_str(),
+            )?;
+        }
+        if self.unbonding_on_hold_ref_count != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "unbondingOnHoldRefCount",
+                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -7915,6 +8263,10 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
             "initial_balance",
             "initialBalance",
             "balance",
+            "unbonding_id",
+            "unbondingId",
+            "unbonding_on_hold_ref_count",
+            "unbondingOnHoldRefCount",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -7923,6 +8275,8 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
             CompletionTime,
             InitialBalance,
             Balance,
+            UnbondingId,
+            UnbondingOnHoldRefCount,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -7958,6 +8312,10 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
                                 Ok(GeneratedField::InitialBalance)
                             }
                             "balance" => Ok(GeneratedField::Balance),
+                            "unbondingId" | "unbonding_id" => Ok(GeneratedField::UnbondingId),
+                            "unbondingOnHoldRefCount" | "unbonding_on_hold_ref_count" => {
+                                Ok(GeneratedField::UnbondingOnHoldRefCount)
+                            }
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -7984,6 +8342,8 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
                 let mut completion_time__ = None;
                 let mut initial_balance__ = None;
                 let mut balance__ = None;
+                let mut unbonding_id__ = None;
+                let mut unbonding_on_hold_ref_count__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::CreationHeight => {
@@ -8013,6 +8373,26 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
                             }
                             balance__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::UnbondingId => {
+                            if unbonding_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("unbondingId"));
+                            }
+                            unbonding_id__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                        GeneratedField::UnbondingOnHoldRefCount => {
+                            if unbonding_on_hold_ref_count__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "unbondingOnHoldRefCount",
+                                ));
+                            }
+                            unbonding_on_hold_ref_count__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
                     }
                 }
                 Ok(UnbondingDelegationEntry {
@@ -8020,6 +8400,8 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
                     completion_time: completion_time__,
                     initial_balance: initial_balance__.unwrap_or_default(),
                     balance: balance__.unwrap_or_default(),
+                    unbonding_id: unbonding_id__.unwrap_or_default(),
+                    unbonding_on_hold_ref_count: unbonding_on_hold_ref_count__.unwrap_or_default(),
                 })
             }
         }
@@ -8172,6 +8554,12 @@ impl serde::Serialize for Validator {
         if !self.min_self_delegation.is_empty() {
             len += 1;
         }
+        if self.unbonding_on_hold_ref_count != 0 {
+            len += 1;
+        }
+        if !self.unbonding_ids.is_empty() {
+            len += 1;
+        }
         let mut struct_ser =
             serializer.serialize_struct("cosmos.staking.v1beta1.Validator", len)?;
         if !self.operator_address.is_empty() {
@@ -8214,6 +8602,23 @@ impl serde::Serialize for Validator {
         if !self.min_self_delegation.is_empty() {
             struct_ser.serialize_field("minSelfDelegation", &self.min_self_delegation)?;
         }
+        if self.unbonding_on_hold_ref_count != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "unbondingOnHoldRefCount",
+                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+            )?;
+        }
+        if !self.unbonding_ids.is_empty() {
+            struct_ser.serialize_field(
+                "unbondingIds",
+                &self
+                    .unbonding_ids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+            )?;
+        }
         struct_ser.end()
     }
 }
@@ -8242,6 +8647,10 @@ impl<'de> serde::Deserialize<'de> for Validator {
             "commission",
             "min_self_delegation",
             "minSelfDelegation",
+            "unbonding_on_hold_ref_count",
+            "unbondingOnHoldRefCount",
+            "unbonding_ids",
+            "unbondingIds",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -8257,6 +8666,8 @@ impl<'de> serde::Deserialize<'de> for Validator {
             UnbondingTime,
             Commission,
             MinSelfDelegation,
+            UnbondingOnHoldRefCount,
+            UnbondingIds,
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -8303,6 +8714,10 @@ impl<'de> serde::Deserialize<'de> for Validator {
                             "minSelfDelegation" | "min_self_delegation" => {
                                 Ok(GeneratedField::MinSelfDelegation)
                             }
+                            "unbondingOnHoldRefCount" | "unbonding_on_hold_ref_count" => {
+                                Ok(GeneratedField::UnbondingOnHoldRefCount)
+                            }
+                            "unbondingIds" | "unbonding_ids" => Ok(GeneratedField::UnbondingIds),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -8333,6 +8748,8 @@ impl<'de> serde::Deserialize<'de> for Validator {
                 let mut unbonding_time__ = None;
                 let mut commission__ = None;
                 let mut min_self_delegation__ = None;
+                let mut unbonding_on_hold_ref_count__ = None;
+                let mut unbonding_ids__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::OperatorAddress => {
@@ -8404,6 +8821,28 @@ impl<'de> serde::Deserialize<'de> for Validator {
                             }
                             min_self_delegation__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::UnbondingOnHoldRefCount => {
+                            if unbonding_on_hold_ref_count__.is_some() {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "unbondingOnHoldRefCount",
+                                ));
+                            }
+                            unbonding_on_hold_ref_count__ = Some(
+                                map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                        GeneratedField::UnbondingIds => {
+                            if unbonding_ids__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("unbondingIds"));
+                            }
+                            unbonding_ids__ = Some(
+                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter()
+                                    .map(|x| x.0)
+                                    .collect(),
+                            );
+                        }
                     }
                 }
                 Ok(Validator {
@@ -8418,11 +8857,113 @@ impl<'de> serde::Deserialize<'de> for Validator {
                     unbonding_time: unbonding_time__,
                     commission: commission__,
                     min_self_delegation: min_self_delegation__.unwrap_or_default(),
+                    unbonding_on_hold_ref_count: unbonding_on_hold_ref_count__.unwrap_or_default(),
+                    unbonding_ids: unbonding_ids__.unwrap_or_default(),
                 })
             }
         }
         deserializer.deserialize_struct(
             "cosmos.staking.v1beta1.Validator",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for ValidatorUpdates {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.updates.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.staking.v1beta1.ValidatorUpdates", len)?;
+        if !self.updates.is_empty() {
+            struct_ser.serialize_field("updates", &self.updates)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ValidatorUpdates {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["updates"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Updates,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "updates" => Ok(GeneratedField::Updates),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ValidatorUpdates;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.staking.v1beta1.ValidatorUpdates")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ValidatorUpdates, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut updates__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Updates => {
+                            if updates__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("updates"));
+                            }
+                            updates__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(ValidatorUpdates {
+                    updates: updates__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.staking.v1beta1.ValidatorUpdates",
             FIELDS,
             GeneratedVisitor,
         )

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
@@ -1367,6 +1367,27 @@ pub mod msg_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.staking.v1beta1.Msg/UpdateParams");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.staking.v1beta1.Msg",
+                "UpdateParams",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1404,6 +1425,10 @@ pub mod msg_server {
             tonic::Response<super::MsgCancelUnbondingDelegationResponse>,
             tonic::Status,
         >;
+        async fn update_params(
+            &self,
+            request: tonic::Request<super::MsgUpdateParams>,
+        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1697,6 +1722,44 @@ pub mod msg_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CancelUnbondingDelegationSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.staking.v1beta1.Msg/UpdateParams" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateParamsSvc<T: Msg>(pub Arc<T>);
+                    impl<T: Msg> tonic::server::UnaryService<super::MsgUpdateParams> for UpdateParamsSvc<T> {
+                        type Response = super::MsgUpdateParamsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::MsgUpdateParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).update_params(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateParamsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.rs
@@ -1,0 +1,16 @@
+// @generated
+/// Config is the config object of the x/auth/tx package.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Config {
+    /// skip_ante_handler defines whether the ante handler registration should be skipped in case an app wants to override
+    /// this functionality.
+    #[prost(bool, tag = "1")]
+    pub skip_ante_handler: bool,
+    /// skip_post_handler defines whether the post handler registration should be skipped in case an app wants to override
+    /// this functionality.
+    #[prost(bool, tag = "2")]
+    pub skip_post_handler: bool,
+}
+include!("cosmos.tx.config.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.serde.rs
@@ -1,0 +1,121 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Config {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.skip_ante_handler {
+            len += 1;
+        }
+        if self.skip_post_handler {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.tx.config.v1.Config", len)?;
+        if self.skip_ante_handler {
+            struct_ser.serialize_field("skipAnteHandler", &self.skip_ante_handler)?;
+        }
+        if self.skip_post_handler {
+            struct_ser.serialize_field("skipPostHandler", &self.skip_post_handler)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Config {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "skip_ante_handler",
+            "skipAnteHandler",
+            "skip_post_handler",
+            "skipPostHandler",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SkipAnteHandler,
+            SkipPostHandler,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "skipAnteHandler" | "skip_ante_handler" => {
+                                Ok(GeneratedField::SkipAnteHandler)
+                            }
+                            "skipPostHandler" | "skip_post_handler" => {
+                                Ok(GeneratedField::SkipPostHandler)
+                            }
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Config;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.config.v1.Config")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Config, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut skip_ante_handler__ = None;
+                let mut skip_post_handler__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SkipAnteHandler => {
+                            if skip_ante_handler__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("skipAnteHandler"));
+                            }
+                            skip_ante_handler__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SkipPostHandler => {
+                            if skip_post_handler__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("skipPostHandler"));
+                            }
+                            skip_post_handler__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Config {
+                    skip_ante_handler: skip_ante_handler__.unwrap_or_default(),
+                    skip_post_handler: skip_post_handler__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.tx.config.v1.Config", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.rs
@@ -425,6 +425,90 @@ pub struct GetBlockWithTxsResponse {
     #[prost(message, optional, tag = "4")]
     pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
 }
+/// TxDecodeRequest is the request type for the Service.TxDecode
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxDecodeRequest {
+    /// tx_bytes is the raw transaction.
+    #[prost(bytes = "vec", tag = "1")]
+    pub tx_bytes: ::prost::alloc::vec::Vec<u8>,
+}
+/// TxDecodeResponse is the response type for the
+/// Service.TxDecode method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxDecodeResponse {
+    /// tx is the decoded transaction.
+    #[prost(message, optional, tag = "1")]
+    pub tx: ::core::option::Option<Tx>,
+}
+/// TxEncodeRequest is the request type for the Service.TxEncode
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxEncodeRequest {
+    /// tx is the transaction to encode.
+    #[prost(message, optional, tag = "1")]
+    pub tx: ::core::option::Option<Tx>,
+}
+/// TxEncodeResponse is the response type for the
+/// Service.TxEncode method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxEncodeResponse {
+    /// tx_bytes is the encoded transaction bytes.
+    #[prost(bytes = "vec", tag = "1")]
+    pub tx_bytes: ::prost::alloc::vec::Vec<u8>,
+}
+/// TxEncodeAminoRequest is the request type for the Service.TxEncodeAmino
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxEncodeAminoRequest {
+    #[prost(string, tag = "1")]
+    pub amino_json: ::prost::alloc::string::String,
+}
+/// TxEncodeAminoResponse is the response type for the Service.TxEncodeAmino
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxEncodeAminoResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub amino_binary: ::prost::alloc::vec::Vec<u8>,
+}
+/// TxDecodeAminoRequest is the request type for the Service.TxDecodeAmino
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxDecodeAminoRequest {
+    #[prost(bytes = "vec", tag = "1")]
+    pub amino_binary: ::prost::alloc::vec::Vec<u8>,
+}
+/// TxDecodeAminoResponse is the response type for the Service.TxDecodeAmino
+/// RPC method.
+///
+/// Since: cosmos-sdk 0.47
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxDecodeAminoResponse {
+    #[prost(string, tag = "1")]
+    pub amino_json: ::prost::alloc::string::String,
+}
 /// OrderBy defines the sorting order
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -464,8 +548,8 @@ impl OrderBy {
 pub enum BroadcastMode {
     /// zero-value for mode ordering
     Unspecified = 0,
-    /// BROADCAST_MODE_BLOCK defines a tx broadcasting mode where the client waits for
-    /// the tx to be committed in a block.
+    /// DEPRECATED: use BROADCAST_MODE_SYNC instead,
+    /// BROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.
     Block = 1,
     /// BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for
     /// a CheckTx execution response only.

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.serde.rs
@@ -3144,6 +3144,842 @@ impl<'de> serde::Deserialize<'de> for TxBody {
     }
 }
 #[cfg(feature = "serde")]
+impl serde::Serialize for TxDecodeAminoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.amino_binary.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxDecodeAminoRequest", len)?;
+        if !self.amino_binary.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "aminoBinary",
+                pbjson::private::base64::encode(&self.amino_binary).as_str(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["amino_binary", "aminoBinary"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AminoBinary,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "aminoBinary" | "amino_binary" => Ok(GeneratedField::AminoBinary),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxDecodeAminoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeAminoRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<TxDecodeAminoRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut amino_binary__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AminoBinary => {
+                            if amino_binary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("aminoBinary"));
+                            }
+                            amino_binary__ = Some(
+                                map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                    }
+                }
+                Ok(TxDecodeAminoRequest {
+                    amino_binary: amino_binary__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxDecodeAminoRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxDecodeAminoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.amino_json.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxDecodeAminoResponse", len)?;
+        if !self.amino_json.is_empty() {
+            struct_ser.serialize_field("aminoJson", &self.amino_json)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["amino_json", "aminoJson"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AminoJson,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "aminoJson" | "amino_json" => Ok(GeneratedField::AminoJson),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxDecodeAminoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeAminoResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<TxDecodeAminoResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut amino_json__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AminoJson => {
+                            if amino_json__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("aminoJson"));
+                            }
+                            amino_json__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TxDecodeAminoResponse {
+                    amino_json: amino_json__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxDecodeAminoResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxDecodeRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.tx_bytes.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxDecodeRequest", len)?;
+        if !self.tx_bytes.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "txBytes",
+                pbjson::private::base64::encode(&self.tx_bytes).as_str(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tx_bytes", "txBytes"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            TxBytes,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "txBytes" | "tx_bytes" => Ok(GeneratedField::TxBytes),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxDecodeRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxDecodeRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut tx_bytes__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::TxBytes => {
+                            if tx_bytes__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("txBytes"));
+                            }
+                            tx_bytes__ = Some(
+                                map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                    }
+                }
+                Ok(TxDecodeRequest {
+                    tx_bytes: tx_bytes__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxDecodeRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxDecodeResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.tx.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxDecodeResponse", len)?;
+        if let Some(v) = self.tx.as_ref() {
+            struct_ser.serialize_field("tx", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tx"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Tx,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "tx" => Ok(GeneratedField::Tx),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxDecodeResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxDecodeResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut tx__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Tx => {
+                            if tx__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("tx"));
+                            }
+                            tx__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(TxDecodeResponse { tx: tx__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxDecodeResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxEncodeAminoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.amino_json.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxEncodeAminoRequest", len)?;
+        if !self.amino_json.is_empty() {
+            struct_ser.serialize_field("aminoJson", &self.amino_json)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["amino_json", "aminoJson"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AminoJson,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "aminoJson" | "amino_json" => Ok(GeneratedField::AminoJson),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxEncodeAminoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeAminoRequest")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<TxEncodeAminoRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut amino_json__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AminoJson => {
+                            if amino_json__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("aminoJson"));
+                            }
+                            amino_json__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TxEncodeAminoRequest {
+                    amino_json: amino_json__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxEncodeAminoRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxEncodeAminoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.amino_binary.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxEncodeAminoResponse", len)?;
+        if !self.amino_binary.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "aminoBinary",
+                pbjson::private::base64::encode(&self.amino_binary).as_str(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["amino_binary", "aminoBinary"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AminoBinary,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "aminoBinary" | "amino_binary" => Ok(GeneratedField::AminoBinary),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxEncodeAminoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeAminoResponse")
+            }
+
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> std::result::Result<TxEncodeAminoResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut amino_binary__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AminoBinary => {
+                            if amino_binary__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("aminoBinary"));
+                            }
+                            amino_binary__ = Some(
+                                map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                    }
+                }
+                Ok(TxEncodeAminoResponse {
+                    amino_binary: amino_binary__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxEncodeAminoResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxEncodeRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.tx.is_some() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxEncodeRequest", len)?;
+        if let Some(v) = self.tx.as_ref() {
+            struct_ser.serialize_field("tx", v)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tx"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Tx,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "tx" => Ok(GeneratedField::Tx),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxEncodeRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxEncodeRequest, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut tx__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Tx => {
+                            if tx__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("tx"));
+                            }
+                            tx__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(TxEncodeRequest { tx: tx__ })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxEncodeRequest",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
+impl serde::Serialize for TxEncodeResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.tx_bytes.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser =
+            serializer.serialize_struct("cosmos.tx.v1beta1.TxEncodeResponse", len)?;
+        if !self.tx_bytes.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field(
+                "txBytes",
+                pbjson::private::base64::encode(&self.tx_bytes).as_str(),
+            )?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tx_bytes", "txBytes"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            TxBytes,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "txBytes" | "tx_bytes" => Ok(GeneratedField::TxBytes),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TxEncodeResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxEncodeResponse, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut tx_bytes__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::TxBytes => {
+                            if tx_bytes__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("txBytes"));
+                            }
+                            tx_bytes__ = Some(
+                                map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?
+                                    .0,
+                            );
+                        }
+                    }
+                }
+                Ok(TxEncodeResponse {
+                    tx_bytes: tx_bytes__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct(
+            "cosmos.tx.v1beta1.TxEncodeResponse",
+            FIELDS,
+            GeneratedVisitor,
+        )
+    }
+}
+#[cfg(feature = "serde")]
 impl serde::Serialize for TxRaw {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
@@ -178,6 +178,82 @@ pub mod service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn tx_decode(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TxDecodeRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.tx.v1beta1.Service/TxDecode");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.tx.v1beta1.Service", "TxDecode"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn tx_encode(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TxEncodeRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cosmos.tx.v1beta1.Service/TxEncode");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("cosmos.tx.v1beta1.Service", "TxEncode"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn tx_encode_amino(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TxEncodeAminoRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.tx.v1beta1.Service/TxEncodeAmino");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.tx.v1beta1.Service",
+                "TxEncodeAmino",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn tx_decode_amino(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TxDecodeAminoRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/cosmos.tx.v1beta1.Service/TxDecodeAmino");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cosmos.tx.v1beta1.Service",
+                "TxDecodeAmino",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -208,6 +284,22 @@ pub mod service_server {
             &self,
             request: tonic::Request<super::GetBlockWithTxsRequest>,
         ) -> std::result::Result<tonic::Response<super::GetBlockWithTxsResponse>, tonic::Status>;
+        async fn tx_decode(
+            &self,
+            request: tonic::Request<super::TxDecodeRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status>;
+        async fn tx_encode(
+            &self,
+            request: tonic::Request<super::TxEncodeRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status>;
+        async fn tx_encode_amino(
+            &self,
+            request: tonic::Request<super::TxEncodeAminoRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>;
+        async fn tx_decode_amino(
+            &self,
+            request: tonic::Request<super::TxDecodeAminoRequest>,
+        ) -> std::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
@@ -462,6 +554,158 @@ pub mod service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetBlockWithTxsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.tx.v1beta1.Service/TxDecode" => {
+                    #[allow(non_camel_case_types)]
+                    struct TxDecodeSvc<T: Service>(pub Arc<T>);
+                    impl<T: Service> tonic::server::UnaryService<super::TxDecodeRequest> for TxDecodeSvc<T> {
+                        type Response = super::TxDecodeResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TxDecodeRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).tx_decode(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = TxDecodeSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.tx.v1beta1.Service/TxEncode" => {
+                    #[allow(non_camel_case_types)]
+                    struct TxEncodeSvc<T: Service>(pub Arc<T>);
+                    impl<T: Service> tonic::server::UnaryService<super::TxEncodeRequest> for TxEncodeSvc<T> {
+                        type Response = super::TxEncodeResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TxEncodeRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).tx_encode(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = TxEncodeSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.tx.v1beta1.Service/TxEncodeAmino" => {
+                    #[allow(non_camel_case_types)]
+                    struct TxEncodeAminoSvc<T: Service>(pub Arc<T>);
+                    impl<T: Service> tonic::server::UnaryService<super::TxEncodeAminoRequest> for TxEncodeAminoSvc<T> {
+                        type Response = super::TxEncodeAminoResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TxEncodeAminoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).tx_encode_amino(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = TxEncodeAminoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cosmos.tx.v1beta1.Service/TxDecodeAmino" => {
+                    #[allow(non_camel_case_types)]
+                    struct TxDecodeAminoSvc<T: Service>(pub Arc<T>);
+                    impl<T: Service> tonic::server::UnaryService<super::TxDecodeAminoRequest> for TxDecodeAminoSvc<T> {
+                        type Response = super::TxDecodeAminoResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TxDecodeAminoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).tx_decode_amino(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = TxDecodeAminoSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.rs
@@ -1,0 +1,11 @@
+// @generated
+/// Module is the config object of the upgrade module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {
+    /// authority defines the custom module authority. If not set, defaults to the governance module.
+    #[prost(string, tag = "1")]
+    pub authority: ::prost::alloc::string::String,
+}
+include!("cosmos.upgrade.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.serde.rs
@@ -1,0 +1,96 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.authority.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("cosmos.upgrade.module.v1.Module", len)?;
+        if !self.authority.is_empty() {
+            struct_ser.serialize_field("authority", &self.authority)?;
+        }
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["authority"];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Authority,
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "authority" => Ok(GeneratedField::Authority),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.upgrade.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut authority__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Authority => {
+                            if authority__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("authority"));
+                            }
+                            authority__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Module {
+                    authority: authority__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("cosmos.upgrade.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.rs
@@ -19,7 +19,6 @@ pub struct Plan {
     #[prost(message, optional, tag = "2")]
     pub time: ::core::option::Option<::tendermint_proto::google::protobuf::Timestamp>,
     /// The height at which the upgrade must be performed.
-    /// Only used if Time is not set.
     #[prost(int64, tag = "3")]
     pub height: i64,
     /// Any application specific upgrade info to be included on-chain
@@ -40,10 +39,13 @@ pub struct Plan {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SoftwareUpgradeProposal {
+    /// title of the proposal
     #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
+    /// description of the proposal
     #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
+    /// plan of the proposal
     #[prost(message, optional, tag = "3")]
     pub plan: ::core::option::Option<Plan>,
 }
@@ -54,8 +56,10 @@ pub struct SoftwareUpgradeProposal {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelSoftwareUpgradeProposal {
+    /// title of the proposal
     #[prost(string, tag = "1")]
     pub title: ::prost::alloc::string::String,
+    /// description of the proposal
     #[prost(string, tag = "2")]
     pub description: ::prost::alloc::string::String,
 }
@@ -168,7 +172,7 @@ pub struct QueryAuthorityResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgSoftwareUpgrade {
-    /// authority is the address of the governance account.
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
     #[prost(string, tag = "1")]
     pub authority: ::prost::alloc::string::String,
     /// plan is the upgrade plan.
@@ -187,7 +191,7 @@ pub struct MsgSoftwareUpgradeResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCancelUpgrade {
-    /// authority is the address of the governance account.
+    /// authority is the address that controls the module (defaults to x/gov unless overwritten).
     #[prost(string, tag = "1")]
     pub authority: ::prost::alloc::string::String,
 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.rs
@@ -1,0 +1,7 @@
+// @generated
+/// Module is the config object of the vesting module.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Module {}
+include!("cosmos.vesting.module.v1.serde.rs");
+// @@protoc_insertion_point(module)

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.serde.rs
@@ -1,0 +1,75 @@
+// @generated
+#[cfg(feature = "serde")]
+impl serde::Serialize for Module {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("cosmos.vesting.module.v1.Module", len)?;
+        struct_ser.end()
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Module {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {}
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Module;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct cosmos.vesting.module.v1.Module")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(Module {})
+            }
+        }
+        deserializer.deserialize_struct("cosmos.vesting.module.v1.Module", FIELDS, GeneratedVisitor)
+    }
+}

--- a/cosmrs/src/staking/validator.rs
+++ b/cosmrs/src/staking/validator.rs
@@ -38,11 +38,18 @@ pub struct Validator {
     /// unbonding_height defines, if unbonding, the height at which this validator has begun unbonding.
     pub unbonding_height: i64,
 
+    /// list of unbonding ids, each uniquely identifing an unbonding of this validator
+    pub unbonding_ids: Vec<u64>,
+
+    /// strictly positive if this validator's unbonding has been stopped by external modules
+    pub unbonding_on_hold_ref_count: i64,
+
     /// unbonding_time defines, if unbonding, the min time for the validator to complete unbonding.
     pub unbonding_time: Option<Time>,
 
     /// commission defines the commission parameters.
     pub commission: Option<Commission>,
+
     /// min_self_delegation is the validator's self declared minimum self delegation.
     ///
     /// Since: cosmos-sdk 0.46
@@ -62,6 +69,8 @@ impl TryFrom<proto::cosmos::staking::v1beta1::Validator> for Validator {
             delegator_shares: proto.delegator_shares,
             description: proto.description.map(Into::into),
             unbonding_height: proto.unbonding_height,
+            unbonding_ids: proto.unbonding_ids,
+            unbonding_on_hold_ref_count: proto.unbonding_on_hold_ref_count,
             unbonding_time: proto
                 .unbonding_time
                 .map(|jailed_until| {
@@ -89,6 +98,8 @@ impl From<Validator> for proto::cosmos::staking::v1beta1::Validator {
             delegator_shares: validator.delegator_shares,
             description: validator.description.map(Into::into),
             unbonding_height: validator.unbonding_height,
+            unbonding_ids: validator.unbonding_ids,
+            unbonding_on_hold_ref_count: validator.unbonding_on_hold_ref_count,
             unbonding_time: validator
                 .unbonding_time
                 .map(cosmos_sdk_proto::tendermint::google::protobuf::Timestamp::from)


### PR DESCRIPTION
The submodule wasn't properly updated in #485

Also adds support for the `unbonding_ids` and `unbonding_on_hold_ref_count` fields of `message Validator`.