### PR TITLE
cosmos-sdk-proto v0.25.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.24.0"
+version = "0.25.0-pre.0"
 dependencies = [
  "ics23",
  "informalsystems-pbjson",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.19.0"
+version = "0.20.0-pre"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.0-pre.0 (prerelease)
+### Changed
+- Re-export ICS23 proto definitions from the `ics23` crate ([#495])
+- Use tendermint proto from `tendermint_proto` instead of `tendermint_proto::v0_34` ([#495])
+
+### Removed
+- IBC protos; use `ibc-proto` crate instead ([#495])
+
+[#495]: https://github.com/cosmos/cosmos-rust/pull/495
+
 ## 0.24.0 (2024-08-14)
 ### Added
 - `serde` feature for Protobuf JSON using `informalsystems/pbjson` ([#471])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.24.0"
+version = "0.25.0-pre.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.19.0"
+version = "0.20.0-pre"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "=0.25.0-pre.0", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Re-export ICS23 proto definitions from the `ics23` crate ([#495])
- Use tendermint proto from `tendermint_proto` instead of `tendermint_proto::v0_34` ([#495])

### Removed
- IBC protos; use `ibc-proto` crate instead ([#495])

[#495]: https://github.com/cosmos/cosmos-rust/pull/495

cc @romac