### PR TITLE
cosmrs v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.19.0-pre"
+version = "0.19.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.0 (2024-08-14)
+### Changed
+- Bump tendermint-rs dependencies to v0.39 ([#482], [#483])
+- Bump `cosmos-sdk-proto` to v0.24 ([#493])
+
+[#482]: https://github.com/cosmos/cosmos-rust/pull/482
+[#483]: https://github.com/cosmos/cosmos-rust/pull/483
+[#493]: https://github.com/cosmos/cosmos-rust/pull/493
+
 ## 0.18.0 (2024-08-02)
 ### Added
 - Support `Coin` with amount `0` and empty denom ([#479])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.19.0-pre"
+version = "0.19.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump tendermint-rs dependencies to v0.39 ([#482], [#483])
- Bump `cosmos-sdk-proto` to v0.24 ([#493])

[#482]: https://github.com/cosmos/cosmos-rust/pull/482
[#483]: https://github.com/cosmos/cosmos-rust/pull/483
[#493]: https://github.com/cosmos/cosmos-rust/pull/493