### PR TITLE
cosmos-sdk-proto v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.24.0-pre"
+version = "0.24.0"
 dependencies = [
  "informalsystems-pbjson",
  "prost",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.0 (2024-08-14)
+### Added
+- `serde` feature for Protobuf JSON using `informalsystems/pbjson` ([#471])
+
+### Changed
+- Bump `tendermint-proto` to v0.39 ([#482])
+- Use `google.protobuf` types from `tendermint-proto` ([#482])
+- cosmos-sdk-go: bump to v0.50.9 ([#488])
+- wasmd: bump to v0.52.0 ([#489])
+- Use buf's `enable_type_names` feature ([#490])
+- proto-build: use `buf` to process ibc-go protos ([#491])
+- ibc-go: bump to v8.4.0 ([#492])
+
+[#471]: https://github.com/cosmos/cosmos-rust/pull/471
+[#482]: https://github.com/cosmos/cosmos-rust/pull/482
+[#488]: https://github.com/cosmos/cosmos-rust/pull/488
+[#489]: https://github.com/cosmos/cosmos-rust/pull/489
+[#490]: https://github.com/cosmos/cosmos-rust/pull/490
+[#491]: https://github.com/cosmos/cosmos-rust/pull/491
+[#492]: https://github.com/cosmos/cosmos-rust/pull/492
+
 ## 0.23.0 (2024-08-02)
 ### Added
 - Support for `no_std` ([#478])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.24.0-pre"
+version = "0.24.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.24.0-pre", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Added
- `serde` feature for Protobuf JSON using `informalsystems/pbjson` ([#471])

### Changed
- Bump `tendermint-proto` to v0.39 ([#482])
- Use `google.protobuf` types from `tendermint-proto` ([#482])
- cosmos-sdk-go: bump to v0.50.9 ([#488])
- wasmd: bump to v0.52.0 ([#489])
- Use buf's `enable_type_names` feature ([#490])
- proto-build: use `buf` to process ibc-go protos ([#491])
- ibc-go: bump to v8.4.0 ([#492])

[#471]: https://github.com/cosmos/cosmos-rust/pull/471
[#482]: https://github.com/cosmos/cosmos-rust/pull/482
[#488]: https://github.com/cosmos/cosmos-rust/pull/488
[#489]: https://github.com/cosmos/cosmos-rust/pull/489
[#490]: https://github.com/cosmos/cosmos-rust/pull/490
[#491]: https://github.com/cosmos/cosmos-rust/pull/491
[#492]: https://github.com/cosmos/cosmos-rust/pull/492