### PR TITLE
cosmos-sdk-proto: fix `no_std` + `serde`

### DIFF
--- a/.github/workflows/cosmos-sdk-proto.yml
+++ b/.github/workflows/cosmos-sdk-proto.yml
@@ -35,6 +35,7 @@ jobs:
           target: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features grpc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
 
   test:
     runs-on: ubuntu-latest
@@ -49,3 +50,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo test --release
+      - run: cargo test --all-features --release

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.runtime.v1alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -70,7 +70,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -108,7 +108,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -119,13 +119,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -156,11 +156,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.runtime.v1alpha1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -256,7 +256,7 @@ impl<'de> serde::Deserialize<'de> for Module {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreKeyConfig {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -282,7 +282,7 @@ impl serde::Serialize for StoreKeyConfig {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreKeyConfig {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -295,7 +295,7 @@ impl<'de> serde::Deserialize<'de> for StoreKeyConfig {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -306,13 +306,13 @@ impl<'de> serde::Deserialize<'de> for StoreKeyConfig {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -330,11 +330,11 @@ impl<'de> serde::Deserialize<'de> for StoreKeyConfig {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreKeyConfig;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.runtime.v1alpha1.StoreKeyConfig")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StoreKeyConfig, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StoreKeyConfig, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Config {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Config {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Config {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Config {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Config {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -77,11 +77,11 @@ impl<'de> serde::Deserialize<'de> for Config {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Config;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.Config")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Config, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Config, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -115,7 +115,7 @@ impl<'de> serde::Deserialize<'de> for Config {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GolangBinding {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -141,7 +141,7 @@ impl serde::Serialize for GolangBinding {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GolangBinding {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -154,7 +154,7 @@ impl<'de> serde::Deserialize<'de> for GolangBinding {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -165,13 +165,13 @@ impl<'de> serde::Deserialize<'de> for GolangBinding {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -189,11 +189,11 @@ impl<'de> serde::Deserialize<'de> for GolangBinding {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GolangBinding;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.GolangBinding")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GolangBinding, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GolangBinding, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -231,7 +231,7 @@ impl<'de> serde::Deserialize<'de> for GolangBinding {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MigrateFromInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -251,7 +251,7 @@ impl serde::Serialize for MigrateFromInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MigrateFromInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -263,7 +263,7 @@ impl<'de> serde::Deserialize<'de> for MigrateFromInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -274,13 +274,13 @@ impl<'de> serde::Deserialize<'de> for MigrateFromInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -297,11 +297,11 @@ impl<'de> serde::Deserialize<'de> for MigrateFromInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MigrateFromInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.MigrateFromInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MigrateFromInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MigrateFromInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -331,7 +331,7 @@ impl<'de> serde::Deserialize<'de> for MigrateFromInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleConfig {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -363,7 +363,7 @@ impl serde::Serialize for ModuleConfig {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleConfig {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -377,7 +377,7 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -388,13 +388,13 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -415,11 +415,11 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleConfig;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.ModuleConfig")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleConfig, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleConfig, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -465,7 +465,7 @@ impl<'de> serde::Deserialize<'de> for ModuleConfig {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -497,7 +497,7 @@ impl serde::Serialize for ModuleDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -518,7 +518,7 @@ impl<'de> serde::Deserialize<'de> for ModuleDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -529,13 +529,13 @@ impl<'de> serde::Deserialize<'de> for ModuleDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -556,11 +556,11 @@ impl<'de> serde::Deserialize<'de> for ModuleDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.ModuleDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -606,7 +606,7 @@ impl<'de> serde::Deserialize<'de> for ModuleDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PackageReference {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -632,7 +632,7 @@ impl serde::Serialize for PackageReference {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PackageReference {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -645,7 +645,7 @@ impl<'de> serde::Deserialize<'de> for PackageReference {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -656,13 +656,13 @@ impl<'de> serde::Deserialize<'de> for PackageReference {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -680,11 +680,11 @@ impl<'de> serde::Deserialize<'de> for PackageReference {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PackageReference;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.PackageReference")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PackageReference, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PackageReference, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -725,7 +725,7 @@ impl<'de> serde::Deserialize<'de> for PackageReference {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryConfigRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -739,7 +739,7 @@ impl serde::Serialize for QueryConfigRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryConfigRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -749,7 +749,7 @@ impl<'de> serde::Deserialize<'de> for QueryConfigRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -760,13 +760,13 @@ impl<'de> serde::Deserialize<'de> for QueryConfigRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -780,11 +780,11 @@ impl<'de> serde::Deserialize<'de> for QueryConfigRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryConfigRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.QueryConfigRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryConfigRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryConfigRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -804,7 +804,7 @@ impl<'de> serde::Deserialize<'de> for QueryConfigRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryConfigResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -824,7 +824,7 @@ impl serde::Serialize for QueryConfigResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryConfigResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -836,7 +836,7 @@ impl<'de> serde::Deserialize<'de> for QueryConfigResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -847,13 +847,13 @@ impl<'de> serde::Deserialize<'de> for QueryConfigResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -870,11 +870,14 @@ impl<'de> serde::Deserialize<'de> for QueryConfigResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryConfigResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.app.v1alpha1.QueryConfigResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryConfigResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryConfigResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.app.v1alpha1.tonic.rs
@@ -92,12 +92,12 @@ pub mod query_client {
         pub async fn config(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConfigRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryConfigResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryConfigResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -122,7 +122,7 @@ pub mod query_server {
         async fn config(
             &self,
             request: tonic::Request<super::QueryConfigRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryConfigResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryConfigResponse>, tonic::Status>;
     }
     /** Query is the app module query service.
     */
@@ -196,7 +196,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -268,8 +268,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -54,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -65,13 +65,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -92,11 +92,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -140,7 +140,7 @@ impl<'de> serde::Deserialize<'de> for Module {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleAccountPermission {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -166,7 +166,7 @@ impl serde::Serialize for ModuleAccountPermission {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleAccountPermission {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -179,7 +179,7 @@ impl<'de> serde::Deserialize<'de> for ModuleAccountPermission {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -190,13 +190,13 @@ impl<'de> serde::Deserialize<'de> for ModuleAccountPermission {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -214,14 +214,14 @@ impl<'de> serde::Deserialize<'de> for ModuleAccountPermission {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleAccountPermission;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.module.v1.ModuleAccountPermission")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ModuleAccountPermission, V::Error>
+            ) -> core::result::Result<ModuleAccountPermission, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AddressBytesToStringRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -26,7 +26,7 @@ impl serde::Serialize for AddressBytesToStringRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AddressBytesToStringRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -38,7 +38,7 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -49,13 +49,13 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -72,14 +72,14 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AddressBytesToStringRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.AddressBytesToStringRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AddressBytesToStringRequest, V::Error>
+            ) -> core::result::Result<AddressBytesToStringRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -112,7 +112,7 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AddressBytesToStringResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -132,7 +132,7 @@ impl serde::Serialize for AddressBytesToStringResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AddressBytesToStringResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -144,7 +144,7 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -155,13 +155,13 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -178,14 +178,14 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AddressBytesToStringResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.AddressBytesToStringResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AddressBytesToStringResponse, V::Error>
+            ) -> core::result::Result<AddressBytesToStringResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -215,7 +215,7 @@ impl<'de> serde::Deserialize<'de> for AddressBytesToStringResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AddressStringToBytesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -235,7 +235,7 @@ impl serde::Serialize for AddressStringToBytesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AddressStringToBytesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -247,7 +247,7 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -258,13 +258,13 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -281,14 +281,14 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AddressStringToBytesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.AddressStringToBytesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AddressStringToBytesRequest, V::Error>
+            ) -> core::result::Result<AddressStringToBytesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -318,7 +318,7 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AddressStringToBytesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -342,7 +342,7 @@ impl serde::Serialize for AddressStringToBytesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AddressStringToBytesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -354,7 +354,7 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -365,13 +365,13 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -388,14 +388,14 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AddressStringToBytesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.AddressStringToBytesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AddressStringToBytesResponse, V::Error>
+            ) -> core::result::Result<AddressStringToBytesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -428,7 +428,7 @@ impl<'de> serde::Deserialize<'de> for AddressStringToBytesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BaseAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -457,12 +457,15 @@ impl serde::Serialize for BaseAccount {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "accountNumber",
-                ToString::to_string(&self.account_number).as_str(),
+                alloc::string::ToString::to_string(&self.account_number).as_str(),
             )?;
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequence", ToString::to_string(&self.sequence).as_str())?;
+            struct_ser.serialize_field(
+                "sequence",
+                alloc::string::ToString::to_string(&self.sequence).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -470,7 +473,7 @@ impl serde::Serialize for BaseAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BaseAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -492,7 +495,7 @@ impl<'de> serde::Deserialize<'de> for BaseAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -503,13 +506,13 @@ impl<'de> serde::Deserialize<'de> for BaseAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -529,11 +532,11 @@ impl<'de> serde::Deserialize<'de> for BaseAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BaseAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.BaseAccount")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BaseAccount, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<BaseAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -589,7 +592,7 @@ impl<'de> serde::Deserialize<'de> for BaseAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Bech32PrefixRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -603,7 +606,7 @@ impl serde::Serialize for Bech32PrefixRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Bech32PrefixRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -613,7 +616,7 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -624,13 +627,13 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -644,11 +647,14 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Bech32PrefixRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.Bech32PrefixRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Bech32PrefixRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<Bech32PrefixRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -668,7 +674,7 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Bech32PrefixResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -688,7 +694,7 @@ impl serde::Serialize for Bech32PrefixResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Bech32PrefixResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -700,7 +706,7 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -711,13 +717,13 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -734,14 +740,14 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Bech32PrefixResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.Bech32PrefixResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<Bech32PrefixResponse, V::Error>
+            ) -> core::result::Result<Bech32PrefixResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -771,7 +777,7 @@ impl<'de> serde::Deserialize<'de> for Bech32PrefixResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -797,7 +803,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -810,7 +816,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -821,13 +827,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -845,11 +851,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -887,7 +893,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -919,7 +925,7 @@ impl serde::Serialize for ModuleAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -933,7 +939,7 @@ impl<'de> serde::Deserialize<'de> for ModuleAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -944,13 +950,13 @@ impl<'de> serde::Deserialize<'de> for ModuleAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -969,11 +975,11 @@ impl<'de> serde::Deserialize<'de> for ModuleAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.ModuleAccount")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleAccount, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1019,7 +1025,7 @@ impl<'de> serde::Deserialize<'de> for ModuleAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleCredential {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1043,7 +1049,7 @@ impl serde::Serialize for ModuleCredential {
                     .derivation_keys
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -1052,7 +1058,7 @@ impl serde::Serialize for ModuleCredential {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleCredential {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1070,7 +1076,7 @@ impl<'de> serde::Deserialize<'de> for ModuleCredential {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1081,13 +1087,13 @@ impl<'de> serde::Deserialize<'de> for ModuleCredential {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1107,11 +1113,11 @@ impl<'de> serde::Deserialize<'de> for ModuleCredential {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleCredential;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.ModuleCredential")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleCredential, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleCredential, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1129,12 +1135,10 @@ impl<'de> serde::Deserialize<'de> for ModuleCredential {
                             if derivation_keys__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("derivationKeys"));
                             }
-                            derivation_keys__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            derivation_keys__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -1154,7 +1158,7 @@ impl<'de> serde::Deserialize<'de> for ModuleCredential {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1180,7 +1184,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1193,7 +1197,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1204,13 +1208,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1228,11 +1232,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1270,7 +1274,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1284,7 +1288,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1294,7 +1298,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1305,13 +1309,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1325,14 +1329,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1352,7 +1356,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1378,35 +1382,35 @@ impl serde::Serialize for Params {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "maxMemoCharacters",
-                ToString::to_string(&self.max_memo_characters).as_str(),
+                alloc::string::ToString::to_string(&self.max_memo_characters).as_str(),
             )?;
         }
         if self.tx_sig_limit != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "txSigLimit",
-                ToString::to_string(&self.tx_sig_limit).as_str(),
+                alloc::string::ToString::to_string(&self.tx_sig_limit).as_str(),
             )?;
         }
         if self.tx_size_cost_per_byte != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "txSizeCostPerByte",
-                ToString::to_string(&self.tx_size_cost_per_byte).as_str(),
+                alloc::string::ToString::to_string(&self.tx_size_cost_per_byte).as_str(),
             )?;
         }
         if self.sig_verify_cost_ed25519 != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "sigVerifyCostEd25519",
-                ToString::to_string(&self.sig_verify_cost_ed25519).as_str(),
+                alloc::string::ToString::to_string(&self.sig_verify_cost_ed25519).as_str(),
             )?;
         }
         if self.sig_verify_cost_secp256k1 != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "sigVerifyCostSecp256k1",
-                ToString::to_string(&self.sig_verify_cost_secp256k1).as_str(),
+                alloc::string::ToString::to_string(&self.sig_verify_cost_secp256k1).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1415,7 +1419,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1442,7 +1446,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1453,13 +1457,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1488,11 +1492,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1569,7 +1573,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountAddressByIdRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1585,12 +1589,15 @@ impl serde::Serialize for QueryAccountAddressByIdRequest {
             .serialize_struct("cosmos.auth.v1beta1.QueryAccountAddressByIDRequest", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("id", ToString::to_string(&self.id).as_str())?;
+            struct_ser
+                .serialize_field("id", alloc::string::ToString::to_string(&self.id).as_str())?;
         }
         if self.account_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("accountId", ToString::to_string(&self.account_id).as_str())?;
+            struct_ser.serialize_field(
+                "accountId",
+                alloc::string::ToString::to_string(&self.account_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -1598,7 +1605,7 @@ impl serde::Serialize for QueryAccountAddressByIdRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1611,7 +1618,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1622,13 +1629,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1646,14 +1653,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountAddressByIdRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountAddressByIDRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountAddressByIdRequest, V::Error>
+            ) -> core::result::Result<QueryAccountAddressByIdRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1697,7 +1704,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountAddressByIdResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1717,7 +1724,7 @@ impl serde::Serialize for QueryAccountAddressByIdResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1729,7 +1736,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1740,13 +1747,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1765,14 +1772,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountAddressByIdResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountAddressByIDResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountAddressByIdResponse, V::Error>
+            ) -> core::result::Result<QueryAccountAddressByIdResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1802,7 +1809,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountAddressByIdResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1822,7 +1829,7 @@ impl serde::Serialize for QueryAccountInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1834,7 +1841,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1845,13 +1852,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1868,14 +1875,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountInfoRequest, V::Error>
+            ) -> core::result::Result<QueryAccountInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1905,7 +1912,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1925,7 +1932,7 @@ impl serde::Serialize for QueryAccountInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1937,7 +1944,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1948,13 +1955,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1971,14 +1978,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountInfoResponse, V::Error>
+            ) -> core::result::Result<QueryAccountInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2006,7 +2013,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2026,7 +2033,7 @@ impl serde::Serialize for QueryAccountRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2038,7 +2045,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2049,13 +2056,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2072,11 +2079,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryAccountRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryAccountRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2106,7 +2116,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2126,7 +2136,7 @@ impl serde::Serialize for QueryAccountResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2138,7 +2148,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2149,13 +2159,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2172,14 +2182,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountResponse, V::Error>
+            ) -> core::result::Result<QueryAccountResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2207,7 +2217,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2227,7 +2237,7 @@ impl serde::Serialize for QueryAccountsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2239,7 +2249,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2250,13 +2260,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2273,14 +2283,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountsRequest, V::Error>
+            ) -> core::result::Result<QueryAccountsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2310,7 +2320,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2336,7 +2346,7 @@ impl serde::Serialize for QueryAccountsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2349,7 +2359,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2360,13 +2370,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2384,14 +2394,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryAccountsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountsResponse, V::Error>
+            ) -> core::result::Result<QueryAccountsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2429,7 +2439,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleAccountByNameRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2449,7 +2459,7 @@ impl serde::Serialize for QueryModuleAccountByNameRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2461,7 +2471,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2472,13 +2482,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2495,14 +2505,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleAccountByNameRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryModuleAccountByNameRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleAccountByNameRequest, V::Error>
+            ) -> core::result::Result<QueryModuleAccountByNameRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2532,7 +2542,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleAccountByNameResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2552,7 +2562,7 @@ impl serde::Serialize for QueryModuleAccountByNameResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2564,7 +2574,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2575,13 +2585,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2598,14 +2608,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleAccountByNameResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryModuleAccountByNameResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleAccountByNameResponse, V::Error>
+            ) -> core::result::Result<QueryModuleAccountByNameResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2633,7 +2643,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountByNameResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleAccountsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2647,7 +2657,7 @@ impl serde::Serialize for QueryModuleAccountsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleAccountsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2657,7 +2667,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2668,13 +2678,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2688,14 +2698,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleAccountsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryModuleAccountsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleAccountsRequest, V::Error>
+            ) -> core::result::Result<QueryModuleAccountsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2715,7 +2725,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleAccountsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2735,7 +2745,7 @@ impl serde::Serialize for QueryModuleAccountsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleAccountsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2747,7 +2757,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2758,13 +2768,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2781,14 +2791,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleAccountsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryModuleAccountsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleAccountsResponse, V::Error>
+            ) -> core::result::Result<QueryModuleAccountsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2818,7 +2828,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleAccountsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2832,7 +2842,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2842,7 +2852,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2853,13 +2863,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2873,11 +2883,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2897,7 +2907,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2917,7 +2927,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2929,7 +2939,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2940,13 +2950,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2963,11 +2973,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.auth.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.auth.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAccountsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn account(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAccountResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -124,14 +124,14 @@ pub mod query_client {
         pub async fn account_address_by_id(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountAddressByIdRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryAccountAddressByIdResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -148,12 +148,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -166,12 +166,12 @@ pub mod query_client {
         pub async fn module_accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryModuleAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryModuleAccountsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryModuleAccountsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -187,14 +187,14 @@ pub mod query_client {
         pub async fn module_account_by_name(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryModuleAccountByNameRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryModuleAccountByNameResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -211,12 +211,12 @@ pub mod query_client {
         pub async fn bech32_prefix(
             &mut self,
             request: impl tonic::IntoRequest<super::Bech32PrefixRequest>,
-        ) -> std::result::Result<tonic::Response<super::Bech32PrefixResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::Bech32PrefixResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -230,12 +230,12 @@ pub mod query_client {
         pub async fn address_bytes_to_string(
             &mut self,
             request: impl tonic::IntoRequest<super::AddressBytesToStringRequest>,
-        ) -> std::result::Result<tonic::Response<super::AddressBytesToStringResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::AddressBytesToStringResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -252,12 +252,12 @@ pub mod query_client {
         pub async fn address_string_to_bytes(
             &mut self,
             request: impl tonic::IntoRequest<super::AddressStringToBytesRequest>,
-        ) -> std::result::Result<tonic::Response<super::AddressStringToBytesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::AddressStringToBytesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -274,12 +274,12 @@ pub mod query_client {
         pub async fn account_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -303,49 +303,49 @@ pub mod query_server {
         async fn accounts(
             &self,
             request: tonic::Request<super::QueryAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAccountsResponse>, tonic::Status>;
         async fn account(
             &self,
             request: tonic::Request<super::QueryAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAccountResponse>, tonic::Status>;
         async fn account_address_by_id(
             &self,
             request: tonic::Request<super::QueryAccountAddressByIdRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryAccountAddressByIdResponse>,
             tonic::Status,
         >;
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn module_accounts(
             &self,
             request: tonic::Request<super::QueryModuleAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryModuleAccountsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryModuleAccountsResponse>, tonic::Status>;
         async fn module_account_by_name(
             &self,
             request: tonic::Request<super::QueryModuleAccountByNameRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryModuleAccountByNameResponse>,
             tonic::Status,
         >;
         async fn bech32_prefix(
             &self,
             request: tonic::Request<super::Bech32PrefixRequest>,
-        ) -> std::result::Result<tonic::Response<super::Bech32PrefixResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::Bech32PrefixResponse>, tonic::Status>;
         async fn address_bytes_to_string(
             &self,
             request: tonic::Request<super::AddressBytesToStringRequest>,
-        ) -> std::result::Result<tonic::Response<super::AddressBytesToStringResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AddressBytesToStringResponse>, tonic::Status>;
         async fn address_string_to_bytes(
             &self,
             request: tonic::Request<super::AddressStringToBytesRequest>,
-        ) -> std::result::Result<tonic::Response<super::AddressStringToBytesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AddressStringToBytesResponse>, tonic::Status>;
         async fn account_info(
             &self,
             request: tonic::Request<super::QueryAccountInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAccountInfoResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -417,7 +417,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -845,8 +845,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -940,12 +940,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -969,7 +969,7 @@ pub mod msg_server {
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1041,7 +1041,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1113,8 +1113,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventGrant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -33,7 +33,7 @@ impl serde::Serialize for EventGrant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventGrant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -47,7 +47,7 @@ impl<'de> serde::Deserialize<'de> for EventGrant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -58,13 +58,13 @@ impl<'de> serde::Deserialize<'de> for EventGrant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -83,11 +83,11 @@ impl<'de> serde::Deserialize<'de> for EventGrant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventGrant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.EventGrant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventGrant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventGrant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -129,7 +129,7 @@ impl<'de> serde::Deserialize<'de> for EventGrant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventRevoke {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -161,7 +161,7 @@ impl serde::Serialize for EventRevoke {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventRevoke {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -175,7 +175,7 @@ impl<'de> serde::Deserialize<'de> for EventRevoke {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -186,13 +186,13 @@ impl<'de> serde::Deserialize<'de> for EventRevoke {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -211,11 +211,11 @@ impl<'de> serde::Deserialize<'de> for EventRevoke {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventRevoke;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.EventRevoke")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventRevoke, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventRevoke, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -261,7 +261,7 @@ impl<'de> serde::Deserialize<'de> for EventRevoke {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenericAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -281,7 +281,7 @@ impl serde::Serialize for GenericAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenericAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -293,7 +293,7 @@ impl<'de> serde::Deserialize<'de> for GenericAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -304,13 +304,13 @@ impl<'de> serde::Deserialize<'de> for GenericAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -327,14 +327,14 @@ impl<'de> serde::Deserialize<'de> for GenericAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenericAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.GenericAuthorization")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GenericAuthorization, V::Error>
+            ) -> core::result::Result<GenericAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -364,7 +364,7 @@ impl<'de> serde::Deserialize<'de> for GenericAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -384,7 +384,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -396,7 +396,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -407,13 +407,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -430,11 +430,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -464,7 +464,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Grant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -489,7 +489,7 @@ impl serde::Serialize for Grant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Grant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -502,7 +502,7 @@ impl<'de> serde::Deserialize<'de> for Grant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -513,13 +513,13 @@ impl<'de> serde::Deserialize<'de> for Grant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -537,11 +537,11 @@ impl<'de> serde::Deserialize<'de> for Grant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Grant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.Grant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Grant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Grant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -575,7 +575,7 @@ impl<'de> serde::Deserialize<'de> for Grant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GrantAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -613,7 +613,7 @@ impl serde::Serialize for GrantAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GrantAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -628,7 +628,7 @@ impl<'de> serde::Deserialize<'de> for GrantAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -639,13 +639,13 @@ impl<'de> serde::Deserialize<'de> for GrantAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -665,11 +665,11 @@ impl<'de> serde::Deserialize<'de> for GrantAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GrantAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.GrantAuthorization")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GrantAuthorization, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GrantAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -723,7 +723,7 @@ impl<'de> serde::Deserialize<'de> for GrantAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GrantQueueItem {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -743,7 +743,7 @@ impl serde::Serialize for GrantQueueItem {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GrantQueueItem {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -755,7 +755,7 @@ impl<'de> serde::Deserialize<'de> for GrantQueueItem {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -766,13 +766,13 @@ impl<'de> serde::Deserialize<'de> for GrantQueueItem {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -789,11 +789,11 @@ impl<'de> serde::Deserialize<'de> for GrantQueueItem {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GrantQueueItem;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.GrantQueueItem")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GrantQueueItem, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GrantQueueItem, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -823,7 +823,7 @@ impl<'de> serde::Deserialize<'de> for GrantQueueItem {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -848,7 +848,7 @@ impl serde::Serialize for MsgExec {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -861,7 +861,7 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -872,13 +872,13 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -896,11 +896,11 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgExec")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgExec, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgExec, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -934,7 +934,7 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -952,7 +952,7 @@ impl serde::Serialize for MsgExecResponse {
                     .results
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -961,7 +961,7 @@ impl serde::Serialize for MsgExecResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -973,7 +973,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -984,13 +984,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1007,11 +1007,11 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgExecResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgExecResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgExecResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1022,12 +1022,10 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
                             if results__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("results"));
                             }
-                            results__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            results__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -1046,7 +1044,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgGrant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1077,7 +1075,7 @@ impl serde::Serialize for MsgGrant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgGrant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1091,7 +1089,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1102,13 +1100,13 @@ impl<'de> serde::Deserialize<'de> for MsgGrant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1127,11 +1125,11 @@ impl<'de> serde::Deserialize<'de> for MsgGrant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgGrant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgGrant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgGrant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgGrant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1173,7 +1171,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgGrantResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1187,7 +1185,7 @@ impl serde::Serialize for MsgGrantResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgGrantResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1197,7 +1195,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1208,13 +1206,13 @@ impl<'de> serde::Deserialize<'de> for MsgGrantResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1228,11 +1226,11 @@ impl<'de> serde::Deserialize<'de> for MsgGrantResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgGrantResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgGrantResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgGrantResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgGrantResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1252,7 +1250,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRevoke {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1283,7 +1281,7 @@ impl serde::Serialize for MsgRevoke {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRevoke {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1297,7 +1295,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevoke {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1308,13 +1306,13 @@ impl<'de> serde::Deserialize<'de> for MsgRevoke {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1333,11 +1331,11 @@ impl<'de> serde::Deserialize<'de> for MsgRevoke {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRevoke;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgRevoke")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgRevoke, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgRevoke, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1379,7 +1377,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevoke {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRevokeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1393,7 +1391,7 @@ impl serde::Serialize for MsgRevokeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRevokeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1403,7 +1401,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1414,13 +1412,13 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1434,11 +1432,11 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRevokeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.MsgRevokeResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgRevokeResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgRevokeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1458,7 +1456,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGranteeGrantsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1484,7 +1482,7 @@ impl serde::Serialize for QueryGranteeGrantsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1497,7 +1495,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1508,13 +1506,13 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1532,14 +1530,14 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGranteeGrantsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGranteeGrantsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGranteeGrantsRequest, V::Error>
+            ) -> core::result::Result<QueryGranteeGrantsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1577,7 +1575,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGranteeGrantsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1603,7 +1601,7 @@ impl serde::Serialize for QueryGranteeGrantsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1616,7 +1614,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1627,13 +1625,13 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1651,14 +1649,14 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGranteeGrantsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGranteeGrantsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGranteeGrantsResponse, V::Error>
+            ) -> core::result::Result<QueryGranteeGrantsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1696,7 +1694,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranteeGrantsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGranterGrantsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1722,7 +1720,7 @@ impl serde::Serialize for QueryGranterGrantsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGranterGrantsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1735,7 +1733,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1746,13 +1744,13 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1770,14 +1768,14 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGranterGrantsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGranterGrantsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGranterGrantsRequest, V::Error>
+            ) -> core::result::Result<QueryGranterGrantsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1815,7 +1813,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGranterGrantsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1841,7 +1839,7 @@ impl serde::Serialize for QueryGranterGrantsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGranterGrantsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1854,7 +1852,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1865,13 +1863,13 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1889,14 +1887,14 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGranterGrantsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGranterGrantsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGranterGrantsResponse, V::Error>
+            ) -> core::result::Result<QueryGranterGrantsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1934,7 +1932,7 @@ impl<'de> serde::Deserialize<'de> for QueryGranterGrantsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGrantsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1972,7 +1970,7 @@ impl serde::Serialize for QueryGrantsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGrantsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1993,7 +1991,7 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2004,13 +2002,13 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2030,11 +2028,11 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGrantsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGrantsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryGrantsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryGrantsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2088,7 +2086,7 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGrantsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2114,7 +2112,7 @@ impl serde::Serialize for QueryGrantsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGrantsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2127,7 +2125,7 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2138,13 +2136,13 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2162,11 +2160,14 @@ impl<'de> serde::Deserialize<'de> for QueryGrantsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGrantsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.authz.v1beta1.QueryGrantsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryGrantsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryGrantsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.authz.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn grants(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn granter_grants(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGranterGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -127,12 +127,12 @@ pub mod query_client {
         pub async fn grantee_grants(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGranteeGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -158,15 +158,15 @@ pub mod query_server {
         async fn grants(
             &self,
             request: tonic::Request<super::QueryGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGrantsResponse>, tonic::Status>;
         async fn granter_grants(
             &self,
             request: tonic::Request<super::QueryGranterGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGranterGrantsResponse>, tonic::Status>;
         async fn grantee_grants(
             &self,
             request: tonic::Request<super::QueryGranteeGrantsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGranteeGrantsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -238,7 +238,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -390,8 +390,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -485,11 +485,11 @@ pub mod msg_client {
         pub async fn grant(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgGrant>,
-        ) -> std::result::Result<tonic::Response<super::MsgGrantResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgGrantResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -502,11 +502,11 @@ pub mod msg_client {
         pub async fn exec(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgExec>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -519,11 +519,12 @@ pub mod msg_client {
         pub async fn revoke(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgRevoke>,
-        ) -> std::result::Result<tonic::Response<super::MsgRevokeResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgRevokeResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -546,15 +547,15 @@ pub mod msg_server {
         async fn grant(
             &self,
             request: tonic::Request<super::MsgGrant>,
-        ) -> std::result::Result<tonic::Response<super::MsgGrantResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgGrantResponse>, tonic::Status>;
         async fn exec(
             &self,
             request: tonic::Request<super::MsgExec>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status>;
         async fn revoke(
             &self,
             request: tonic::Request<super::MsgRevoke>,
-        ) -> std::result::Result<tonic::Response<super::MsgRevokeResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgRevokeResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -626,7 +627,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -774,8 +775,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AppOptionsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for AppOptionsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AppOptionsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.AppOptionsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AppOptionsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AppOptionsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -80,7 +80,7 @@ impl<'de> serde::Deserialize<'de> for AppOptionsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AppOptionsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -100,7 +100,7 @@ impl serde::Serialize for AppOptionsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -112,7 +112,7 @@ impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -123,13 +123,13 @@ impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -146,11 +146,11 @@ impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AppOptionsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.AppOptionsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AppOptionsResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AppOptionsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -181,7 +181,7 @@ impl<'de> serde::Deserialize<'de> for AppOptionsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for FlagOptions {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -236,7 +236,7 @@ impl serde::Serialize for FlagOptions {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for FlagOptions {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -264,7 +264,7 @@ impl<'de> serde::Deserialize<'de> for FlagOptions {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -275,13 +275,13 @@ impl<'de> serde::Deserialize<'de> for FlagOptions {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -306,11 +306,11 @@ impl<'de> serde::Deserialize<'de> for FlagOptions {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = FlagOptions;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.FlagOptions")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FlagOptions, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<FlagOptions, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -386,7 +386,7 @@ impl<'de> serde::Deserialize<'de> for FlagOptions {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleOptions {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -411,7 +411,7 @@ impl serde::Serialize for ModuleOptions {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleOptions {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -424,7 +424,7 @@ impl<'de> serde::Deserialize<'de> for ModuleOptions {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -435,13 +435,13 @@ impl<'de> serde::Deserialize<'de> for ModuleOptions {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -459,11 +459,11 @@ impl<'de> serde::Deserialize<'de> for ModuleOptions {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleOptions;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.ModuleOptions")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleOptions, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleOptions, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -497,7 +497,7 @@ impl<'de> serde::Deserialize<'de> for ModuleOptions {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PositionalArgDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -523,7 +523,7 @@ impl serde::Serialize for PositionalArgDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -536,7 +536,7 @@ impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -547,13 +547,13 @@ impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -571,14 +571,14 @@ impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PositionalArgDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.PositionalArgDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<PositionalArgDescriptor, V::Error>
+            ) -> core::result::Result<PositionalArgDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -616,7 +616,7 @@ impl<'de> serde::Deserialize<'de> for PositionalArgDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for RpcCommandOptions {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -702,7 +702,7 @@ impl serde::Serialize for RpcCommandOptions {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -742,7 +742,7 @@ impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -753,13 +753,13 @@ impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -789,11 +789,11 @@ impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = RpcCommandOptions;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.RpcCommandOptions")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<RpcCommandOptions, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<RpcCommandOptions, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -912,7 +912,7 @@ impl<'de> serde::Deserialize<'de> for RpcCommandOptions {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ServiceCommandDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -944,7 +944,7 @@ impl serde::Serialize for ServiceCommandDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ServiceCommandDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -964,7 +964,7 @@ impl<'de> serde::Deserialize<'de> for ServiceCommandDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -975,13 +975,13 @@ impl<'de> serde::Deserialize<'de> for ServiceCommandDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1002,14 +1002,14 @@ impl<'de> serde::Deserialize<'de> for ServiceCommandDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ServiceCommandDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.autocli.v1.ServiceCommandDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ServiceCommandDescriptor, V::Error>
+            ) -> core::result::Result<ServiceCommandDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.autocli.v1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn app_options(
             &mut self,
             request: impl tonic::IntoRequest<super::AppOptionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -116,7 +116,7 @@ pub mod query_server {
         async fn app_options(
             &self,
             request: tonic::Request<super::AppOptionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AppOptionsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -188,7 +188,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -260,8 +260,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -36,7 +36,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -56,7 +56,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -67,13 +67,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -97,11 +97,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Balance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Balance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Balance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Balance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Balance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -75,11 +75,11 @@ impl<'de> serde::Deserialize<'de> for Balance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Balance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Balance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Balance, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Balance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -113,7 +113,7 @@ impl<'de> serde::Deserialize<'de> for Balance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DenomOwner {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -138,7 +138,7 @@ impl serde::Serialize for DenomOwner {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DenomOwner {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -151,7 +151,7 @@ impl<'de> serde::Deserialize<'de> for DenomOwner {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -162,13 +162,13 @@ impl<'de> serde::Deserialize<'de> for DenomOwner {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -186,11 +186,11 @@ impl<'de> serde::Deserialize<'de> for DenomOwner {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DenomOwner;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.DenomOwner")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DenomOwner, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DenomOwner, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -224,7 +224,7 @@ impl<'de> serde::Deserialize<'de> for DenomOwner {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DenomUnit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -255,7 +255,7 @@ impl serde::Serialize for DenomUnit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DenomUnit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -269,7 +269,7 @@ impl<'de> serde::Deserialize<'de> for DenomUnit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -280,13 +280,13 @@ impl<'de> serde::Deserialize<'de> for DenomUnit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -305,11 +305,11 @@ impl<'de> serde::Deserialize<'de> for DenomUnit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DenomUnit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.DenomUnit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DenomUnit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DenomUnit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -354,7 +354,7 @@ impl<'de> serde::Deserialize<'de> for DenomUnit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -398,7 +398,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -422,7 +422,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -433,13 +433,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -460,11 +460,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -526,7 +526,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Input {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -551,7 +551,7 @@ impl serde::Serialize for Input {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Input {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -564,7 +564,7 @@ impl<'de> serde::Deserialize<'de> for Input {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -575,13 +575,13 @@ impl<'de> serde::Deserialize<'de> for Input {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -599,11 +599,11 @@ impl<'de> serde::Deserialize<'de> for Input {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Input;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Input")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Input, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Input, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -637,7 +637,7 @@ impl<'de> serde::Deserialize<'de> for Input {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Metadata {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -698,7 +698,7 @@ impl serde::Serialize for Metadata {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Metadata {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -728,7 +728,7 @@ impl<'de> serde::Deserialize<'de> for Metadata {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -739,13 +739,13 @@ impl<'de> serde::Deserialize<'de> for Metadata {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -769,11 +769,11 @@ impl<'de> serde::Deserialize<'de> for Metadata {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Metadata;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Metadata")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Metadata, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Metadata, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -855,7 +855,7 @@ impl<'de> serde::Deserialize<'de> for Metadata {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgMultiSend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -881,7 +881,7 @@ impl serde::Serialize for MsgMultiSend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgMultiSend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -894,7 +894,7 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -905,13 +905,13 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -929,11 +929,11 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgMultiSend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgMultiSend")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgMultiSend, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgMultiSend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -971,7 +971,7 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgMultiSendResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -985,7 +985,7 @@ impl serde::Serialize for MsgMultiSendResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgMultiSendResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -995,7 +995,7 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSendResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1006,13 +1006,13 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSendResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1026,14 +1026,14 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSendResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgMultiSendResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgMultiSendResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgMultiSendResponse, V::Error>
+            ) -> core::result::Result<MsgMultiSendResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1053,7 +1053,7 @@ impl<'de> serde::Deserialize<'de> for MsgMultiSendResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1084,7 +1084,7 @@ impl serde::Serialize for MsgSend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1104,7 +1104,7 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1115,13 +1115,13 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1140,11 +1140,11 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgSend")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSend, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1186,7 +1186,7 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSendResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1199,7 +1199,7 @@ impl serde::Serialize for MsgSendResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSendResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1209,7 +1209,7 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1220,13 +1220,13 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1240,11 +1240,11 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSendResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgSendResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSendResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSendResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1264,7 +1264,7 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSetSendEnabled {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1296,7 +1296,7 @@ impl serde::Serialize for MsgSetSendEnabled {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1316,7 +1316,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1327,13 +1327,13 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1354,11 +1354,11 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSetSendEnabled;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgSetSendEnabled")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSetSendEnabled, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSetSendEnabled, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1404,7 +1404,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabled {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSetSendEnabledResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1418,7 +1418,7 @@ impl serde::Serialize for MsgSetSendEnabledResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1428,7 +1428,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1439,13 +1439,13 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1459,14 +1459,14 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSetSendEnabledResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgSetSendEnabledResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSetSendEnabledResponse, V::Error>
+            ) -> core::result::Result<MsgSetSendEnabledResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1486,7 +1486,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetSendEnabledResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1512,7 +1512,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1525,7 +1525,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1536,13 +1536,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1560,11 +1560,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1602,7 +1602,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1616,7 +1616,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1626,7 +1626,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1637,13 +1637,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1657,14 +1657,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1684,7 +1684,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Output {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1709,7 +1709,7 @@ impl serde::Serialize for Output {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Output {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1722,7 +1722,7 @@ impl<'de> serde::Deserialize<'de> for Output {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1733,13 +1733,13 @@ impl<'de> serde::Deserialize<'de> for Output {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1757,11 +1757,11 @@ impl<'de> serde::Deserialize<'de> for Output {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Output;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Output")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Output, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Output, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1795,7 +1795,7 @@ impl<'de> serde::Deserialize<'de> for Output {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1820,7 +1820,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1838,7 +1838,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1849,13 +1849,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1875,11 +1875,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1915,7 +1915,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllBalancesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1947,7 +1947,7 @@ impl serde::Serialize for QueryAllBalancesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllBalancesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1961,7 +1961,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1972,13 +1972,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1997,14 +1997,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllBalancesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryAllBalancesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllBalancesRequest, V::Error>
+            ) -> core::result::Result<QueryAllBalancesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2050,7 +2050,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllBalancesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2076,7 +2076,7 @@ impl serde::Serialize for QueryAllBalancesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllBalancesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2089,7 +2089,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2100,13 +2100,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2124,14 +2124,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllBalancesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryAllBalancesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllBalancesResponse, V::Error>
+            ) -> core::result::Result<QueryAllBalancesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2169,7 +2169,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllBalancesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBalanceRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2195,7 +2195,7 @@ impl serde::Serialize for QueryBalanceRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2208,7 +2208,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2219,13 +2219,13 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2243,11 +2243,14 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBalanceRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryBalanceRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryBalanceRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryBalanceRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2285,7 +2288,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBalanceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2305,7 +2308,7 @@ impl serde::Serialize for QueryBalanceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2317,7 +2320,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2328,13 +2331,13 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2351,14 +2354,14 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBalanceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryBalanceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryBalanceResponse, V::Error>
+            ) -> core::result::Result<QueryBalanceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2386,7 +2389,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomMetadataByQueryStringRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2408,7 +2411,7 @@ impl serde::Serialize for QueryDenomMetadataByQueryStringRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2420,7 +2423,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2431,13 +2434,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2454,7 +2457,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomMetadataByQueryStringRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.bank.v1beta1.QueryDenomMetadataByQueryStringRequest")
             }
@@ -2462,7 +2465,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomMetadataByQueryStringRequest, V::Error>
+            ) -> core::result::Result<QueryDenomMetadataByQueryStringRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2492,7 +2495,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomMetadataByQueryStringResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2514,7 +2517,7 @@ impl serde::Serialize for QueryDenomMetadataByQueryStringResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2526,7 +2529,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2537,13 +2540,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2560,7 +2563,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomMetadataByQueryStringResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.bank.v1beta1.QueryDenomMetadataByQueryStringResponse")
             }
@@ -2568,7 +2571,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomMetadataByQueryStringResponse, V::Error>
+            ) -> core::result::Result<QueryDenomMetadataByQueryStringResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2598,7 +2601,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataByQueryStringResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomMetadataRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2618,7 +2621,7 @@ impl serde::Serialize for QueryDenomMetadataRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomMetadataRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2630,7 +2633,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2641,13 +2644,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2664,14 +2667,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomMetadataRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomMetadataRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomMetadataRequest, V::Error>
+            ) -> core::result::Result<QueryDenomMetadataRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2701,7 +2704,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomMetadataResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2721,7 +2724,7 @@ impl serde::Serialize for QueryDenomMetadataResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomMetadataResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2733,7 +2736,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2744,13 +2747,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2767,14 +2770,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomMetadataResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomMetadataResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomMetadataResponse, V::Error>
+            ) -> core::result::Result<QueryDenomMetadataResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2804,7 +2807,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomMetadataResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomOwnersByQueryRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2830,7 +2833,7 @@ impl serde::Serialize for QueryDenomOwnersByQueryRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2843,7 +2846,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2854,13 +2857,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2878,14 +2881,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomOwnersByQueryRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomOwnersByQueryRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomOwnersByQueryRequest, V::Error>
+            ) -> core::result::Result<QueryDenomOwnersByQueryRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2923,7 +2926,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomOwnersByQueryResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2949,7 +2952,7 @@ impl serde::Serialize for QueryDenomOwnersByQueryResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2962,7 +2965,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2973,13 +2976,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2997,14 +3000,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomOwnersByQueryResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomOwnersByQueryResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomOwnersByQueryResponse, V::Error>
+            ) -> core::result::Result<QueryDenomOwnersByQueryResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3042,7 +3045,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersByQueryResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomOwnersRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3068,7 +3071,7 @@ impl serde::Serialize for QueryDenomOwnersRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomOwnersRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3081,7 +3084,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3092,13 +3095,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3116,14 +3119,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomOwnersRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomOwnersRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomOwnersRequest, V::Error>
+            ) -> core::result::Result<QueryDenomOwnersRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3161,7 +3164,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomOwnersResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3187,7 +3190,7 @@ impl serde::Serialize for QueryDenomOwnersResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomOwnersResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3200,7 +3203,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3211,13 +3214,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3235,14 +3238,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomOwnersResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomOwnersResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomOwnersResponse, V::Error>
+            ) -> core::result::Result<QueryDenomOwnersResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3280,7 +3283,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomOwnersResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomsMetadataRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3300,7 +3303,7 @@ impl serde::Serialize for QueryDenomsMetadataRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3312,7 +3315,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3323,13 +3326,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3346,14 +3349,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomsMetadataRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomsMetadataRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomsMetadataRequest, V::Error>
+            ) -> core::result::Result<QueryDenomsMetadataRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3383,7 +3386,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDenomsMetadataResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3409,7 +3412,7 @@ impl serde::Serialize for QueryDenomsMetadataResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3422,7 +3425,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3433,13 +3436,13 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3457,14 +3460,14 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDenomsMetadataResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryDenomsMetadataResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDenomsMetadataResponse, V::Error>
+            ) -> core::result::Result<QueryDenomsMetadataResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3502,7 +3505,7 @@ impl<'de> serde::Deserialize<'de> for QueryDenomsMetadataResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3516,7 +3519,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3526,7 +3529,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3537,13 +3540,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3557,11 +3560,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3581,7 +3584,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3601,7 +3604,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3613,7 +3616,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3624,13 +3627,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3647,11 +3650,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3679,7 +3685,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySendEnabledRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3705,7 +3711,7 @@ impl serde::Serialize for QuerySendEnabledRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3718,7 +3724,7 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3729,13 +3735,13 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3753,14 +3759,14 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySendEnabledRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySendEnabledRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySendEnabledRequest, V::Error>
+            ) -> core::result::Result<QuerySendEnabledRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3798,7 +3804,7 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySendEnabledResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3824,7 +3830,7 @@ impl serde::Serialize for QuerySendEnabledResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3837,7 +3843,7 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3848,13 +3854,13 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3872,14 +3878,14 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySendEnabledResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySendEnabledResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySendEnabledResponse, V::Error>
+            ) -> core::result::Result<QuerySendEnabledResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3917,7 +3923,7 @@ impl<'de> serde::Deserialize<'de> for QuerySendEnabledResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySpendableBalanceByDenomRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3945,7 +3951,7 @@ impl serde::Serialize for QuerySpendableBalanceByDenomRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3958,7 +3964,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3969,13 +3975,13 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3993,7 +3999,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySpendableBalanceByDenomRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.bank.v1beta1.QuerySpendableBalanceByDenomRequest")
             }
@@ -4001,7 +4007,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySpendableBalanceByDenomRequest, V::Error>
+            ) -> core::result::Result<QuerySpendableBalanceByDenomRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4039,7 +4045,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySpendableBalanceByDenomResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4061,7 +4067,7 @@ impl serde::Serialize for QuerySpendableBalanceByDenomResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4073,7 +4079,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4084,13 +4090,13 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4107,7 +4113,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySpendableBalanceByDenomResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse")
             }
@@ -4115,7 +4121,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySpendableBalanceByDenomResponse, V::Error>
+            ) -> core::result::Result<QuerySpendableBalanceByDenomResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4143,7 +4149,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalanceByDenomResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySpendableBalancesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4169,7 +4175,7 @@ impl serde::Serialize for QuerySpendableBalancesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4182,7 +4188,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4193,13 +4199,13 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4217,14 +4223,14 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySpendableBalancesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySpendableBalancesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySpendableBalancesRequest, V::Error>
+            ) -> core::result::Result<QuerySpendableBalancesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4262,7 +4268,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySpendableBalancesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4288,7 +4294,7 @@ impl serde::Serialize for QuerySpendableBalancesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4301,7 +4307,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4312,13 +4318,13 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4336,14 +4342,14 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySpendableBalancesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySpendableBalancesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySpendableBalancesResponse, V::Error>
+            ) -> core::result::Result<QuerySpendableBalancesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4381,7 +4387,7 @@ impl<'de> serde::Deserialize<'de> for QuerySpendableBalancesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySupplyOfRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4401,7 +4407,7 @@ impl serde::Serialize for QuerySupplyOfRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySupplyOfRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4413,7 +4419,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4424,13 +4430,13 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4447,14 +4453,14 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySupplyOfRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySupplyOfRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySupplyOfRequest, V::Error>
+            ) -> core::result::Result<QuerySupplyOfRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4484,7 +4490,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySupplyOfResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4504,7 +4510,7 @@ impl serde::Serialize for QuerySupplyOfResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySupplyOfResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4516,7 +4522,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4527,13 +4533,13 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4550,14 +4556,14 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySupplyOfResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QuerySupplyOfResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySupplyOfResponse, V::Error>
+            ) -> core::result::Result<QuerySupplyOfResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4585,7 +4591,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyOfResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTotalSupplyRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4605,7 +4611,7 @@ impl serde::Serialize for QueryTotalSupplyRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTotalSupplyRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4617,7 +4623,7 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4628,13 +4634,13 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4651,14 +4657,14 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTotalSupplyRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryTotalSupplyRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTotalSupplyRequest, V::Error>
+            ) -> core::result::Result<QueryTotalSupplyRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4688,7 +4694,7 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTotalSupplyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4714,7 +4720,7 @@ impl serde::Serialize for QueryTotalSupplyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTotalSupplyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4727,7 +4733,7 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4738,13 +4744,13 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4762,14 +4768,14 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTotalSupplyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.QueryTotalSupplyResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTotalSupplyResponse, V::Error>
+            ) -> core::result::Result<QueryTotalSupplyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4807,7 +4813,7 @@ impl<'de> serde::Deserialize<'de> for QueryTotalSupplyResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SendAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4833,7 +4839,7 @@ impl serde::Serialize for SendAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SendAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4846,7 +4852,7 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4857,13 +4863,13 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4881,11 +4887,11 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SendAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.SendAuthorization")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SendAuthorization, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SendAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4923,7 +4929,7 @@ impl<'de> serde::Deserialize<'de> for SendAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SendEnabled {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4948,7 +4954,7 @@ impl serde::Serialize for SendEnabled {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SendEnabled {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4961,7 +4967,7 @@ impl<'de> serde::Deserialize<'de> for SendEnabled {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4972,13 +4978,13 @@ impl<'de> serde::Deserialize<'de> for SendEnabled {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4996,11 +5002,11 @@ impl<'de> serde::Deserialize<'de> for SendEnabled {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SendEnabled;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.SendEnabled")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SendEnabled, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SendEnabled, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5034,7 +5040,7 @@ impl<'de> serde::Deserialize<'de> for SendEnabled {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Supply {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5053,7 +5059,7 @@ impl serde::Serialize for Supply {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Supply {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5065,7 +5071,7 @@ impl<'de> serde::Deserialize<'de> for Supply {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5076,13 +5082,13 @@ impl<'de> serde::Deserialize<'de> for Supply {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5099,11 +5105,11 @@ impl<'de> serde::Deserialize<'de> for Supply {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Supply;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.bank.v1beta1.Supply")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Supply, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Supply, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.bank.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn balance(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryBalanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn all_balances(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllBalancesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllBalancesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAllBalancesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -125,14 +125,14 @@ pub mod query_client {
         pub async fn spendable_balances(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySpendableBalancesRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QuerySpendableBalancesResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -149,14 +149,14 @@ pub mod query_client {
         pub async fn spendable_balance_by_denom(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySpendableBalanceByDenomRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QuerySpendableBalanceByDenomResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -173,12 +173,12 @@ pub mod query_client {
         pub async fn total_supply(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryTotalSupplyRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTotalSupplyResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryTotalSupplyResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -192,12 +192,12 @@ pub mod query_client {
         pub async fn supply_of(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySupplyOfRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySupplyOfResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySupplyOfResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -210,12 +210,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -228,12 +228,12 @@ pub mod query_client {
         pub async fn denom_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDenomMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomMetadataResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDenomMetadataResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -249,14 +249,14 @@ pub mod query_client {
         pub async fn denom_metadata_by_query_string(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDenomMetadataByQueryStringRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDenomMetadataByQueryStringResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -273,12 +273,12 @@ pub mod query_client {
         pub async fn denoms_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDenomsMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomsMetadataResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDenomsMetadataResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -294,12 +294,12 @@ pub mod query_client {
         pub async fn denom_owners(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDenomOwnersRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomOwnersResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDenomOwnersResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -313,14 +313,14 @@ pub mod query_client {
         pub async fn denom_owners_by_query(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDenomOwnersByQueryRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDenomOwnersByQueryResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -337,12 +337,12 @@ pub mod query_client {
         pub async fn send_enabled(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySendEnabledRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -366,67 +366,67 @@ pub mod query_server {
         async fn balance(
             &self,
             request: tonic::Request<super::QueryBalanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>;
         async fn all_balances(
             &self,
             request: tonic::Request<super::QueryAllBalancesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllBalancesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAllBalancesResponse>, tonic::Status>;
         async fn spendable_balances(
             &self,
             request: tonic::Request<super::QuerySpendableBalancesRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QuerySpendableBalancesResponse>,
             tonic::Status,
         >;
         async fn spendable_balance_by_denom(
             &self,
             request: tonic::Request<super::QuerySpendableBalanceByDenomRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QuerySpendableBalanceByDenomResponse>,
             tonic::Status,
         >;
         async fn total_supply(
             &self,
             request: tonic::Request<super::QueryTotalSupplyRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTotalSupplyResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryTotalSupplyResponse>, tonic::Status>;
         async fn supply_of(
             &self,
             request: tonic::Request<super::QuerySupplyOfRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySupplyOfResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySupplyOfResponse>, tonic::Status>;
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn denom_metadata(
             &self,
             request: tonic::Request<super::QueryDenomMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomMetadataResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDenomMetadataResponse>, tonic::Status>;
         async fn denom_metadata_by_query_string(
             &self,
             request: tonic::Request<super::QueryDenomMetadataByQueryStringRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDenomMetadataByQueryStringResponse>,
             tonic::Status,
         >;
         async fn denoms_metadata(
             &self,
             request: tonic::Request<super::QueryDenomsMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomsMetadataResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDenomsMetadataResponse>, tonic::Status>;
         async fn denom_owners(
             &self,
             request: tonic::Request<super::QueryDenomOwnersRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDenomOwnersResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDenomOwnersResponse>, tonic::Status>;
         async fn denom_owners_by_query(
             &self,
             request: tonic::Request<super::QueryDenomOwnersByQueryRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDenomOwnersByQueryResponse>,
             tonic::Status,
         >;
         async fn send_enabled(
             &self,
             request: tonic::Request<super::QuerySendEnabledRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySendEnabledResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -498,7 +498,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1044,8 +1044,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -1139,11 +1139,11 @@ pub mod msg_client {
         pub async fn send(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1156,12 +1156,12 @@ pub mod msg_client {
         pub async fn multi_send(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgMultiSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1174,12 +1174,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1193,12 +1193,12 @@ pub mod msg_client {
         pub async fn set_send_enabled(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSetSendEnabled>,
-        ) -> std::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1222,19 +1222,19 @@ pub mod msg_server {
         async fn send(
             &self,
             request: tonic::Request<super::MsgSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status>;
         async fn multi_send(
             &self,
             request: tonic::Request<super::MsgMultiSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgMultiSendResponse>, tonic::Status>;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
         async fn set_send_enabled(
             &self,
             request: tonic::Request<super::MsgSetSendEnabled>,
-        ) -> std::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSetSendEnabledResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1306,7 +1306,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1492,8 +1492,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.abci.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.abci.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AbciMessageLog {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for AbciMessageLog {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AbciMessageLog {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -48,7 +48,7 @@ impl<'de> serde::Deserialize<'de> for AbciMessageLog {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -59,13 +59,13 @@ impl<'de> serde::Deserialize<'de> for AbciMessageLog {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -84,11 +84,11 @@ impl<'de> serde::Deserialize<'de> for AbciMessageLog {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AbciMessageLog;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.ABCIMessageLog")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AbciMessageLog, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AbciMessageLog, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -137,7 +137,7 @@ impl<'de> serde::Deserialize<'de> for AbciMessageLog {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Attribute {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -163,7 +163,7 @@ impl serde::Serialize for Attribute {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Attribute {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -176,7 +176,7 @@ impl<'de> serde::Deserialize<'de> for Attribute {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -187,13 +187,13 @@ impl<'de> serde::Deserialize<'de> for Attribute {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -211,11 +211,11 @@ impl<'de> serde::Deserialize<'de> for Attribute {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Attribute;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.Attribute")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Attribute, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Attribute, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -253,7 +253,7 @@ impl<'de> serde::Deserialize<'de> for Attribute {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GasInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -269,12 +269,17 @@ impl serde::Serialize for GasInfo {
             serializer.serialize_struct("cosmos.base.abci.v1beta1.GasInfo", len)?;
         if self.gas_wanted != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("gasWanted", ToString::to_string(&self.gas_wanted).as_str())?;
+            struct_ser.serialize_field(
+                "gasWanted",
+                alloc::string::ToString::to_string(&self.gas_wanted).as_str(),
+            )?;
         }
         if self.gas_used != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gasUsed", ToString::to_string(&self.gas_used).as_str())?;
+            struct_ser.serialize_field(
+                "gasUsed",
+                alloc::string::ToString::to_string(&self.gas_used).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -282,7 +287,7 @@ impl serde::Serialize for GasInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GasInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -295,7 +300,7 @@ impl<'de> serde::Deserialize<'de> for GasInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -306,13 +311,13 @@ impl<'de> serde::Deserialize<'de> for GasInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -330,11 +335,11 @@ impl<'de> serde::Deserialize<'de> for GasInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GasInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.GasInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GasInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GasInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -378,7 +383,7 @@ impl<'de> serde::Deserialize<'de> for GasInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgData {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -406,7 +411,7 @@ impl serde::Serialize for MsgData {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgData {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -419,7 +424,7 @@ impl<'de> serde::Deserialize<'de> for MsgData {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -430,13 +435,13 @@ impl<'de> serde::Deserialize<'de> for MsgData {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -454,11 +459,11 @@ impl<'de> serde::Deserialize<'de> for MsgData {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgData;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.MsgData")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgData, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgData, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -499,7 +504,7 @@ impl<'de> serde::Deserialize<'de> for MsgData {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Result {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -538,7 +543,7 @@ impl serde::Serialize for Result {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Result {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -553,7 +558,7 @@ impl<'de> serde::Deserialize<'de> for Result {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -564,13 +569,13 @@ impl<'de> serde::Deserialize<'de> for Result {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -590,11 +595,11 @@ impl<'de> serde::Deserialize<'de> for Result {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Result;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.Result")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Result, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Result, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -647,7 +652,7 @@ impl<'de> serde::Deserialize<'de> for Result {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SearchBlocksResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -677,28 +682,36 @@ impl serde::Serialize for SearchBlocksResult {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "totalCount",
-                ToString::to_string(&self.total_count).as_str(),
+                alloc::string::ToString::to_string(&self.total_count).as_str(),
             )?;
         }
         if self.count != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("count", ToString::to_string(&self.count).as_str())?;
+            struct_ser.serialize_field(
+                "count",
+                alloc::string::ToString::to_string(&self.count).as_str(),
+            )?;
         }
         if self.page_number != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "pageNumber",
-                ToString::to_string(&self.page_number).as_str(),
+                alloc::string::ToString::to_string(&self.page_number).as_str(),
             )?;
         }
         if self.page_total != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("pageTotal", ToString::to_string(&self.page_total).as_str())?;
+            struct_ser.serialize_field(
+                "pageTotal",
+                alloc::string::ToString::to_string(&self.page_total).as_str(),
+            )?;
         }
         if self.limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("limit", ToString::to_string(&self.limit).as_str())?;
+            struct_ser.serialize_field(
+                "limit",
+                alloc::string::ToString::to_string(&self.limit).as_str(),
+            )?;
         }
         if !self.blocks.is_empty() {
             struct_ser.serialize_field("blocks", &self.blocks)?;
@@ -709,7 +722,7 @@ impl serde::Serialize for SearchBlocksResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SearchBlocksResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -736,7 +749,7 @@ impl<'de> serde::Deserialize<'de> for SearchBlocksResult {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -747,13 +760,13 @@ impl<'de> serde::Deserialize<'de> for SearchBlocksResult {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -775,11 +788,11 @@ impl<'de> serde::Deserialize<'de> for SearchBlocksResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SearchBlocksResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.SearchBlocksResult")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SearchBlocksResult, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SearchBlocksResult, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -864,7 +877,7 @@ impl<'de> serde::Deserialize<'de> for SearchBlocksResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SearchTxsResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -894,28 +907,36 @@ impl serde::Serialize for SearchTxsResult {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "totalCount",
-                ToString::to_string(&self.total_count).as_str(),
+                alloc::string::ToString::to_string(&self.total_count).as_str(),
             )?;
         }
         if self.count != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("count", ToString::to_string(&self.count).as_str())?;
+            struct_ser.serialize_field(
+                "count",
+                alloc::string::ToString::to_string(&self.count).as_str(),
+            )?;
         }
         if self.page_number != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "pageNumber",
-                ToString::to_string(&self.page_number).as_str(),
+                alloc::string::ToString::to_string(&self.page_number).as_str(),
             )?;
         }
         if self.page_total != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("pageTotal", ToString::to_string(&self.page_total).as_str())?;
+            struct_ser.serialize_field(
+                "pageTotal",
+                alloc::string::ToString::to_string(&self.page_total).as_str(),
+            )?;
         }
         if self.limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("limit", ToString::to_string(&self.limit).as_str())?;
+            struct_ser.serialize_field(
+                "limit",
+                alloc::string::ToString::to_string(&self.limit).as_str(),
+            )?;
         }
         if !self.txs.is_empty() {
             struct_ser.serialize_field("txs", &self.txs)?;
@@ -926,7 +947,7 @@ impl serde::Serialize for SearchTxsResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SearchTxsResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -953,7 +974,7 @@ impl<'de> serde::Deserialize<'de> for SearchTxsResult {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -964,13 +985,13 @@ impl<'de> serde::Deserialize<'de> for SearchTxsResult {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -992,11 +1013,11 @@ impl<'de> serde::Deserialize<'de> for SearchTxsResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SearchTxsResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.SearchTxsResult")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SearchTxsResult, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SearchTxsResult, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1081,7 +1102,7 @@ impl<'de> serde::Deserialize<'de> for SearchTxsResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SimulationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1107,7 +1128,7 @@ impl serde::Serialize for SimulationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SimulationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1120,7 +1141,7 @@ impl<'de> serde::Deserialize<'de> for SimulationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1131,13 +1152,13 @@ impl<'de> serde::Deserialize<'de> for SimulationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1155,11 +1176,11 @@ impl<'de> serde::Deserialize<'de> for SimulationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SimulationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.SimulationResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SimulationResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SimulationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1197,7 +1218,7 @@ impl<'de> serde::Deserialize<'de> for SimulationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StringEvent {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1223,7 +1244,7 @@ impl serde::Serialize for StringEvent {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StringEvent {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1236,7 +1257,7 @@ impl<'de> serde::Deserialize<'de> for StringEvent {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1247,13 +1268,13 @@ impl<'de> serde::Deserialize<'de> for StringEvent {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1271,11 +1292,11 @@ impl<'de> serde::Deserialize<'de> for StringEvent {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StringEvent;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.StringEvent")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StringEvent, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StringEvent, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1313,7 +1334,7 @@ impl<'de> serde::Deserialize<'de> for StringEvent {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxMsgData {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1339,7 +1360,7 @@ impl serde::Serialize for TxMsgData {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxMsgData {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1352,7 +1373,7 @@ impl<'de> serde::Deserialize<'de> for TxMsgData {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1363,13 +1384,13 @@ impl<'de> serde::Deserialize<'de> for TxMsgData {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1387,11 +1408,11 @@ impl<'de> serde::Deserialize<'de> for TxMsgData {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxMsgData;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.TxMsgData")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxMsgData, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxMsgData, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1429,7 +1450,7 @@ impl<'de> serde::Deserialize<'de> for TxMsgData {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1478,7 +1499,10 @@ impl serde::Serialize for TxResponse {
             serializer.serialize_struct("cosmos.base.abci.v1beta1.TxResponse", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if !self.txhash.is_empty() {
             struct_ser.serialize_field("txhash", &self.txhash)?;
@@ -1503,12 +1527,17 @@ impl serde::Serialize for TxResponse {
         }
         if self.gas_wanted != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("gasWanted", ToString::to_string(&self.gas_wanted).as_str())?;
+            struct_ser.serialize_field(
+                "gasWanted",
+                alloc::string::ToString::to_string(&self.gas_wanted).as_str(),
+            )?;
         }
         if self.gas_used != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gasUsed", ToString::to_string(&self.gas_used).as_str())?;
+            struct_ser.serialize_field(
+                "gasUsed",
+                alloc::string::ToString::to_string(&self.gas_used).as_str(),
+            )?;
         }
         if let Some(v) = self.tx.as_ref() {
             struct_ser.serialize_field("tx", v)?;
@@ -1525,7 +1554,7 @@ impl serde::Serialize for TxResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1566,7 +1595,7 @@ impl<'de> serde::Deserialize<'de> for TxResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1577,13 +1606,13 @@ impl<'de> serde::Deserialize<'de> for TxResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1612,11 +1641,11 @@ impl<'de> serde::Deserialize<'de> for TxResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.abci.v1beta1.TxResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for ConfigRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -16,7 +16,7 @@ impl serde::Serialize for ConfigRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ConfigRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -26,7 +26,7 @@ impl<'de> serde::Deserialize<'de> for ConfigRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -37,13 +37,13 @@ impl<'de> serde::Deserialize<'de> for ConfigRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -57,11 +57,11 @@ impl<'de> serde::Deserialize<'de> for ConfigRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ConfigRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.node.v1beta1.ConfigRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ConfigRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ConfigRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -81,7 +81,7 @@ impl<'de> serde::Deserialize<'de> for ConfigRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ConfigResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -114,7 +114,7 @@ impl serde::Serialize for ConfigResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "haltHeight",
-                ToString::to_string(&self.halt_height).as_str(),
+                alloc::string::ToString::to_string(&self.halt_height).as_str(),
             )?;
         }
         struct_ser.end()
@@ -123,7 +123,7 @@ impl serde::Serialize for ConfigResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ConfigResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -147,7 +147,7 @@ impl<'de> serde::Deserialize<'de> for ConfigResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -158,13 +158,13 @@ impl<'de> serde::Deserialize<'de> for ConfigResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -190,11 +190,11 @@ impl<'de> serde::Deserialize<'de> for ConfigResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ConfigResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.node.v1beta1.ConfigResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ConfigResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ConfigResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -251,7 +251,7 @@ impl<'de> serde::Deserialize<'de> for ConfigResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StatusRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -265,7 +265,7 @@ impl serde::Serialize for StatusRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StatusRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -275,7 +275,7 @@ impl<'de> serde::Deserialize<'de> for StatusRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -286,13 +286,13 @@ impl<'de> serde::Deserialize<'de> for StatusRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -306,11 +306,11 @@ impl<'de> serde::Deserialize<'de> for StatusRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StatusRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.node.v1beta1.StatusRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StatusRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StatusRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -330,7 +330,7 @@ impl<'de> serde::Deserialize<'de> for StatusRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StatusResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -357,12 +357,15 @@ impl serde::Serialize for StatusResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "earliestStoreHeight",
-                ToString::to_string(&self.earliest_store_height).as_str(),
+                alloc::string::ToString::to_string(&self.earliest_store_height).as_str(),
             )?;
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if let Some(v) = self.timestamp.as_ref() {
             struct_ser.serialize_field("timestamp", v)?;
@@ -387,7 +390,7 @@ impl serde::Serialize for StatusResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StatusResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -412,7 +415,7 @@ impl<'de> serde::Deserialize<'de> for StatusResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -423,13 +426,13 @@ impl<'de> serde::Deserialize<'de> for StatusResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -452,11 +455,11 @@ impl<'de> serde::Deserialize<'de> for StatusResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StatusResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.node.v1beta1.StatusResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StatusResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StatusResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.node.v1beta1.tonic.rs
@@ -88,11 +88,11 @@ pub mod service_client {
         pub async fn config(
             &mut self,
             request: impl tonic::IntoRequest<super::ConfigRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConfigResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::ConfigResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -108,11 +108,11 @@ pub mod service_client {
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -138,11 +138,11 @@ pub mod service_server {
         async fn config(
             &self,
             request: tonic::Request<super::ConfigRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConfigResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ConfigResponse>, tonic::Status>;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
-        ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::StatusResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
@@ -214,7 +214,7 @@ pub mod service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -324,8 +324,8 @@ pub mod service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.query.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.query.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PageRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -32,11 +32,17 @@ impl serde::Serialize for PageRequest {
         }
         if self.offset != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("offset", ToString::to_string(&self.offset).as_str())?;
+            struct_ser.serialize_field(
+                "offset",
+                alloc::string::ToString::to_string(&self.offset).as_str(),
+            )?;
         }
         if self.limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("limit", ToString::to_string(&self.limit).as_str())?;
+            struct_ser.serialize_field(
+                "limit",
+                alloc::string::ToString::to_string(&self.limit).as_str(),
+            )?;
         }
         if self.count_total {
             struct_ser.serialize_field("countTotal", &self.count_total)?;
@@ -50,7 +56,7 @@ impl serde::Serialize for PageRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PageRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -73,7 +79,7 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -84,13 +90,13 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -111,11 +117,11 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PageRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.query.v1beta1.PageRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PageRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PageRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -186,7 +192,7 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PageResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -209,7 +215,10 @@ impl serde::Serialize for PageResponse {
         }
         if self.total != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("total", ToString::to_string(&self.total).as_str())?;
+            struct_ser.serialize_field(
+                "total",
+                alloc::string::ToString::to_string(&self.total).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -217,7 +226,7 @@ impl serde::Serialize for PageResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PageResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -230,7 +239,7 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -241,13 +250,13 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -265,11 +274,11 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PageResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.query.v1beta1.PageResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PageResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PageResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListAllInterfacesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -18,7 +18,7 @@ impl serde::Serialize for ListAllInterfacesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -28,7 +28,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -39,13 +39,13 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -59,7 +59,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListAllInterfacesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v1beta1.ListAllInterfacesRequest")
             }
@@ -67,7 +67,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListAllInterfacesRequest, V::Error>
+            ) -> core::result::Result<ListAllInterfacesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -87,7 +87,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListAllInterfacesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -109,7 +109,7 @@ impl serde::Serialize for ListAllInterfacesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -121,7 +121,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -132,13 +132,13 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -157,7 +157,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListAllInterfacesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v1beta1.ListAllInterfacesResponse")
             }
@@ -165,7 +165,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListAllInterfacesResponse, V::Error>
+            ) -> core::result::Result<ListAllInterfacesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -195,7 +195,7 @@ impl<'de> serde::Deserialize<'de> for ListAllInterfacesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListImplementationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -217,7 +217,7 @@ impl serde::Serialize for ListImplementationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -229,7 +229,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -240,13 +240,13 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -263,7 +263,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListImplementationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v1beta1.ListImplementationsRequest")
             }
@@ -271,7 +271,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListImplementationsRequest, V::Error>
+            ) -> core::result::Result<ListImplementationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -301,7 +301,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListImplementationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -326,7 +326,7 @@ impl serde::Serialize for ListImplementationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListImplementationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -338,7 +338,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -349,13 +349,13 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -374,7 +374,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListImplementationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v1beta1.ListImplementationsResponse")
             }
@@ -382,7 +382,7 @@ impl<'de> serde::Deserialize<'de> for ListImplementationsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListImplementationsResponse, V::Error>
+            ) -> core::result::Result<ListImplementationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod reflection_service_client {
         pub async fn list_all_interfaces(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAllInterfacesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAllInterfacesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::ListAllInterfacesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -110,12 +110,12 @@ pub mod reflection_service_client {
         pub async fn list_implementations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListImplementationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListImplementationsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::ListImplementationsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -142,11 +142,11 @@ pub mod reflection_service_server {
         async fn list_all_interfaces(
             &self,
             request: tonic::Request<super::ListAllInterfacesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAllInterfacesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ListAllInterfacesResponse>, tonic::Status>;
         async fn list_implementations(
             &self,
             request: tonic::Request<super::ListImplementationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListImplementationsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ListImplementationsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ReflectionServiceServer<T: ReflectionService> {
@@ -218,7 +218,7 @@ pub mod reflection_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -334,8 +334,8 @@ pub mod reflection_service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AppDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -52,7 +52,7 @@ impl serde::Serialize for AppDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AppDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -77,7 +77,7 @@ impl<'de> serde::Deserialize<'de> for AppDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -88,13 +88,13 @@ impl<'de> serde::Deserialize<'de> for AppDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -116,11 +116,11 @@ impl<'de> serde::Deserialize<'de> for AppDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AppDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.AppDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AppDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AppDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -190,7 +190,7 @@ impl<'de> serde::Deserialize<'de> for AppDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AuthnDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -210,7 +210,7 @@ impl serde::Serialize for AuthnDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AuthnDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -222,7 +222,7 @@ impl<'de> serde::Deserialize<'de> for AuthnDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -233,13 +233,13 @@ impl<'de> serde::Deserialize<'de> for AuthnDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -256,11 +256,11 @@ impl<'de> serde::Deserialize<'de> for AuthnDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AuthnDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.AuthnDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AuthnDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AuthnDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -290,7 +290,7 @@ impl<'de> serde::Deserialize<'de> for AuthnDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ChainDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -310,7 +310,7 @@ impl serde::Serialize for ChainDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ChainDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -322,7 +322,7 @@ impl<'de> serde::Deserialize<'de> for ChainDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -333,13 +333,13 @@ impl<'de> serde::Deserialize<'de> for ChainDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -356,11 +356,11 @@ impl<'de> serde::Deserialize<'de> for ChainDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ChainDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.ChainDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ChainDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ChainDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -390,7 +390,7 @@ impl<'de> serde::Deserialize<'de> for ChainDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CodecDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -410,7 +410,7 @@ impl serde::Serialize for CodecDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CodecDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -422,7 +422,7 @@ impl<'de> serde::Deserialize<'de> for CodecDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -433,13 +433,13 @@ impl<'de> serde::Deserialize<'de> for CodecDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -456,11 +456,11 @@ impl<'de> serde::Deserialize<'de> for CodecDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CodecDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.CodecDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CodecDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CodecDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -490,7 +490,7 @@ impl<'de> serde::Deserialize<'de> for CodecDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ConfigurationDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -515,7 +515,7 @@ impl serde::Serialize for ConfigurationDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -530,7 +530,7 @@ impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -541,13 +541,13 @@ impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -566,7 +566,7 @@ impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ConfigurationDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.ConfigurationDescriptor")
             }
@@ -574,7 +574,7 @@ impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ConfigurationDescriptor, V::Error>
+            ) -> core::result::Result<ConfigurationDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -607,7 +607,7 @@ impl<'de> serde::Deserialize<'de> for ConfigurationDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetAuthnDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -623,7 +623,7 @@ impl serde::Serialize for GetAuthnDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -633,7 +633,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -644,13 +644,13 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -664,7 +664,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetAuthnDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetAuthnDescriptorRequest")
             }
@@ -672,7 +672,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetAuthnDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetAuthnDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -692,7 +692,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetAuthnDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -714,7 +714,7 @@ impl serde::Serialize for GetAuthnDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -726,7 +726,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -737,13 +737,13 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -760,7 +760,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetAuthnDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetAuthnDescriptorResponse")
             }
@@ -768,7 +768,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetAuthnDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetAuthnDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -796,7 +796,7 @@ impl<'de> serde::Deserialize<'de> for GetAuthnDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetChainDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -812,7 +812,7 @@ impl serde::Serialize for GetChainDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -822,7 +822,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -833,13 +833,13 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -853,7 +853,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetChainDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetChainDescriptorRequest")
             }
@@ -861,7 +861,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetChainDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetChainDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -881,7 +881,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetChainDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -903,7 +903,7 @@ impl serde::Serialize for GetChainDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -915,7 +915,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -926,13 +926,13 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -949,7 +949,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetChainDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetChainDescriptorResponse")
             }
@@ -957,7 +957,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetChainDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetChainDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -985,7 +985,7 @@ impl<'de> serde::Deserialize<'de> for GetChainDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetCodecDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1001,7 +1001,7 @@ impl serde::Serialize for GetCodecDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1011,7 +1011,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1022,13 +1022,13 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1042,7 +1042,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetCodecDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetCodecDescriptorRequest")
             }
@@ -1050,7 +1050,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetCodecDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetCodecDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1070,7 +1070,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetCodecDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1092,7 +1092,7 @@ impl serde::Serialize for GetCodecDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1104,7 +1104,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1115,13 +1115,13 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1138,7 +1138,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetCodecDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetCodecDescriptorResponse")
             }
@@ -1146,7 +1146,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetCodecDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetCodecDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1174,7 +1174,7 @@ impl<'de> serde::Deserialize<'de> for GetCodecDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetConfigurationDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1190,7 +1190,7 @@ impl serde::Serialize for GetConfigurationDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1200,7 +1200,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1211,13 +1211,13 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1231,7 +1231,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetConfigurationDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorRequest",
                 )
@@ -1240,7 +1240,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetConfigurationDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetConfigurationDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1260,7 +1260,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetConfigurationDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1282,7 +1282,7 @@ impl serde::Serialize for GetConfigurationDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1294,7 +1294,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1305,13 +1305,13 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1328,7 +1328,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetConfigurationDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.GetConfigurationDescriptorResponse",
                 )
@@ -1337,7 +1337,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetConfigurationDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetConfigurationDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1365,7 +1365,7 @@ impl<'de> serde::Deserialize<'de> for GetConfigurationDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetQueryServicesDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1381,7 +1381,7 @@ impl serde::Serialize for GetQueryServicesDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1391,7 +1391,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1402,13 +1402,13 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1422,7 +1422,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetQueryServicesDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorRequest",
                 )
@@ -1431,7 +1431,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetQueryServicesDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetQueryServicesDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1451,7 +1451,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetQueryServicesDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1473,7 +1473,7 @@ impl serde::Serialize for GetQueryServicesDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1485,7 +1485,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1496,13 +1496,13 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1519,7 +1519,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetQueryServicesDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.GetQueryServicesDescriptorResponse",
                 )
@@ -1528,7 +1528,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetQueryServicesDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetQueryServicesDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1556,7 +1556,7 @@ impl<'de> serde::Deserialize<'de> for GetQueryServicesDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxDescriptorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1572,7 +1572,7 @@ impl serde::Serialize for GetTxDescriptorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxDescriptorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1582,7 +1582,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1593,13 +1593,13 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1613,14 +1613,14 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxDescriptorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.GetTxDescriptorRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetTxDescriptorRequest, V::Error>
+            ) -> core::result::Result<GetTxDescriptorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1640,7 +1640,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxDescriptorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1662,7 +1662,7 @@ impl serde::Serialize for GetTxDescriptorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1674,7 +1674,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1685,13 +1685,13 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1708,7 +1708,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxDescriptorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.GetTxDescriptorResponse")
             }
@@ -1716,7 +1716,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetTxDescriptorResponse, V::Error>
+            ) -> core::result::Result<GetTxDescriptorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1744,7 +1744,7 @@ impl<'de> serde::Deserialize<'de> for GetTxDescriptorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for InterfaceAcceptingMessageDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1772,7 +1772,7 @@ impl serde::Serialize for InterfaceAcceptingMessageDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1785,7 +1785,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1796,13 +1796,13 @@ impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1822,7 +1822,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InterfaceAcceptingMessageDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.InterfaceAcceptingMessageDescriptor",
                 )
@@ -1831,7 +1831,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<InterfaceAcceptingMessageDescriptor, V::Error>
+            ) -> core::result::Result<InterfaceAcceptingMessageDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1871,7 +1871,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceAcceptingMessageDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1906,7 +1906,7 @@ impl serde::Serialize for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1926,7 +1926,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1937,13 +1937,13 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1966,11 +1966,14 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InterfaceDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.InterfaceDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InterfaceDescriptor, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<InterfaceDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2021,7 +2024,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for InterfaceImplementerDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2049,7 +2052,7 @@ impl serde::Serialize for InterfaceImplementerDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2062,7 +2065,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2073,13 +2076,13 @@ impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2097,7 +2100,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InterfaceImplementerDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.reflection.v2alpha1.InterfaceImplementerDescriptor",
                 )
@@ -2106,7 +2109,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<InterfaceImplementerDescriptor, V::Error>
+            ) -> core::result::Result<InterfaceImplementerDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2144,7 +2147,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceImplementerDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2164,7 +2167,7 @@ impl serde::Serialize for MsgDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2176,7 +2179,7 @@ impl<'de> serde::Deserialize<'de> for MsgDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2187,13 +2190,13 @@ impl<'de> serde::Deserialize<'de> for MsgDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2210,11 +2213,11 @@ impl<'de> serde::Deserialize<'de> for MsgDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.MsgDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2244,7 +2247,7 @@ impl<'de> serde::Deserialize<'de> for MsgDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryMethodDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2270,7 +2273,7 @@ impl serde::Serialize for QueryMethodDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryMethodDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2283,7 +2286,7 @@ impl<'de> serde::Deserialize<'de> for QueryMethodDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2294,13 +2297,13 @@ impl<'de> serde::Deserialize<'de> for QueryMethodDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2320,14 +2323,14 @@ impl<'de> serde::Deserialize<'de> for QueryMethodDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryMethodDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.QueryMethodDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryMethodDescriptor, V::Error>
+            ) -> core::result::Result<QueryMethodDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2365,7 +2368,7 @@ impl<'de> serde::Deserialize<'de> for QueryMethodDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryServiceDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2399,7 +2402,7 @@ impl serde::Serialize for QueryServiceDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryServiceDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2413,7 +2416,7 @@ impl<'de> serde::Deserialize<'de> for QueryServiceDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2424,13 +2427,13 @@ impl<'de> serde::Deserialize<'de> for QueryServiceDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2449,14 +2452,14 @@ impl<'de> serde::Deserialize<'de> for QueryServiceDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryServiceDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.QueryServiceDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryServiceDescriptor, V::Error>
+            ) -> core::result::Result<QueryServiceDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2502,7 +2505,7 @@ impl<'de> serde::Deserialize<'de> for QueryServiceDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryServicesDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2524,7 +2527,7 @@ impl serde::Serialize for QueryServicesDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2536,7 +2539,7 @@ impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2547,13 +2550,13 @@ impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2570,7 +2573,7 @@ impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryServicesDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.reflection.v2alpha1.QueryServicesDescriptor")
             }
@@ -2578,7 +2581,7 @@ impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryServicesDescriptor, V::Error>
+            ) -> core::result::Result<QueryServicesDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2608,7 +2611,7 @@ impl<'de> serde::Deserialize<'de> for QueryServicesDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SigningModeDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2643,7 +2646,7 @@ impl serde::Serialize for SigningModeDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SigningModeDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2662,7 +2665,7 @@ impl<'de> serde::Deserialize<'de> for SigningModeDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2673,13 +2676,13 @@ impl<'de> serde::Deserialize<'de> for SigningModeDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2701,14 +2704,14 @@ impl<'de> serde::Deserialize<'de> for SigningModeDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SigningModeDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.SigningModeDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SigningModeDescriptor, V::Error>
+            ) -> core::result::Result<SigningModeDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2760,7 +2763,7 @@ impl<'de> serde::Deserialize<'de> for SigningModeDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2786,7 +2789,7 @@ impl serde::Serialize for TxDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2799,7 +2802,7 @@ impl<'de> serde::Deserialize<'de> for TxDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2810,13 +2813,13 @@ impl<'de> serde::Deserialize<'de> for TxDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2834,11 +2837,11 @@ impl<'de> serde::Deserialize<'de> for TxDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.reflection.v2alpha1.TxDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.reflection.v2alpha1.tonic.rs
@@ -88,12 +88,12 @@ pub mod reflection_service_client {
         pub async fn get_authn_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAuthnDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAuthnDescriptorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetAuthnDescriptorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -110,12 +110,12 @@ pub mod reflection_service_client {
         pub async fn get_chain_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetChainDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetChainDescriptorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetChainDescriptorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -132,12 +132,12 @@ pub mod reflection_service_client {
         pub async fn get_codec_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetCodecDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCodecDescriptorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetCodecDescriptorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -154,14 +154,14 @@ pub mod reflection_service_client {
         pub async fn get_configuration_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetConfigurationDescriptorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetConfigurationDescriptorResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -178,14 +178,14 @@ pub mod reflection_service_client {
         pub async fn get_query_services_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetQueryServicesDescriptorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetQueryServicesDescriptorResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -202,12 +202,12 @@ pub mod reflection_service_client {
         pub async fn get_tx_descriptor(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTxDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxDescriptorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetTxDescriptorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -234,33 +234,33 @@ pub mod reflection_service_server {
         async fn get_authn_descriptor(
             &self,
             request: tonic::Request<super::GetAuthnDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetAuthnDescriptorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetAuthnDescriptorResponse>, tonic::Status>;
         async fn get_chain_descriptor(
             &self,
             request: tonic::Request<super::GetChainDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetChainDescriptorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetChainDescriptorResponse>, tonic::Status>;
         async fn get_codec_descriptor(
             &self,
             request: tonic::Request<super::GetCodecDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetCodecDescriptorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetCodecDescriptorResponse>, tonic::Status>;
         async fn get_configuration_descriptor(
             &self,
             request: tonic::Request<super::GetConfigurationDescriptorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetConfigurationDescriptorResponse>,
             tonic::Status,
         >;
         async fn get_query_services_descriptor(
             &self,
             request: tonic::Request<super::GetQueryServicesDescriptorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetQueryServicesDescriptorResponse>,
             tonic::Status,
         >;
         async fn get_tx_descriptor(
             &self,
             request: tonic::Request<super::GetTxDescriptorRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxDescriptorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetTxDescriptorResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ReflectionServiceServer<T: ReflectionService> {
@@ -332,7 +332,7 @@ pub mod reflection_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -615,8 +615,8 @@ pub mod reflection_service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AbciQueryRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -32,7 +32,10 @@ impl serde::Serialize for AbciQueryRequest {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if self.prove {
             struct_ser.serialize_field("prove", &self.prove)?;
@@ -43,7 +46,7 @@ impl serde::Serialize for AbciQueryRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AbciQueryRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -58,7 +61,7 @@ impl<'de> serde::Deserialize<'de> for AbciQueryRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -69,13 +72,13 @@ impl<'de> serde::Deserialize<'de> for AbciQueryRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -95,11 +98,11 @@ impl<'de> serde::Deserialize<'de> for AbciQueryRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AbciQueryRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.ABCIQueryRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AbciQueryRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AbciQueryRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -159,7 +162,7 @@ impl<'de> serde::Deserialize<'de> for AbciQueryRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AbciQueryResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -205,7 +208,10 @@ impl serde::Serialize for AbciQueryResponse {
         }
         if self.index != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("index", ToString::to_string(&self.index).as_str())?;
+            struct_ser.serialize_field(
+                "index",
+                alloc::string::ToString::to_string(&self.index).as_str(),
+            )?;
         }
         if !self.key.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -224,7 +230,10 @@ impl serde::Serialize for AbciQueryResponse {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if !self.codespace.is_empty() {
             struct_ser.serialize_field("codespace", &self.codespace)?;
@@ -235,7 +244,7 @@ impl serde::Serialize for AbciQueryResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AbciQueryResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -266,7 +275,7 @@ impl<'de> serde::Deserialize<'de> for AbciQueryResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -277,13 +286,13 @@ impl<'de> serde::Deserialize<'de> for AbciQueryResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -308,11 +317,11 @@ impl<'de> serde::Deserialize<'de> for AbciQueryResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AbciQueryResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.ABCIQueryResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AbciQueryResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AbciQueryResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -421,7 +430,7 @@ impl<'de> serde::Deserialize<'de> for AbciQueryResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Block {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -459,7 +468,7 @@ impl serde::Serialize for Block {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Block {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -474,7 +483,7 @@ impl<'de> serde::Deserialize<'de> for Block {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -485,13 +494,13 @@ impl<'de> serde::Deserialize<'de> for Block {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -511,11 +520,11 @@ impl<'de> serde::Deserialize<'de> for Block {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Block;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.Block")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Block, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Block, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -569,7 +578,7 @@ impl<'de> serde::Deserialize<'de> for Block {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetBlockByHeightRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -584,7 +593,10 @@ impl serde::Serialize for GetBlockByHeightRequest {
         )?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -592,7 +604,7 @@ impl serde::Serialize for GetBlockByHeightRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetBlockByHeightRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -604,7 +616,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -615,13 +627,13 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -638,14 +650,14 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetBlockByHeightRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetBlockByHeightRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetBlockByHeightRequest, V::Error>
+            ) -> core::result::Result<GetBlockByHeightRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -678,7 +690,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetBlockByHeightResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -712,7 +724,7 @@ impl serde::Serialize for GetBlockByHeightResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -726,7 +738,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -737,13 +749,13 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -762,7 +774,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetBlockByHeightResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.tendermint.v1beta1.GetBlockByHeightResponse")
             }
@@ -770,7 +782,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetBlockByHeightResponse, V::Error>
+            ) -> core::result::Result<GetBlockByHeightResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -816,7 +828,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockByHeightResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetLatestBlockRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -830,7 +842,7 @@ impl serde::Serialize for GetLatestBlockRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetLatestBlockRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -840,7 +852,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -851,13 +863,13 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -871,14 +883,14 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetLatestBlockRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetLatestBlockRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetLatestBlockRequest, V::Error>
+            ) -> core::result::Result<GetLatestBlockRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -898,7 +910,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetLatestBlockResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -930,7 +942,7 @@ impl serde::Serialize for GetLatestBlockResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetLatestBlockResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -944,7 +956,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -955,13 +967,13 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -980,14 +992,14 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetLatestBlockResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetLatestBlockResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetLatestBlockResponse, V::Error>
+            ) -> core::result::Result<GetLatestBlockResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1033,7 +1045,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestBlockResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetLatestValidatorSetRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1055,7 +1067,7 @@ impl serde::Serialize for GetLatestValidatorSetRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1067,7 +1079,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1078,13 +1090,13 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1101,7 +1113,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetLatestValidatorSetRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.base.tendermint.v1beta1.GetLatestValidatorSetRequest")
             }
@@ -1109,7 +1121,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetLatestValidatorSetRequest, V::Error>
+            ) -> core::result::Result<GetLatestValidatorSetRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1139,7 +1151,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetLatestValidatorSetResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1162,7 +1174,7 @@ impl serde::Serialize for GetLatestValidatorSetResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "blockHeight",
-                ToString::to_string(&self.block_height).as_str(),
+                alloc::string::ToString::to_string(&self.block_height).as_str(),
             )?;
         }
         if !self.validators.is_empty() {
@@ -1177,7 +1189,7 @@ impl serde::Serialize for GetLatestValidatorSetResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1191,7 +1203,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1202,13 +1214,13 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1227,7 +1239,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetLatestValidatorSetResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.tendermint.v1beta1.GetLatestValidatorSetResponse",
                 )
@@ -1236,7 +1248,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetLatestValidatorSetResponse, V::Error>
+            ) -> core::result::Result<GetLatestValidatorSetResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1285,7 +1297,7 @@ impl<'de> serde::Deserialize<'de> for GetLatestValidatorSetResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetNodeInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1299,7 +1311,7 @@ impl serde::Serialize for GetNodeInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetNodeInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1309,7 +1321,7 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1320,13 +1332,13 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1340,11 +1352,11 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetNodeInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetNodeInfoRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetNodeInfoRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetNodeInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1364,7 +1376,7 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetNodeInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1390,7 +1402,7 @@ impl serde::Serialize for GetNodeInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetNodeInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1408,7 +1420,7 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1419,13 +1431,13 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1447,11 +1459,14 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetNodeInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetNodeInfoResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetNodeInfoResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<GetNodeInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1491,7 +1506,7 @@ impl<'de> serde::Deserialize<'de> for GetNodeInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetSyncingRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1505,7 +1520,7 @@ impl serde::Serialize for GetSyncingRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetSyncingRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1515,7 +1530,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncingRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1526,13 +1541,13 @@ impl<'de> serde::Deserialize<'de> for GetSyncingRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1546,11 +1561,11 @@ impl<'de> serde::Deserialize<'de> for GetSyncingRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetSyncingRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetSyncingRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetSyncingRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetSyncingRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1570,7 +1585,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncingRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetSyncingResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1590,7 +1605,7 @@ impl serde::Serialize for GetSyncingResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetSyncingResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1602,7 +1617,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncingResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1613,13 +1628,13 @@ impl<'de> serde::Deserialize<'de> for GetSyncingResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1636,11 +1651,11 @@ impl<'de> serde::Deserialize<'de> for GetSyncingResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetSyncingResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.GetSyncingResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetSyncingResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetSyncingResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1670,7 +1685,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncingResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetValidatorSetByHeightRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1688,7 +1703,10 @@ impl serde::Serialize for GetValidatorSetByHeightRequest {
         )?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if let Some(v) = self.pagination.as_ref() {
             struct_ser.serialize_field("pagination", v)?;
@@ -1699,7 +1717,7 @@ impl serde::Serialize for GetValidatorSetByHeightRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1712,7 +1730,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1723,13 +1741,13 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1747,7 +1765,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetValidatorSetByHeightRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.tendermint.v1beta1.GetValidatorSetByHeightRequest",
                 )
@@ -1756,7 +1774,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetValidatorSetByHeightRequest, V::Error>
+            ) -> core::result::Result<GetValidatorSetByHeightRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1797,7 +1815,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetValidatorSetByHeightResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1820,7 +1838,7 @@ impl serde::Serialize for GetValidatorSetByHeightResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "blockHeight",
-                ToString::to_string(&self.block_height).as_str(),
+                alloc::string::ToString::to_string(&self.block_height).as_str(),
             )?;
         }
         if !self.validators.is_empty() {
@@ -1835,7 +1853,7 @@ impl serde::Serialize for GetValidatorSetByHeightResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1849,7 +1867,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1860,13 +1878,13 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1885,7 +1903,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetValidatorSetByHeightResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.base.tendermint.v1beta1.GetValidatorSetByHeightResponse",
                 )
@@ -1894,7 +1912,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetValidatorSetByHeightResponse, V::Error>
+            ) -> core::result::Result<GetValidatorSetByHeightResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1943,7 +1961,7 @@ impl<'de> serde::Deserialize<'de> for GetValidatorSetByHeightResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Header {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2001,7 +2019,10 @@ impl serde::Serialize for Header {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if let Some(v) = self.time.as_ref() {
             struct_ser.serialize_field("time", v)?;
@@ -2074,7 +2095,7 @@ impl serde::Serialize for Header {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Header {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2125,7 +2146,7 @@ impl<'de> serde::Deserialize<'de> for Header {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2136,13 +2157,13 @@ impl<'de> serde::Deserialize<'de> for Header {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2182,11 +2203,11 @@ impl<'de> serde::Deserialize<'de> for Header {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Header;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.Header")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Header, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Header, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2349,7 +2370,7 @@ impl<'de> serde::Deserialize<'de> for Header {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2381,7 +2402,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2395,7 +2416,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2406,13 +2427,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2431,11 +2452,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2481,7 +2502,7 @@ impl<'de> serde::Deserialize<'de> for Module {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProofOp {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2517,7 +2538,7 @@ impl serde::Serialize for ProofOp {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProofOp {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2531,7 +2552,7 @@ impl<'de> serde::Deserialize<'de> for ProofOp {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2542,13 +2563,13 @@ impl<'de> serde::Deserialize<'de> for ProofOp {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2567,11 +2588,11 @@ impl<'de> serde::Deserialize<'de> for ProofOp {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProofOp;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.ProofOp")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ProofOp, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ProofOp, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2623,7 +2644,7 @@ impl<'de> serde::Deserialize<'de> for ProofOp {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProofOps {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2643,7 +2664,7 @@ impl serde::Serialize for ProofOps {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProofOps {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2655,7 +2676,7 @@ impl<'de> serde::Deserialize<'de> for ProofOps {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2666,13 +2687,13 @@ impl<'de> serde::Deserialize<'de> for ProofOps {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2689,11 +2710,11 @@ impl<'de> serde::Deserialize<'de> for ProofOps {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProofOps;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.ProofOps")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ProofOps, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ProofOps, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2723,7 +2744,7 @@ impl<'de> serde::Deserialize<'de> for ProofOps {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Validator {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2753,14 +2774,14 @@ impl serde::Serialize for Validator {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "votingPower",
-                ToString::to_string(&self.voting_power).as_str(),
+                alloc::string::ToString::to_string(&self.voting_power).as_str(),
             )?;
         }
         if self.proposer_priority != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposerPriority",
-                ToString::to_string(&self.proposer_priority).as_str(),
+                alloc::string::ToString::to_string(&self.proposer_priority).as_str(),
             )?;
         }
         struct_ser.end()
@@ -2769,7 +2790,7 @@ impl serde::Serialize for Validator {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Validator {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2792,7 +2813,7 @@ impl<'de> serde::Deserialize<'de> for Validator {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2803,13 +2824,13 @@ impl<'de> serde::Deserialize<'de> for Validator {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2831,11 +2852,11 @@ impl<'de> serde::Deserialize<'de> for Validator {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Validator;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.Validator")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Validator, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Validator, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2895,7 +2916,7 @@ impl<'de> serde::Deserialize<'de> for Validator {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VersionInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2957,7 +2978,7 @@ impl serde::Serialize for VersionInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VersionInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2991,7 +3012,7 @@ impl<'de> serde::Deserialize<'de> for VersionInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3002,13 +3023,13 @@ impl<'de> serde::Deserialize<'de> for VersionInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3034,11 +3055,11 @@ impl<'de> serde::Deserialize<'de> for VersionInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VersionInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.tendermint.v1beta1.VersionInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<VersionInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<VersionInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.tendermint.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod service_client {
         pub async fn get_node_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetNodeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetNodeInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetNodeInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -110,12 +110,12 @@ pub mod service_client {
         pub async fn get_syncing(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSyncingRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSyncingResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetSyncingResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -132,12 +132,12 @@ pub mod service_client {
         pub async fn get_latest_block(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLatestBlockRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLatestBlockResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetLatestBlockResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -154,12 +154,12 @@ pub mod service_client {
         pub async fn get_block_by_height(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBlockByHeightRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -176,12 +176,14 @@ pub mod service_client {
         pub async fn get_latest_validator_set(
             &mut self,
             request: impl tonic::IntoRequest<super::GetLatestValidatorSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLatestValidatorSetResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::GetLatestValidatorSetResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -198,14 +200,14 @@ pub mod service_client {
         pub async fn get_validator_set_by_height(
             &mut self,
             request: impl tonic::IntoRequest<super::GetValidatorSetByHeightRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetValidatorSetByHeightResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -222,11 +224,12 @@ pub mod service_client {
         pub async fn abci_query(
             &mut self,
             request: impl tonic::IntoRequest<super::AbciQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::AbciQueryResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::AbciQueryResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -253,34 +256,37 @@ pub mod service_server {
         async fn get_node_info(
             &self,
             request: tonic::Request<super::GetNodeInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetNodeInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetNodeInfoResponse>, tonic::Status>;
         async fn get_syncing(
             &self,
             request: tonic::Request<super::GetSyncingRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetSyncingResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetSyncingResponse>, tonic::Status>;
         async fn get_latest_block(
             &self,
             request: tonic::Request<super::GetLatestBlockRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLatestBlockResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetLatestBlockResponse>, tonic::Status>;
         async fn get_block_by_height(
             &self,
             request: tonic::Request<super::GetBlockByHeightRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status>;
         async fn get_latest_validator_set(
             &self,
             request: tonic::Request<super::GetLatestValidatorSetRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetLatestValidatorSetResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::GetLatestValidatorSetResponse>,
+            tonic::Status,
+        >;
         async fn get_validator_set_by_height(
             &self,
             request: tonic::Request<super::GetValidatorSetByHeightRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::GetValidatorSetByHeightResponse>,
             tonic::Status,
         >;
         async fn abci_query(
             &self,
             request: tonic::Request<super::AbciQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::AbciQueryResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AbciQueryResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
@@ -352,7 +358,7 @@ pub mod service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -664,8 +670,8 @@ pub mod service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.base.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Coin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Coin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Coin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Coin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Coin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -75,11 +75,11 @@ impl<'de> serde::Deserialize<'de> for Coin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Coin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.Coin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Coin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Coin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -113,7 +113,7 @@ impl<'de> serde::Deserialize<'de> for Coin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DecCoin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -138,7 +138,7 @@ impl serde::Serialize for DecCoin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DecCoin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -151,7 +151,7 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -162,13 +162,13 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -186,11 +186,11 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DecCoin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.DecCoin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DecCoin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DecCoin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -224,7 +224,7 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DecProto {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -243,7 +243,7 @@ impl serde::Serialize for DecProto {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DecProto {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -255,7 +255,7 @@ impl<'de> serde::Deserialize<'de> for DecProto {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -266,13 +266,13 @@ impl<'de> serde::Deserialize<'de> for DecProto {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -289,11 +289,11 @@ impl<'de> serde::Deserialize<'de> for DecProto {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DecProto;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.DecProto")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DecProto, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DecProto, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -319,7 +319,7 @@ impl<'de> serde::Deserialize<'de> for DecProto {
 #[cfg(feature = "serde")]
 impl serde::Serialize for IntProto {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -338,7 +338,7 @@ impl serde::Serialize for IntProto {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for IntProto {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -350,7 +350,7 @@ impl<'de> serde::Deserialize<'de> for IntProto {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -361,13 +361,13 @@ impl<'de> serde::Deserialize<'de> for IntProto {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -384,11 +384,11 @@ impl<'de> serde::Deserialize<'de> for IntProto {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = IntProto;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.IntProto")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IntProto, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<IntProto, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -21,7 +21,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -33,7 +33,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -44,13 +44,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -67,11 +67,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccountResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for AccountResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccountResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -34,7 +34,7 @@ impl<'de> serde::Deserialize<'de> for AccountResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -45,13 +45,13 @@ impl<'de> serde::Deserialize<'de> for AccountResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -68,11 +68,11 @@ impl<'de> serde::Deserialize<'de> for AccountResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccountResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.AccountResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccountResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AccountResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -102,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for AccountResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccountsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -128,7 +128,7 @@ impl serde::Serialize for AccountsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccountsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -141,7 +141,7 @@ impl<'de> serde::Deserialize<'de> for AccountsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -152,13 +152,13 @@ impl<'de> serde::Deserialize<'de> for AccountsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -176,11 +176,11 @@ impl<'de> serde::Deserialize<'de> for AccountsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccountsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.AccountsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccountsResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AccountsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -218,7 +218,7 @@ impl<'de> serde::Deserialize<'de> for AccountsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DisabledListResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -238,7 +238,7 @@ impl serde::Serialize for DisabledListResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DisabledListResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -250,7 +250,7 @@ impl<'de> serde::Deserialize<'de> for DisabledListResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -261,13 +261,13 @@ impl<'de> serde::Deserialize<'de> for DisabledListResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -284,14 +284,14 @@ impl<'de> serde::Deserialize<'de> for DisabledListResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DisabledListResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.DisabledListResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DisabledListResponse, V::Error>
+            ) -> core::result::Result<DisabledListResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -321,7 +321,7 @@ impl<'de> serde::Deserialize<'de> for DisabledListResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisAccountPermissions {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -347,7 +347,7 @@ impl serde::Serialize for GenesisAccountPermissions {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisAccountPermissions {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -360,7 +360,7 @@ impl<'de> serde::Deserialize<'de> for GenesisAccountPermissions {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -371,13 +371,13 @@ impl<'de> serde::Deserialize<'de> for GenesisAccountPermissions {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -395,14 +395,14 @@ impl<'de> serde::Deserialize<'de> for GenesisAccountPermissions {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisAccountPermissions;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.GenesisAccountPermissions")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GenesisAccountPermissions, V::Error>
+            ) -> core::result::Result<GenesisAccountPermissions, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -440,7 +440,7 @@ impl<'de> serde::Deserialize<'de> for GenesisAccountPermissions {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -465,7 +465,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -483,7 +483,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -494,13 +494,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -522,11 +522,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -562,7 +562,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgAuthorizeCircuitBreaker {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -594,7 +594,7 @@ impl serde::Serialize for MsgAuthorizeCircuitBreaker {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreaker {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -608,7 +608,7 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreaker {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -619,13 +619,13 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreaker {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -644,14 +644,14 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreaker {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgAuthorizeCircuitBreaker;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgAuthorizeCircuitBreaker")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgAuthorizeCircuitBreaker, V::Error>
+            ) -> core::result::Result<MsgAuthorizeCircuitBreaker, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -697,7 +697,7 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreaker {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgAuthorizeCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -717,7 +717,7 @@ impl serde::Serialize for MsgAuthorizeCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -729,7 +729,7 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreakerResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -740,13 +740,13 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreakerResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -763,14 +763,14 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreakerResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgAuthorizeCircuitBreakerResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgAuthorizeCircuitBreakerResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgAuthorizeCircuitBreakerResponse, V::Error>
+            ) -> core::result::Result<MsgAuthorizeCircuitBreakerResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -800,7 +800,7 @@ impl<'de> serde::Deserialize<'de> for MsgAuthorizeCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgResetCircuitBreaker {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -826,7 +826,7 @@ impl serde::Serialize for MsgResetCircuitBreaker {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreaker {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -839,7 +839,7 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreaker {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -850,13 +850,13 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreaker {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -874,14 +874,14 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreaker {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgResetCircuitBreaker;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgResetCircuitBreaker")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgResetCircuitBreaker, V::Error>
+            ) -> core::result::Result<MsgResetCircuitBreaker, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -919,7 +919,7 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreaker {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgResetCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -939,7 +939,7 @@ impl serde::Serialize for MsgResetCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -951,7 +951,7 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreakerResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -962,13 +962,13 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreakerResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -985,14 +985,14 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreakerResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgResetCircuitBreakerResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgResetCircuitBreakerResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgResetCircuitBreakerResponse, V::Error>
+            ) -> core::result::Result<MsgResetCircuitBreakerResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1022,7 +1022,7 @@ impl<'de> serde::Deserialize<'de> for MsgResetCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgTripCircuitBreaker {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1048,7 +1048,7 @@ impl serde::Serialize for MsgTripCircuitBreaker {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreaker {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1061,7 +1061,7 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreaker {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1072,13 +1072,13 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreaker {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1096,14 +1096,14 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreaker {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgTripCircuitBreaker;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgTripCircuitBreaker")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgTripCircuitBreaker, V::Error>
+            ) -> core::result::Result<MsgTripCircuitBreaker, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1141,7 +1141,7 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreaker {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgTripCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1161,7 +1161,7 @@ impl serde::Serialize for MsgTripCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreakerResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1173,7 +1173,7 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreakerResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1184,13 +1184,13 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreakerResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1207,14 +1207,14 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreakerResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgTripCircuitBreakerResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.MsgTripCircuitBreakerResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgTripCircuitBreakerResponse, V::Error>
+            ) -> core::result::Result<MsgTripCircuitBreakerResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1244,7 +1244,7 @@ impl<'de> serde::Deserialize<'de> for MsgTripCircuitBreakerResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Permissions {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1259,7 +1259,7 @@ impl serde::Serialize for Permissions {
         let mut struct_ser = serializer.serialize_struct("cosmos.circuit.v1.Permissions", len)?;
         if self.level != 0 {
             let v = permissions::Level::try_from(self.level).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.level))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.level))
             })?;
             struct_ser.serialize_field("level", &v)?;
         }
@@ -1272,7 +1272,7 @@ impl serde::Serialize for Permissions {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Permissions {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1285,7 +1285,7 @@ impl<'de> serde::Deserialize<'de> for Permissions {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1296,13 +1296,13 @@ impl<'de> serde::Deserialize<'de> for Permissions {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1322,11 +1322,11 @@ impl<'de> serde::Deserialize<'de> for Permissions {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Permissions;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.Permissions")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Permissions, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Permissions, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1360,7 +1360,7 @@ impl<'de> serde::Deserialize<'de> for Permissions {
 #[cfg(feature = "serde")]
 impl serde::Serialize for permissions::Level {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1376,7 +1376,7 @@ impl serde::Serialize for permissions::Level {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for permissions::Level {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1392,11 +1392,11 @@ impl<'de> serde::Deserialize<'de> for permissions::Level {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = permissions::Level;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1408,7 +1408,7 @@ impl<'de> serde::Deserialize<'de> for permissions::Level {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1420,7 +1420,7 @@ impl<'de> serde::Deserialize<'de> for permissions::Level {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1439,7 +1439,7 @@ impl<'de> serde::Deserialize<'de> for permissions::Level {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1459,7 +1459,7 @@ impl serde::Serialize for QueryAccountRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1471,7 +1471,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1482,13 +1482,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1505,11 +1505,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.QueryAccountRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryAccountRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryAccountRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1539,7 +1542,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAccountsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1559,7 +1562,7 @@ impl serde::Serialize for QueryAccountsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1571,7 +1574,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1582,13 +1585,13 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1605,14 +1608,14 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAccountsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.QueryAccountsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAccountsRequest, V::Error>
+            ) -> core::result::Result<QueryAccountsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1642,7 +1645,7 @@ impl<'de> serde::Deserialize<'de> for QueryAccountsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDisabledListRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1656,7 +1659,7 @@ impl serde::Serialize for QueryDisabledListRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDisabledListRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1666,7 +1669,7 @@ impl<'de> serde::Deserialize<'de> for QueryDisabledListRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1677,13 +1680,13 @@ impl<'de> serde::Deserialize<'de> for QueryDisabledListRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1697,14 +1700,14 @@ impl<'de> serde::Deserialize<'de> for QueryDisabledListRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDisabledListRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.circuit.v1.QueryDisabledListRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDisabledListRequest, V::Error>
+            ) -> core::result::Result<QueryDisabledListRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.circuit.v1.tonic.rs
@@ -88,11 +88,11 @@ pub mod query_client {
         pub async fn account(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::AccountResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::AccountResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -105,11 +105,11 @@ pub mod query_client {
         pub async fn accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::AccountsResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::AccountsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -122,12 +122,12 @@ pub mod query_client {
         pub async fn disabled_list(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDisabledListRequest>,
-        ) -> std::result::Result<tonic::Response<super::DisabledListResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::DisabledListResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -151,15 +151,15 @@ pub mod query_server {
         async fn account(
             &self,
             request: tonic::Request<super::QueryAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::AccountResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AccountResponse>, tonic::Status>;
         async fn accounts(
             &self,
             request: tonic::Request<super::QueryAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::AccountsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::AccountsResponse>, tonic::Status>;
         async fn disabled_list(
             &self,
             request: tonic::Request<super::QueryDisabledListRequest>,
-        ) -> std::result::Result<tonic::Response<super::DisabledListResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::DisabledListResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -231,7 +231,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -379,8 +379,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -474,14 +474,14 @@ pub mod msg_client {
         pub async fn authorize_circuit_breaker(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgAuthorizeCircuitBreaker>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgAuthorizeCircuitBreakerResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -498,12 +498,14 @@ pub mod msg_client {
         pub async fn trip_circuit_breaker(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgTripCircuitBreaker>,
-        ) -> std::result::Result<tonic::Response<super::MsgTripCircuitBreakerResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::MsgTripCircuitBreakerResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -519,14 +521,14 @@ pub mod msg_client {
         pub async fn reset_circuit_breaker(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgResetCircuitBreaker>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgResetCircuitBreakerResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -552,18 +554,21 @@ pub mod msg_server {
         async fn authorize_circuit_breaker(
             &self,
             request: tonic::Request<super::MsgAuthorizeCircuitBreaker>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgAuthorizeCircuitBreakerResponse>,
             tonic::Status,
         >;
         async fn trip_circuit_breaker(
             &self,
             request: tonic::Request<super::MsgTripCircuitBreaker>,
-        ) -> std::result::Result<tonic::Response<super::MsgTripCircuitBreakerResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::MsgTripCircuitBreakerResponse>,
+            tonic::Status,
+        >;
         async fn reset_circuit_breaker(
             &self,
             request: tonic::Request<super::MsgResetCircuitBreaker>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgResetCircuitBreakerResponse>,
             tonic::Status,
         >;
@@ -638,7 +643,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -793,8 +798,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -34,7 +34,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -45,13 +45,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -68,11 +68,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.consensus.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -46,7 +46,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -62,7 +62,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -73,13 +73,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -100,11 +100,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.consensus.v1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -166,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -180,7 +180,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -190,7 +190,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -201,13 +201,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -221,14 +221,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.consensus.v1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -248,7 +248,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -262,7 +262,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -272,7 +272,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -283,13 +283,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -303,11 +303,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.consensus.v1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -327,7 +327,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -347,7 +347,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -359,7 +359,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -370,13 +370,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -393,11 +393,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.consensus.v1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.consensus.v1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -116,7 +116,7 @@ pub mod query_server {
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -188,7 +188,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -260,8 +260,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -355,12 +355,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -384,7 +384,7 @@ pub mod msg_server {
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -456,7 +456,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -528,8 +528,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -77,11 +77,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -34,7 +34,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -45,13 +45,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -68,11 +68,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -102,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -128,7 +128,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -141,7 +141,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -152,13 +152,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -176,11 +176,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -218,7 +218,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -232,7 +232,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -242,7 +242,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -253,13 +253,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -273,14 +273,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -300,7 +300,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVerifyInvariant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -332,7 +332,7 @@ impl serde::Serialize for MsgVerifyInvariant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVerifyInvariant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -352,7 +352,7 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -363,13 +363,13 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -392,11 +392,11 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVerifyInvariant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.v1beta1.MsgVerifyInvariant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVerifyInvariant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVerifyInvariant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -444,7 +444,7 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVerifyInvariantResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -458,7 +458,7 @@ impl serde::Serialize for MsgVerifyInvariantResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVerifyInvariantResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -468,7 +468,7 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariantResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -479,13 +479,13 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariantResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -499,14 +499,14 @@ impl<'de> serde::Deserialize<'de> for MsgVerifyInvariantResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVerifyInvariantResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crisis.v1beta1.MsgVerifyInvariantResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgVerifyInvariantResponse, V::Error>
+            ) -> core::result::Result<MsgVerifyInvariantResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crisis.v1beta1.tonic.rs
@@ -85,12 +85,12 @@ pub mod msg_client {
         pub async fn verify_invariant(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVerifyInvariant>,
-        ) -> std::result::Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -135,11 +135,11 @@ pub mod msg_server {
         async fn verify_invariant(
             &self,
             request: tonic::Request<super::MsgVerifyInvariant>,
-        ) -> std::result::Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVerifyInvariantResponse>, tonic::Status>;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -211,7 +211,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -321,8 +321,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.ed25519.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.ed25519.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PrivKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -23,7 +23,7 @@ impl serde::Serialize for PrivKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PrivKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -35,7 +35,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -46,13 +46,13 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -69,11 +69,11 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PrivKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.ed25519.PrivKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PrivKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PrivKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -102,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PubKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -123,7 +123,7 @@ impl serde::Serialize for PubKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PubKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -135,7 +135,7 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -146,13 +146,13 @@ impl<'de> serde::Deserialize<'de> for PubKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -169,11 +169,11 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PubKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.ed25519.PubKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PubKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PubKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.hd.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.hd.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Bip44Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -45,7 +45,7 @@ impl serde::Serialize for Bip44Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Bip44Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -69,7 +69,7 @@ impl<'de> serde::Deserialize<'de> for Bip44Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -80,13 +80,13 @@ impl<'de> serde::Deserialize<'de> for Bip44Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -107,11 +107,11 @@ impl<'de> serde::Deserialize<'de> for Bip44Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Bip44Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.hd.v1.BIP44Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Bip44Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Bip44Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.keyring.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.keyring.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Record {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -46,7 +46,7 @@ impl serde::Serialize for Record {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Record {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -65,7 +65,7 @@ impl<'de> serde::Deserialize<'de> for Record {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -76,13 +76,13 @@ impl<'de> serde::Deserialize<'de> for Record {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -104,11 +104,11 @@ impl<'de> serde::Deserialize<'de> for Record {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Record;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.keyring.v1.Record")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Record, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Record, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -134,7 +134,7 @@ impl<'de> serde::Deserialize<'de> for Record {
                                 return Err(serde::de::Error::duplicate_field("local"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(record::Item::Local);
                         }
                         GeneratedField::Ledger => {
@@ -142,7 +142,7 @@ impl<'de> serde::Deserialize<'de> for Record {
                                 return Err(serde::de::Error::duplicate_field("ledger"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(record::Item::Ledger);
                         }
                         GeneratedField::Multi => {
@@ -150,7 +150,7 @@ impl<'de> serde::Deserialize<'de> for Record {
                                 return Err(serde::de::Error::duplicate_field("multi"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(record::Item::Multi);
                         }
                         GeneratedField::Offline => {
@@ -158,7 +158,7 @@ impl<'de> serde::Deserialize<'de> for Record {
                                 return Err(serde::de::Error::duplicate_field("offline"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(record::Item::Offline);
                         }
                     }
@@ -176,7 +176,7 @@ impl<'de> serde::Deserialize<'de> for Record {
 #[cfg(feature = "serde")]
 impl serde::Serialize for record::Ledger {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -196,7 +196,7 @@ impl serde::Serialize for record::Ledger {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for record::Ledger {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -208,7 +208,7 @@ impl<'de> serde::Deserialize<'de> for record::Ledger {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -219,13 +219,13 @@ impl<'de> serde::Deserialize<'de> for record::Ledger {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -242,11 +242,11 @@ impl<'de> serde::Deserialize<'de> for record::Ledger {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = record::Ledger;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.keyring.v1.Record.Ledger")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<record::Ledger, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<record::Ledger, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -274,7 +274,7 @@ impl<'de> serde::Deserialize<'de> for record::Ledger {
 #[cfg(feature = "serde")]
 impl serde::Serialize for record::Local {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -294,7 +294,7 @@ impl serde::Serialize for record::Local {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for record::Local {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -306,7 +306,7 @@ impl<'de> serde::Deserialize<'de> for record::Local {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -317,13 +317,13 @@ impl<'de> serde::Deserialize<'de> for record::Local {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -340,11 +340,11 @@ impl<'de> serde::Deserialize<'de> for record::Local {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = record::Local;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.keyring.v1.Record.Local")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<record::Local, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<record::Local, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -374,7 +374,7 @@ impl<'de> serde::Deserialize<'de> for record::Local {
 #[cfg(feature = "serde")]
 impl serde::Serialize for record::Multi {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -388,7 +388,7 @@ impl serde::Serialize for record::Multi {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for record::Multi {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -398,7 +398,7 @@ impl<'de> serde::Deserialize<'de> for record::Multi {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -409,13 +409,13 @@ impl<'de> serde::Deserialize<'de> for record::Multi {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -429,11 +429,11 @@ impl<'de> serde::Deserialize<'de> for record::Multi {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = record::Multi;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.keyring.v1.Record.Multi")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<record::Multi, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<record::Multi, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -453,7 +453,7 @@ impl<'de> serde::Deserialize<'de> for record::Multi {
 #[cfg(feature = "serde")]
 impl serde::Serialize for record::Offline {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -467,7 +467,7 @@ impl serde::Serialize for record::Offline {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for record::Offline {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -477,7 +477,7 @@ impl<'de> serde::Deserialize<'de> for record::Offline {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -488,13 +488,13 @@ impl<'de> serde::Deserialize<'de> for record::Offline {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -508,11 +508,11 @@ impl<'de> serde::Deserialize<'de> for record::Offline {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = record::Offline;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.keyring.v1.Record.Offline")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<record::Offline, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<record::Offline, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.multisig.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.multisig.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for LegacyAminoPubKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for LegacyAminoPubKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for LegacyAminoPubKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for LegacyAminoPubKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for LegacyAminoPubKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,11 +76,11 @@ impl<'de> serde::Deserialize<'de> for LegacyAminoPubKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = LegacyAminoPubKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.multisig.LegacyAminoPubKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<LegacyAminoPubKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<LegacyAminoPubKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.multisig.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.multisig.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for CompactBitArray {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -32,7 +32,7 @@ impl serde::Serialize for CompactBitArray {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CompactBitArray {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -45,7 +45,7 @@ impl<'de> serde::Deserialize<'de> for CompactBitArray {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -56,13 +56,13 @@ impl<'de> serde::Deserialize<'de> for CompactBitArray {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -82,11 +82,11 @@ impl<'de> serde::Deserialize<'de> for CompactBitArray {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CompactBitArray;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.multisig.v1beta1.CompactBitArray")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CompactBitArray, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CompactBitArray, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -130,7 +130,7 @@ impl<'de> serde::Deserialize<'de> for CompactBitArray {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MultiSignature {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -148,7 +148,7 @@ impl serde::Serialize for MultiSignature {
                     .signatures
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -157,7 +157,7 @@ impl serde::Serialize for MultiSignature {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MultiSignature {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -169,7 +169,7 @@ impl<'de> serde::Deserialize<'de> for MultiSignature {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -180,13 +180,13 @@ impl<'de> serde::Deserialize<'de> for MultiSignature {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -203,11 +203,11 @@ impl<'de> serde::Deserialize<'de> for MultiSignature {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MultiSignature;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.multisig.v1beta1.MultiSignature")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MultiSignature, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MultiSignature, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -218,12 +218,10 @@ impl<'de> serde::Deserialize<'de> for MultiSignature {
                             if signatures__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("signatures"));
                             }
-                            signatures__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            signatures__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.secp256k1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.secp256k1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PrivKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -23,7 +23,7 @@ impl serde::Serialize for PrivKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PrivKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -35,7 +35,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -46,13 +46,13 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -69,11 +69,11 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PrivKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.secp256k1.PrivKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PrivKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PrivKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -102,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PubKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -123,7 +123,7 @@ impl serde::Serialize for PubKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PubKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -135,7 +135,7 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -146,13 +146,13 @@ impl<'de> serde::Deserialize<'de> for PubKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -169,11 +169,11 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PubKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.secp256k1.PubKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PubKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PubKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.secp256r1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.crypto.secp256r1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PrivKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -25,7 +25,7 @@ impl serde::Serialize for PrivKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PrivKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -37,7 +37,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -48,13 +48,13 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -71,11 +71,11 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PrivKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.secp256r1.PrivKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PrivKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PrivKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -104,7 +104,7 @@ impl<'de> serde::Deserialize<'de> for PrivKey {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PubKey {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -125,7 +125,7 @@ impl serde::Serialize for PubKey {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PubKey {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -137,7 +137,7 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -148,13 +148,13 @@ impl<'de> serde::Deserialize<'de> for PubKey {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -171,11 +171,11 @@ impl<'de> serde::Deserialize<'de> for PubKey {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PubKey;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.crypto.secp256r1.PubKey")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PubKey, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PubKey, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -78,11 +78,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for CommunityPoolSpendProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -42,7 +42,7 @@ impl serde::Serialize for CommunityPoolSpendProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -57,7 +57,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -68,13 +68,13 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -94,14 +94,14 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommunityPoolSpendProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.CommunityPoolSpendProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<CommunityPoolSpendProposal, V::Error>
+            ) -> core::result::Result<CommunityPoolSpendProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -155,7 +155,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CommunityPoolSpendProposalWithDeposit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -201,7 +201,7 @@ impl serde::Serialize for CommunityPoolSpendProposalWithDeposit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -217,7 +217,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -228,13 +228,13 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -255,7 +255,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommunityPoolSpendProposalWithDeposit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.CommunityPoolSpendProposalWithDeposit",
                 )
@@ -264,7 +264,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<CommunityPoolSpendProposalWithDeposit, V::Error>
+            ) -> core::result::Result<CommunityPoolSpendProposalWithDeposit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -326,7 +326,7 @@ impl<'de> serde::Deserialize<'de> for CommunityPoolSpendProposalWithDeposit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelegationDelegatorReward {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -352,7 +352,7 @@ impl serde::Serialize for DelegationDelegatorReward {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelegationDelegatorReward {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -365,7 +365,7 @@ impl<'de> serde::Deserialize<'de> for DelegationDelegatorReward {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -376,13 +376,13 @@ impl<'de> serde::Deserialize<'de> for DelegationDelegatorReward {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -402,14 +402,14 @@ impl<'de> serde::Deserialize<'de> for DelegationDelegatorReward {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelegationDelegatorReward;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.DelegationDelegatorReward")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DelegationDelegatorReward, V::Error>
+            ) -> core::result::Result<DelegationDelegatorReward, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -447,7 +447,7 @@ impl<'de> serde::Deserialize<'de> for DelegationDelegatorReward {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelegatorStartingInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -468,7 +468,7 @@ impl serde::Serialize for DelegatorStartingInfo {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "previousPeriod",
-                ToString::to_string(&self.previous_period).as_str(),
+                alloc::string::ToString::to_string(&self.previous_period).as_str(),
             )?;
         }
         if !self.stake.is_empty() {
@@ -476,7 +476,10 @@ impl serde::Serialize for DelegatorStartingInfo {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -484,7 +487,7 @@ impl serde::Serialize for DelegatorStartingInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelegatorStartingInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -498,7 +501,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -509,13 +512,13 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -536,14 +539,14 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelegatorStartingInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.DelegatorStartingInfo")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DelegatorStartingInfo, V::Error>
+            ) -> core::result::Result<DelegatorStartingInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -595,7 +598,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelegatorStartingInfoRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -629,7 +632,7 @@ impl serde::Serialize for DelegatorStartingInfoRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -650,7 +653,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -661,13 +664,13 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -690,7 +693,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelegatorStartingInfoRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.DelegatorStartingInfoRecord")
             }
@@ -698,7 +701,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DelegatorStartingInfoRecord, V::Error>
+            ) -> core::result::Result<DelegatorStartingInfoRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -744,7 +747,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorStartingInfoRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelegatorWithdrawInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -770,7 +773,7 @@ impl serde::Serialize for DelegatorWithdrawInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelegatorWithdrawInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -788,7 +791,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorWithdrawInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -799,13 +802,13 @@ impl<'de> serde::Deserialize<'de> for DelegatorWithdrawInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -827,14 +830,14 @@ impl<'de> serde::Deserialize<'de> for DelegatorWithdrawInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelegatorWithdrawInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.DelegatorWithdrawInfo")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DelegatorWithdrawInfo, V::Error>
+            ) -> core::result::Result<DelegatorWithdrawInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -872,7 +875,7 @@ impl<'de> serde::Deserialize<'de> for DelegatorWithdrawInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for FeePool {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -892,7 +895,7 @@ impl serde::Serialize for FeePool {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for FeePool {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -904,7 +907,7 @@ impl<'de> serde::Deserialize<'de> for FeePool {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -915,13 +918,13 @@ impl<'de> serde::Deserialize<'de> for FeePool {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -938,11 +941,11 @@ impl<'de> serde::Deserialize<'de> for FeePool {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = FeePool;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.FeePool")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FeePool, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<FeePool, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -972,7 +975,7 @@ impl<'de> serde::Deserialize<'de> for FeePool {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1053,7 +1056,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1094,7 +1097,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1105,13 +1108,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1154,11 +1157,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1276,7 +1279,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCommunityPoolSpend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1308,7 +1311,7 @@ impl serde::Serialize for MsgCommunityPoolSpend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1322,7 +1325,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1333,13 +1336,13 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1358,14 +1361,14 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCommunityPoolSpend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgCommunityPoolSpend")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCommunityPoolSpend, V::Error>
+            ) -> core::result::Result<MsgCommunityPoolSpend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1411,7 +1414,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCommunityPoolSpendResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1427,7 +1430,7 @@ impl serde::Serialize for MsgCommunityPoolSpendResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1437,7 +1440,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1448,13 +1451,13 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1468,7 +1471,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCommunityPoolSpendResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.MsgCommunityPoolSpendResponse")
             }
@@ -1476,7 +1479,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCommunityPoolSpendResponse, V::Error>
+            ) -> core::result::Result<MsgCommunityPoolSpendResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1496,7 +1499,7 @@ impl<'de> serde::Deserialize<'de> for MsgCommunityPoolSpendResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDepositValidatorRewardsPool {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1530,7 +1533,7 @@ impl serde::Serialize for MsgDepositValidatorRewardsPool {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1549,7 +1552,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1560,13 +1563,13 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1587,7 +1590,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDepositValidatorRewardsPool;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.MsgDepositValidatorRewardsPool")
             }
@@ -1595,7 +1598,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgDepositValidatorRewardsPool, V::Error>
+            ) -> core::result::Result<MsgDepositValidatorRewardsPool, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1641,7 +1644,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPool {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDepositValidatorRewardsPoolResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1657,7 +1660,7 @@ impl serde::Serialize for MsgDepositValidatorRewardsPoolResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1667,7 +1670,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1678,13 +1681,13 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1698,7 +1701,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDepositValidatorRewardsPoolResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.MsgDepositValidatorRewardsPoolResponse",
                 )
@@ -1707,7 +1710,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgDepositValidatorRewardsPoolResponse, V::Error>
+            ) -> core::result::Result<MsgDepositValidatorRewardsPoolResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1727,7 +1730,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositValidatorRewardsPoolResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgFundCommunityPool {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1753,7 +1756,7 @@ impl serde::Serialize for MsgFundCommunityPool {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgFundCommunityPool {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1766,7 +1769,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPool {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1777,13 +1780,13 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPool {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1801,14 +1804,14 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPool {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgFundCommunityPool;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgFundCommunityPool")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgFundCommunityPool, V::Error>
+            ) -> core::result::Result<MsgFundCommunityPool, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1846,7 +1849,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPool {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgFundCommunityPoolResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1862,7 +1865,7 @@ impl serde::Serialize for MsgFundCommunityPoolResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1872,7 +1875,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1883,13 +1886,13 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1903,7 +1906,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgFundCommunityPoolResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.MsgFundCommunityPoolResponse")
             }
@@ -1911,7 +1914,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgFundCommunityPoolResponse, V::Error>
+            ) -> core::result::Result<MsgFundCommunityPoolResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1931,7 +1934,7 @@ impl<'de> serde::Deserialize<'de> for MsgFundCommunityPoolResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSetWithdrawAddress {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1957,7 +1960,7 @@ impl serde::Serialize for MsgSetWithdrawAddress {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddress {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1975,7 +1978,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddress {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1986,13 +1989,13 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddress {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2014,14 +2017,14 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddress {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSetWithdrawAddress;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgSetWithdrawAddress")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSetWithdrawAddress, V::Error>
+            ) -> core::result::Result<MsgSetWithdrawAddress, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2059,7 +2062,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddress {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSetWithdrawAddressResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2075,7 +2078,7 @@ impl serde::Serialize for MsgSetWithdrawAddressResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2085,7 +2088,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2096,13 +2099,13 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2116,7 +2119,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSetWithdrawAddressResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.MsgSetWithdrawAddressResponse")
             }
@@ -2124,7 +2127,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSetWithdrawAddressResponse, V::Error>
+            ) -> core::result::Result<MsgSetWithdrawAddressResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2144,7 +2147,7 @@ impl<'de> serde::Deserialize<'de> for MsgSetWithdrawAddressResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2170,7 +2173,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2183,7 +2186,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2194,13 +2197,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2218,11 +2221,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2260,7 +2263,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2274,7 +2277,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2284,7 +2287,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2295,13 +2298,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2315,14 +2318,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2342,7 +2345,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawDelegatorReward {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2370,7 +2373,7 @@ impl serde::Serialize for MsgWithdrawDelegatorReward {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorReward {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2388,7 +2391,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorReward {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2399,13 +2402,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorReward {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2427,14 +2430,14 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorReward {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawDelegatorReward;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgWithdrawDelegatorReward, V::Error>
+            ) -> core::result::Result<MsgWithdrawDelegatorReward, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2472,7 +2475,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorReward {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawDelegatorRewardResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2494,7 +2497,7 @@ impl serde::Serialize for MsgWithdrawDelegatorRewardResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2506,7 +2509,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2517,13 +2520,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2540,7 +2543,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawDelegatorRewardResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.MsgWithdrawDelegatorRewardResponse",
                 )
@@ -2549,7 +2552,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgWithdrawDelegatorRewardResponse, V::Error>
+            ) -> core::result::Result<MsgWithdrawDelegatorRewardResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2579,7 +2582,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawDelegatorRewardResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawValidatorCommission {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2601,7 +2604,7 @@ impl serde::Serialize for MsgWithdrawValidatorCommission {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2613,7 +2616,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2624,13 +2627,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2649,7 +2652,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawValidatorCommission;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission")
             }
@@ -2657,7 +2660,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgWithdrawValidatorCommission, V::Error>
+            ) -> core::result::Result<MsgWithdrawValidatorCommission, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2687,7 +2690,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommission {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawValidatorCommissionResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2709,7 +2712,7 @@ impl serde::Serialize for MsgWithdrawValidatorCommissionResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2721,7 +2724,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2732,13 +2735,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2755,7 +2758,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawValidatorCommissionResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.MsgWithdrawValidatorCommissionResponse",
                 )
@@ -2764,7 +2767,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgWithdrawValidatorCommissionResponse, V::Error>
+            ) -> core::result::Result<MsgWithdrawValidatorCommissionResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2794,7 +2797,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawValidatorCommissionResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2832,7 +2835,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2856,7 +2859,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2867,13 +2870,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2899,11 +2902,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2963,7 +2966,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCommunityPoolRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2977,7 +2980,7 @@ impl serde::Serialize for QueryCommunityPoolRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCommunityPoolRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2987,7 +2990,7 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2998,13 +3001,13 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3018,14 +3021,14 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCommunityPoolRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.QueryCommunityPoolRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryCommunityPoolRequest, V::Error>
+            ) -> core::result::Result<QueryCommunityPoolRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3045,7 +3048,7 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCommunityPoolResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3067,7 +3070,7 @@ impl serde::Serialize for QueryCommunityPoolResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCommunityPoolResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3079,7 +3082,7 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3090,13 +3093,13 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3113,14 +3116,14 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCommunityPoolResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.QueryCommunityPoolResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryCommunityPoolResponse, V::Error>
+            ) -> core::result::Result<QueryCommunityPoolResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3150,7 +3153,7 @@ impl<'de> serde::Deserialize<'de> for QueryCommunityPoolResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationRewardsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3178,7 +3181,7 @@ impl serde::Serialize for QueryDelegationRewardsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3196,7 +3199,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3207,13 +3210,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3235,7 +3238,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationRewardsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryDelegationRewardsRequest")
             }
@@ -3243,7 +3246,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationRewardsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegationRewardsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3281,7 +3284,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationRewardsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3303,7 +3306,7 @@ impl serde::Serialize for QueryDelegationRewardsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3315,7 +3318,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3326,13 +3329,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3349,7 +3352,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationRewardsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryDelegationRewardsResponse")
             }
@@ -3357,7 +3360,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationRewardsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegationRewardsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3387,7 +3390,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRewardsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationTotalRewardsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3409,7 +3412,7 @@ impl serde::Serialize for QueryDelegationTotalRewardsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3421,7 +3424,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3432,13 +3435,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3457,7 +3460,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationTotalRewardsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryDelegationTotalRewardsRequest",
                 )
@@ -3466,7 +3469,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationTotalRewardsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegationTotalRewardsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3496,7 +3499,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationTotalRewardsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3524,7 +3527,7 @@ impl serde::Serialize for QueryDelegationTotalRewardsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3537,7 +3540,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3548,13 +3551,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3572,7 +3575,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationTotalRewardsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryDelegationTotalRewardsResponse",
                 )
@@ -3581,7 +3584,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationTotalRewardsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegationTotalRewardsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3619,7 +3622,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationTotalRewardsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3641,7 +3644,7 @@ impl serde::Serialize for QueryDelegatorValidatorsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3653,7 +3656,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3664,13 +3667,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3689,7 +3692,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryDelegatorValidatorsRequest")
             }
@@ -3697,7 +3700,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3727,7 +3730,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3749,7 +3752,7 @@ impl serde::Serialize for QueryDelegatorValidatorsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3761,7 +3764,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3772,13 +3775,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3795,7 +3798,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryDelegatorValidatorsResponse",
                 )
@@ -3804,7 +3807,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3834,7 +3837,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorWithdrawAddressRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3856,7 +3859,7 @@ impl serde::Serialize for QueryDelegatorWithdrawAddressRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3868,7 +3871,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3879,13 +3882,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3904,7 +3907,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorWithdrawAddressRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressRequest",
                 )
@@ -3913,7 +3916,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorWithdrawAddressRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorWithdrawAddressRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3943,7 +3946,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorWithdrawAddressResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3965,7 +3968,7 @@ impl serde::Serialize for QueryDelegatorWithdrawAddressResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3977,7 +3980,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3988,13 +3991,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4013,7 +4016,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorWithdrawAddressResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressResponse",
                 )
@@ -4022,7 +4025,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorWithdrawAddressResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorWithdrawAddressResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4052,7 +4055,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorWithdrawAddressResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4066,7 +4069,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4076,7 +4079,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4087,13 +4090,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4107,11 +4110,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4131,7 +4134,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4151,7 +4154,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4163,7 +4166,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4174,13 +4177,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4197,11 +4200,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4229,7 +4235,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorCommissionRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4251,7 +4257,7 @@ impl serde::Serialize for QueryValidatorCommissionRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4263,7 +4269,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4274,13 +4280,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4299,7 +4305,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorCommissionRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryValidatorCommissionRequest")
             }
@@ -4307,7 +4313,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorCommissionRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorCommissionRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4337,7 +4343,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorCommissionResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4359,7 +4365,7 @@ impl serde::Serialize for QueryValidatorCommissionResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4371,7 +4377,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4382,13 +4388,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4405,7 +4411,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorCommissionResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryValidatorCommissionResponse",
                 )
@@ -4414,7 +4420,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorCommissionResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorCommissionResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4444,7 +4450,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorCommissionResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorDistributionInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4466,7 +4472,7 @@ impl serde::Serialize for QueryValidatorDistributionInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4478,7 +4484,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4489,13 +4495,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4514,7 +4520,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorDistributionInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryValidatorDistributionInfoRequest",
                 )
@@ -4523,7 +4529,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorDistributionInfoRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorDistributionInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4553,7 +4559,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorDistributionInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4587,7 +4593,7 @@ impl serde::Serialize for QueryValidatorDistributionInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4607,7 +4613,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4618,13 +4624,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4647,7 +4653,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorDistributionInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse",
                 )
@@ -4656,7 +4662,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorDistributionInfoResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorDistributionInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4702,7 +4708,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDistributionInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorOutstandingRewardsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4724,7 +4730,7 @@ impl serde::Serialize for QueryValidatorOutstandingRewardsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4736,7 +4742,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4747,13 +4753,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4772,7 +4778,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorOutstandingRewardsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsRequest",
                 )
@@ -4781,7 +4787,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorOutstandingRewardsRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorOutstandingRewardsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4811,7 +4817,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorOutstandingRewardsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4833,7 +4839,7 @@ impl serde::Serialize for QueryValidatorOutstandingRewardsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4845,7 +4851,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4856,13 +4862,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4879,7 +4885,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorOutstandingRewardsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsResponse",
                 )
@@ -4888,7 +4894,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorOutstandingRewardsResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorOutstandingRewardsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4916,7 +4922,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorOutstandingRewardsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorSlashesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4945,14 +4951,14 @@ impl serde::Serialize for QueryValidatorSlashesRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "startingHeight",
-                ToString::to_string(&self.starting_height).as_str(),
+                alloc::string::ToString::to_string(&self.starting_height).as_str(),
             )?;
         }
         if self.ending_height != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "endingHeight",
-                ToString::to_string(&self.ending_height).as_str(),
+                alloc::string::ToString::to_string(&self.ending_height).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -4964,7 +4970,7 @@ impl serde::Serialize for QueryValidatorSlashesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4987,7 +4993,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4998,13 +5004,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5028,7 +5034,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorSlashesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryValidatorSlashesRequest")
             }
@@ -5036,7 +5042,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorSlashesRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorSlashesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5096,7 +5102,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorSlashesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5124,7 +5130,7 @@ impl serde::Serialize for QueryValidatorSlashesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5137,7 +5143,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5148,13 +5154,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5172,7 +5178,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorSlashesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.QueryValidatorSlashesResponse")
             }
@@ -5180,7 +5186,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorSlashesResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorSlashesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5218,7 +5224,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorSlashesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorAccumulatedCommission {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5240,7 +5246,7 @@ impl serde::Serialize for ValidatorAccumulatedCommission {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5252,7 +5258,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5263,13 +5269,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5286,7 +5292,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorAccumulatedCommission;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.ValidatorAccumulatedCommission")
             }
@@ -5294,7 +5300,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorAccumulatedCommission, V::Error>
+            ) -> core::result::Result<ValidatorAccumulatedCommission, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5324,7 +5330,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommission {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorAccumulatedCommissionRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5352,7 +5358,7 @@ impl serde::Serialize for ValidatorAccumulatedCommissionRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5365,7 +5371,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5376,13 +5382,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5402,7 +5408,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorAccumulatedCommissionRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.ValidatorAccumulatedCommissionRecord",
                 )
@@ -5411,7 +5417,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorAccumulatedCommissionRecord, V::Error>
+            ) -> core::result::Result<ValidatorAccumulatedCommissionRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5449,7 +5455,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorAccumulatedCommissionRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorCurrentRewards {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5468,7 +5474,10 @@ impl serde::Serialize for ValidatorCurrentRewards {
         }
         if self.period != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("period", ToString::to_string(&self.period).as_str())?;
+            struct_ser.serialize_field(
+                "period",
+                alloc::string::ToString::to_string(&self.period).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -5476,7 +5485,7 @@ impl serde::Serialize for ValidatorCurrentRewards {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewards {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5489,7 +5498,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewards {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5500,13 +5509,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewards {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5524,14 +5533,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewards {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorCurrentRewards;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.ValidatorCurrentRewards")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorCurrentRewards, V::Error>
+            ) -> core::result::Result<ValidatorCurrentRewards, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5572,7 +5581,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewards {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorCurrentRewardsRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5600,7 +5609,7 @@ impl serde::Serialize for ValidatorCurrentRewardsRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5613,7 +5622,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5624,13 +5633,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5650,7 +5659,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorCurrentRewardsRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.ValidatorCurrentRewardsRecord")
             }
@@ -5658,7 +5667,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorCurrentRewardsRecord, V::Error>
+            ) -> core::result::Result<ValidatorCurrentRewardsRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5696,7 +5705,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorCurrentRewardsRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorHistoricalRewards {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5724,7 +5733,7 @@ impl serde::Serialize for ValidatorHistoricalRewards {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewards {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5742,7 +5751,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewards {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5753,13 +5762,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewards {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5781,14 +5790,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewards {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorHistoricalRewards;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.ValidatorHistoricalRewards")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorHistoricalRewards, V::Error>
+            ) -> core::result::Result<ValidatorHistoricalRewards, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5831,7 +5840,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewards {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorHistoricalRewardsRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5855,7 +5864,10 @@ impl serde::Serialize for ValidatorHistoricalRewardsRecord {
         }
         if self.period != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("period", ToString::to_string(&self.period).as_str())?;
+            struct_ser.serialize_field(
+                "period",
+                alloc::string::ToString::to_string(&self.period).as_str(),
+            )?;
         }
         if let Some(v) = self.rewards.as_ref() {
             struct_ser.serialize_field("rewards", v)?;
@@ -5866,7 +5878,7 @@ impl serde::Serialize for ValidatorHistoricalRewardsRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5880,7 +5892,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5891,13 +5903,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5918,7 +5930,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorHistoricalRewardsRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.ValidatorHistoricalRewardsRecord",
                 )
@@ -5927,7 +5939,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorHistoricalRewardsRecord, V::Error>
+            ) -> core::result::Result<ValidatorHistoricalRewardsRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5976,7 +5988,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorHistoricalRewardsRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorOutstandingRewards {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5998,7 +6010,7 @@ impl serde::Serialize for ValidatorOutstandingRewards {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6010,7 +6022,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6021,13 +6033,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6044,7 +6056,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorOutstandingRewards;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.distribution.v1beta1.ValidatorOutstandingRewards")
             }
@@ -6052,7 +6064,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorOutstandingRewards, V::Error>
+            ) -> core::result::Result<ValidatorOutstandingRewards, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6082,7 +6094,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewards {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorOutstandingRewardsRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6110,7 +6122,7 @@ impl serde::Serialize for ValidatorOutstandingRewardsRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6128,7 +6140,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6139,13 +6151,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6167,7 +6179,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorOutstandingRewardsRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.distribution.v1beta1.ValidatorOutstandingRewardsRecord",
                 )
@@ -6176,7 +6188,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorOutstandingRewardsRecord, V::Error>
+            ) -> core::result::Result<ValidatorOutstandingRewardsRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6216,7 +6228,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorOutstandingRewardsRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorSlashEvent {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6234,7 +6246,7 @@ impl serde::Serialize for ValidatorSlashEvent {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "validatorPeriod",
-                ToString::to_string(&self.validator_period).as_str(),
+                alloc::string::ToString::to_string(&self.validator_period).as_str(),
             )?;
         }
         if !self.fraction.is_empty() {
@@ -6246,7 +6258,7 @@ impl serde::Serialize for ValidatorSlashEvent {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorSlashEvent {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6259,7 +6271,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvent {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6270,13 +6282,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvent {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6296,11 +6308,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvent {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorSlashEvent;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.ValidatorSlashEvent")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ValidatorSlashEvent, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<ValidatorSlashEvent, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6341,7 +6356,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvent {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorSlashEventRecord {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6366,11 +6381,17 @@ impl serde::Serialize for ValidatorSlashEventRecord {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if self.period != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("period", ToString::to_string(&self.period).as_str())?;
+            struct_ser.serialize_field(
+                "period",
+                alloc::string::ToString::to_string(&self.period).as_str(),
+            )?;
         }
         if let Some(v) = self.validator_slash_event.as_ref() {
             struct_ser.serialize_field("validatorSlashEvent", v)?;
@@ -6381,7 +6402,7 @@ impl serde::Serialize for ValidatorSlashEventRecord {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorSlashEventRecord {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6403,7 +6424,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEventRecord {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6414,13 +6435,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEventRecord {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6444,14 +6465,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEventRecord {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorSlashEventRecord;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.ValidatorSlashEventRecord")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorSlashEventRecord, V::Error>
+            ) -> core::result::Result<ValidatorSlashEventRecord, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6513,7 +6534,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEventRecord {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorSlashEvents {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6533,7 +6554,7 @@ impl serde::Serialize for ValidatorSlashEvents {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorSlashEvents {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6545,7 +6566,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvents {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6556,13 +6577,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvents {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6581,14 +6602,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorSlashEvents {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorSlashEvents;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.distribution.v1beta1.ValidatorSlashEvents")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorSlashEvents, V::Error>
+            ) -> core::result::Result<ValidatorSlashEvents, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.distribution.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -109,14 +109,14 @@ pub mod query_client {
         pub async fn validator_distribution_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorDistributionInfoRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorDistributionInfoResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -133,14 +133,14 @@ pub mod query_client {
         pub async fn validator_outstanding_rewards(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorOutstandingRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -157,14 +157,14 @@ pub mod query_client {
         pub async fn validator_commission(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorCommissionRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorCommissionResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -181,12 +181,14 @@ pub mod query_client {
         pub async fn validator_slashes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorSlashesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorSlashesResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::QueryValidatorSlashesResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -203,14 +205,14 @@ pub mod query_client {
         pub async fn delegation_rewards(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegationRewardsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -227,14 +229,14 @@ pub mod query_client {
         pub async fn delegation_total_rewards(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationTotalRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegationTotalRewardsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -251,14 +253,14 @@ pub mod query_client {
         pub async fn delegator_validators(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -275,14 +277,14 @@ pub mod query_client {
         pub async fn delegator_withdraw_address(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorWithdrawAddressRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -299,12 +301,12 @@ pub mod query_client {
         pub async fn community_pool(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCommunityPoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCommunityPoolResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryCommunityPoolResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -331,64 +333,67 @@ pub mod query_server {
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn validator_distribution_info(
             &self,
             request: tonic::Request<super::QueryValidatorDistributionInfoRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorDistributionInfoResponse>,
             tonic::Status,
         >;
         async fn validator_outstanding_rewards(
             &self,
             request: tonic::Request<super::QueryValidatorOutstandingRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorOutstandingRewardsResponse>,
             tonic::Status,
         >;
         async fn validator_commission(
             &self,
             request: tonic::Request<super::QueryValidatorCommissionRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorCommissionResponse>,
             tonic::Status,
         >;
         async fn validator_slashes(
             &self,
             request: tonic::Request<super::QueryValidatorSlashesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorSlashesResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::QueryValidatorSlashesResponse>,
+            tonic::Status,
+        >;
         async fn delegation_rewards(
             &self,
             request: tonic::Request<super::QueryDelegationRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegationRewardsResponse>,
             tonic::Status,
         >;
         async fn delegation_total_rewards(
             &self,
             request: tonic::Request<super::QueryDelegationTotalRewardsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegationTotalRewardsResponse>,
             tonic::Status,
         >;
         async fn delegator_validators(
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorsResponse>,
             tonic::Status,
         >;
         async fn delegator_withdraw_address(
             &self,
             request: tonic::Request<super::QueryDelegatorWithdrawAddressRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorWithdrawAddressResponse>,
             tonic::Status,
         >;
         async fn community_pool(
             &self,
             request: tonic::Request<super::QueryCommunityPoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCommunityPoolResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryCommunityPoolResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -460,7 +465,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -903,8 +908,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -998,12 +1003,14 @@ pub mod msg_client {
         pub async fn set_withdraw_address(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSetWithdrawAddress>,
-        ) -> std::result::Result<tonic::Response<super::MsgSetWithdrawAddressResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::MsgSetWithdrawAddressResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1020,14 +1027,14 @@ pub mod msg_client {
         pub async fn withdraw_delegator_reward(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgWithdrawDelegatorReward>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1044,14 +1051,14 @@ pub mod msg_client {
         pub async fn withdraw_validator_commission(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgWithdrawValidatorCommission>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1068,12 +1075,12 @@ pub mod msg_client {
         pub async fn fund_community_pool(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgFundCommunityPool>,
-        ) -> std::result::Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1090,12 +1097,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1112,12 +1119,14 @@ pub mod msg_client {
         pub async fn community_pool_spend(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCommunityPoolSpend>,
-        ) -> std::result::Result<tonic::Response<super::MsgCommunityPoolSpendResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::MsgCommunityPoolSpendResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1134,14 +1143,14 @@ pub mod msg_client {
         pub async fn deposit_validator_rewards_pool(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgDepositValidatorRewardsPool>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgDepositValidatorRewardsPoolResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1168,37 +1177,43 @@ pub mod msg_server {
         async fn set_withdraw_address(
             &self,
             request: tonic::Request<super::MsgSetWithdrawAddress>,
-        ) -> std::result::Result<tonic::Response<super::MsgSetWithdrawAddressResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::MsgSetWithdrawAddressResponse>,
+            tonic::Status,
+        >;
         async fn withdraw_delegator_reward(
             &self,
             request: tonic::Request<super::MsgWithdrawDelegatorReward>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgWithdrawDelegatorRewardResponse>,
             tonic::Status,
         >;
         async fn withdraw_validator_commission(
             &self,
             request: tonic::Request<super::MsgWithdrawValidatorCommission>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgWithdrawValidatorCommissionResponse>,
             tonic::Status,
         >;
         async fn fund_community_pool(
             &self,
             request: tonic::Request<super::MsgFundCommunityPool>,
-        ) -> std::result::Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgFundCommunityPoolResponse>, tonic::Status>;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
         async fn community_pool_spend(
             &self,
             request: tonic::Request<super::MsgCommunityPoolSpend>,
-        ) -> std::result::Result<tonic::Response<super::MsgCommunityPoolSpendResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::MsgCommunityPoolSpendResponse>,
+            tonic::Status,
+        >;
         async fn deposit_validator_rewards_pool(
             &self,
             request: tonic::Request<super::MsgDepositValidatorRewardsPool>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgDepositValidatorRewardsPoolResponse>,
             tonic::Status,
         >;
@@ -1273,7 +1288,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1588,8 +1603,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Equivocation {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -24,14 +24,20 @@ impl serde::Serialize for Equivocation {
             serializer.serialize_struct("cosmos.evidence.v1beta1.Equivocation", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if let Some(v) = self.time.as_ref() {
             struct_ser.serialize_field("time", v)?;
         }
         if self.power != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("power", ToString::to_string(&self.power).as_str())?;
+            struct_ser.serialize_field(
+                "power",
+                alloc::string::ToString::to_string(&self.power).as_str(),
+            )?;
         }
         if !self.consensus_address.is_empty() {
             struct_ser.serialize_field("consensusAddress", &self.consensus_address)?;
@@ -42,7 +48,7 @@ impl serde::Serialize for Equivocation {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Equivocation {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -63,7 +69,7 @@ impl<'de> serde::Deserialize<'de> for Equivocation {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -74,13 +80,13 @@ impl<'de> serde::Deserialize<'de> for Equivocation {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -102,11 +108,11 @@ impl<'de> serde::Deserialize<'de> for Equivocation {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Equivocation;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.Equivocation")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Equivocation, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Equivocation, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -166,7 +172,7 @@ impl<'de> serde::Deserialize<'de> for Equivocation {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -186,7 +192,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -198,7 +204,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -209,13 +215,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -232,11 +238,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -266,7 +272,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitEvidence {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -292,7 +298,7 @@ impl serde::Serialize for MsgSubmitEvidence {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitEvidence {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -305,7 +311,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidence {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -316,13 +322,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidence {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -340,11 +346,11 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidence {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitEvidence;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.MsgSubmitEvidence")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSubmitEvidence, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSubmitEvidence, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -382,7 +388,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidence {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitEvidenceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -404,7 +410,7 @@ impl serde::Serialize for MsgSubmitEvidenceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitEvidenceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -416,7 +422,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidenceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -427,13 +433,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidenceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -450,14 +456,14 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidenceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitEvidenceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.MsgSubmitEvidenceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSubmitEvidenceResponse, V::Error>
+            ) -> core::result::Result<MsgSubmitEvidenceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -490,7 +496,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitEvidenceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllEvidenceRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -510,7 +516,7 @@ impl serde::Serialize for QueryAllEvidenceRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllEvidenceRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -522,7 +528,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -533,13 +539,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -556,14 +562,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllEvidenceRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.QueryAllEvidenceRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllEvidenceRequest, V::Error>
+            ) -> core::result::Result<QueryAllEvidenceRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -593,7 +599,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllEvidenceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -619,7 +625,7 @@ impl serde::Serialize for QueryAllEvidenceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllEvidenceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -632,7 +638,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -643,13 +649,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -667,14 +673,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllEvidenceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.QueryAllEvidenceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllEvidenceResponse, V::Error>
+            ) -> core::result::Result<QueryAllEvidenceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -712,7 +718,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllEvidenceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryEvidenceRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -742,7 +748,7 @@ impl serde::Serialize for QueryEvidenceRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -755,7 +761,7 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -766,13 +772,13 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -790,14 +796,14 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryEvidenceRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.QueryEvidenceRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryEvidenceRequest, V::Error>
+            ) -> core::result::Result<QueryEvidenceRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -838,7 +844,7 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryEvidenceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -858,7 +864,7 @@ impl serde::Serialize for QueryEvidenceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryEvidenceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -870,7 +876,7 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -881,13 +887,13 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -904,14 +910,14 @@ impl<'de> serde::Deserialize<'de> for QueryEvidenceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryEvidenceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.evidence.v1beta1.QueryEvidenceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryEvidenceResponse, V::Error>
+            ) -> core::result::Result<QueryEvidenceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.evidence.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn evidence(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryEvidenceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryEvidenceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryEvidenceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -107,12 +107,12 @@ pub mod query_client {
         pub async fn all_evidence(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllEvidenceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllEvidenceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAllEvidenceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -138,11 +138,11 @@ pub mod query_server {
         async fn evidence(
             &self,
             request: tonic::Request<super::QueryEvidenceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryEvidenceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryEvidenceResponse>, tonic::Status>;
         async fn all_evidence(
             &self,
             request: tonic::Request<super::QueryAllEvidenceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllEvidenceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAllEvidenceResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -214,7 +214,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -324,8 +324,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -419,12 +419,12 @@ pub mod msg_client {
         pub async fn submit_evidence(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSubmitEvidence>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -450,7 +450,7 @@ pub mod msg_server {
         async fn submit_evidence(
             &self,
             request: tonic::Request<super::MsgSubmitEvidence>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitEvidenceResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -522,7 +522,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -594,8 +594,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AllowedMsgAllowance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for AllowedMsgAllowance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AllowedMsgAllowance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for AllowedMsgAllowance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for AllowedMsgAllowance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -78,11 +78,14 @@ impl<'de> serde::Deserialize<'de> for AllowedMsgAllowance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AllowedMsgAllowance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.AllowedMsgAllowance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AllowedMsgAllowance, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<AllowedMsgAllowance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -120,7 +123,7 @@ impl<'de> serde::Deserialize<'de> for AllowedMsgAllowance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BasicAllowance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -146,7 +149,7 @@ impl serde::Serialize for BasicAllowance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BasicAllowance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -159,7 +162,7 @@ impl<'de> serde::Deserialize<'de> for BasicAllowance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -170,13 +173,13 @@ impl<'de> serde::Deserialize<'de> for BasicAllowance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -194,11 +197,11 @@ impl<'de> serde::Deserialize<'de> for BasicAllowance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BasicAllowance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.BasicAllowance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BasicAllowance, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<BasicAllowance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -236,7 +239,7 @@ impl<'de> serde::Deserialize<'de> for BasicAllowance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -256,7 +259,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -268,7 +271,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -279,13 +282,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -302,11 +305,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -336,7 +339,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Grant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -367,7 +370,7 @@ impl serde::Serialize for Grant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Grant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -381,7 +384,7 @@ impl<'de> serde::Deserialize<'de> for Grant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -392,13 +395,13 @@ impl<'de> serde::Deserialize<'de> for Grant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -417,11 +420,11 @@ impl<'de> serde::Deserialize<'de> for Grant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Grant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.Grant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Grant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Grant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -463,7 +466,7 @@ impl<'de> serde::Deserialize<'de> for Grant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgGrantAllowance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -495,7 +498,7 @@ impl serde::Serialize for MsgGrantAllowance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgGrantAllowance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -509,7 +512,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -520,13 +523,13 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -545,11 +548,11 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgGrantAllowance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgGrantAllowance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgGrantAllowance, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgGrantAllowance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -595,7 +598,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgGrantAllowanceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -609,7 +612,7 @@ impl serde::Serialize for MsgGrantAllowanceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgGrantAllowanceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -619,7 +622,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowanceResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -630,13 +633,13 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowanceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -650,14 +653,14 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowanceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgGrantAllowanceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgGrantAllowanceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgGrantAllowanceResponse, V::Error>
+            ) -> core::result::Result<MsgGrantAllowanceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -677,7 +680,7 @@ impl<'de> serde::Deserialize<'de> for MsgGrantAllowanceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgPruneAllowances {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -697,7 +700,7 @@ impl serde::Serialize for MsgPruneAllowances {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgPruneAllowances {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -709,7 +712,7 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowances {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -720,13 +723,13 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowances {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -743,11 +746,11 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowances {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgPruneAllowances;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgPruneAllowances")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgPruneAllowances, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgPruneAllowances, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -777,7 +780,7 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowances {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgPruneAllowancesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -791,7 +794,7 @@ impl serde::Serialize for MsgPruneAllowancesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgPruneAllowancesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -801,7 +804,7 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowancesResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -812,13 +815,13 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowancesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -832,14 +835,14 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowancesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgPruneAllowancesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgPruneAllowancesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgPruneAllowancesResponse, V::Error>
+            ) -> core::result::Result<MsgPruneAllowancesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -859,7 +862,7 @@ impl<'de> serde::Deserialize<'de> for MsgPruneAllowancesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRevokeAllowance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -885,7 +888,7 @@ impl serde::Serialize for MsgRevokeAllowance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRevokeAllowance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -898,7 +901,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -909,13 +912,13 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -933,11 +936,11 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRevokeAllowance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgRevokeAllowance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgRevokeAllowance, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgRevokeAllowance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -975,7 +978,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRevokeAllowanceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -989,7 +992,7 @@ impl serde::Serialize for MsgRevokeAllowanceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRevokeAllowanceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -999,7 +1002,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowanceResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1010,13 +1013,13 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowanceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1030,14 +1033,14 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowanceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRevokeAllowanceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.MsgRevokeAllowanceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgRevokeAllowanceResponse, V::Error>
+            ) -> core::result::Result<MsgRevokeAllowanceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1057,7 +1060,7 @@ impl<'de> serde::Deserialize<'de> for MsgRevokeAllowanceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PeriodicAllowance {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1101,7 +1104,7 @@ impl serde::Serialize for PeriodicAllowance {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PeriodicAllowance {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1126,7 +1129,7 @@ impl<'de> serde::Deserialize<'de> for PeriodicAllowance {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1137,13 +1140,13 @@ impl<'de> serde::Deserialize<'de> for PeriodicAllowance {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1168,11 +1171,11 @@ impl<'de> serde::Deserialize<'de> for PeriodicAllowance {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PeriodicAllowance;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.PeriodicAllowance")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PeriodicAllowance, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PeriodicAllowance, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1234,7 +1237,7 @@ impl<'de> serde::Deserialize<'de> for PeriodicAllowance {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowanceRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1260,7 +1263,7 @@ impl serde::Serialize for QueryAllowanceRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowanceRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1273,7 +1276,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1284,13 +1287,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1308,14 +1311,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowanceRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.QueryAllowanceRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowanceRequest, V::Error>
+            ) -> core::result::Result<QueryAllowanceRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1353,7 +1356,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowanceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1373,7 +1376,7 @@ impl serde::Serialize for QueryAllowanceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowanceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1385,7 +1388,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1396,13 +1399,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1419,14 +1422,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowanceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.QueryAllowanceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowanceResponse, V::Error>
+            ) -> core::result::Result<QueryAllowanceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1456,7 +1459,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowanceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowancesByGranterRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1484,7 +1487,7 @@ impl serde::Serialize for QueryAllowancesByGranterRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1497,7 +1500,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1508,13 +1511,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1532,7 +1535,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowancesByGranterRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.feegrant.v1beta1.QueryAllowancesByGranterRequest")
             }
@@ -1540,7 +1543,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowancesByGranterRequest, V::Error>
+            ) -> core::result::Result<QueryAllowancesByGranterRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1578,7 +1581,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowancesByGranterResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1606,7 +1609,7 @@ impl serde::Serialize for QueryAllowancesByGranterResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1619,7 +1622,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1630,13 +1633,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1654,7 +1657,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowancesByGranterResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.feegrant.v1beta1.QueryAllowancesByGranterResponse")
             }
@@ -1662,7 +1665,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowancesByGranterResponse, V::Error>
+            ) -> core::result::Result<QueryAllowancesByGranterResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1700,7 +1703,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesByGranterResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowancesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1726,7 +1729,7 @@ impl serde::Serialize for QueryAllowancesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowancesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1739,7 +1742,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1750,13 +1753,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1774,14 +1777,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowancesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.QueryAllowancesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowancesRequest, V::Error>
+            ) -> core::result::Result<QueryAllowancesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1819,7 +1822,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllowancesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1845,7 +1848,7 @@ impl serde::Serialize for QueryAllowancesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllowancesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1858,7 +1861,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1869,13 +1872,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1893,14 +1896,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllowancesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllowancesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.feegrant.v1beta1.QueryAllowancesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllowancesResponse, V::Error>
+            ) -> core::result::Result<QueryAllowancesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.feegrant.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn allowance(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllowanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllowanceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAllowanceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -109,12 +109,12 @@ pub mod query_client {
         pub async fn allowances(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllowancesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllowancesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAllowancesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -130,14 +130,14 @@ pub mod query_client {
         pub async fn allowances_by_granter(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllowancesByGranterRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryAllowancesByGranterResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -164,15 +164,15 @@ pub mod query_server {
         async fn allowance(
             &self,
             request: tonic::Request<super::QueryAllowanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllowanceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAllowanceResponse>, tonic::Status>;
         async fn allowances(
             &self,
             request: tonic::Request<super::QueryAllowancesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllowancesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAllowancesResponse>, tonic::Status>;
         async fn allowances_by_granter(
             &self,
             request: tonic::Request<super::QueryAllowancesByGranterRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryAllowancesByGranterResponse>,
             tonic::Status,
         >;
@@ -247,7 +247,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -398,8 +398,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -493,12 +493,12 @@ pub mod msg_client {
         pub async fn grant_allowance(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgGrantAllowance>,
-        ) -> std::result::Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -514,12 +514,12 @@ pub mod msg_client {
         pub async fn revoke_allowance(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgRevokeAllowance>,
-        ) -> std::result::Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -536,12 +536,12 @@ pub mod msg_client {
         pub async fn prune_allowances(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgPruneAllowances>,
-        ) -> std::result::Result<tonic::Response<super::MsgPruneAllowancesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgPruneAllowancesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -568,15 +568,15 @@ pub mod msg_server {
         async fn grant_allowance(
             &self,
             request: tonic::Request<super::MsgGrantAllowance>,
-        ) -> std::result::Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgGrantAllowanceResponse>, tonic::Status>;
         async fn revoke_allowance(
             &self,
             request: tonic::Request<super::MsgRevokeAllowance>,
-        ) -> std::result::Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgRevokeAllowanceResponse>, tonic::Status>;
         async fn prune_allowances(
             &self,
             request: tonic::Request<super::MsgPruneAllowances>,
-        ) -> std::result::Result<tonic::Response<super::MsgPruneAllowancesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgPruneAllowancesResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -648,7 +648,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -796,8 +796,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.genutil.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.genutil.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -20,7 +20,7 @@ impl serde::Serialize for GenesisState {
                     .gen_txs
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -29,7 +29,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -75,11 +75,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.genutil.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -90,12 +90,10 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
                             if gen_txs__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("genTxs"));
                             }
-                            gen_txs__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            gen_txs__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -19,7 +19,7 @@ impl serde::Serialize for Module {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "maxMetadataLen",
-                ToString::to_string(&self.max_metadata_len).as_str(),
+                alloc::string::ToString::to_string(&self.max_metadata_len).as_str(),
             )?;
         }
         if !self.authority.is_empty() {
@@ -31,7 +31,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -44,7 +44,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -55,13 +55,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -81,11 +81,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Deposit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for Deposit {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -37,7 +37,7 @@ impl serde::Serialize for Deposit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Deposit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -51,7 +51,7 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -62,13 +62,13 @@ impl<'de> serde::Deserialize<'de> for Deposit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -87,11 +87,11 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Deposit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.Deposit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Deposit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Deposit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -136,7 +136,7 @@ impl<'de> serde::Deserialize<'de> for Deposit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DepositParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -161,7 +161,7 @@ impl serde::Serialize for DepositParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DepositParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -179,7 +179,7 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -190,13 +190,13 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -216,11 +216,11 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DepositParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.DepositParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DepositParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DepositParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -254,7 +254,7 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -292,7 +292,7 @@ impl serde::Serialize for GenesisState {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "startingProposalId",
-                ToString::to_string(&self.starting_proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.starting_proposal_id).as_str(),
             )?;
         }
         if !self.deposits.is_empty() {
@@ -325,7 +325,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -359,7 +359,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -370,13 +370,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -403,11 +403,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -502,7 +502,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -519,7 +519,7 @@ impl serde::Serialize for MsgCancelProposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.proposer.is_empty() {
@@ -531,7 +531,7 @@ impl serde::Serialize for MsgCancelProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -544,7 +544,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -555,13 +555,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -579,11 +579,11 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgCancelProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgCancelProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgCancelProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -620,7 +620,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -641,7 +641,7 @@ impl serde::Serialize for MsgCancelProposalResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.canceled_time.as_ref() {
@@ -651,7 +651,7 @@ impl serde::Serialize for MsgCancelProposalResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "canceledHeight",
-                ToString::to_string(&self.canceled_height).as_str(),
+                alloc::string::ToString::to_string(&self.canceled_height).as_str(),
             )?;
         }
         struct_ser.end()
@@ -660,7 +660,7 @@ impl serde::Serialize for MsgCancelProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -681,7 +681,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -692,13 +692,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -719,14 +719,14 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgCancelProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCancelProposalResponse, V::Error>
+            ) -> core::result::Result<MsgCancelProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -778,7 +778,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDeposit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -798,7 +798,7 @@ impl serde::Serialize for MsgDeposit {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -813,7 +813,7 @@ impl serde::Serialize for MsgDeposit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDeposit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -827,7 +827,7 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -838,13 +838,13 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -863,11 +863,11 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDeposit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgDeposit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDeposit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDeposit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -912,7 +912,7 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDepositResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -925,7 +925,7 @@ impl serde::Serialize for MsgDepositResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -935,7 +935,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -946,13 +946,13 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -966,11 +966,11 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDepositResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgDepositResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDepositResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDepositResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -990,7 +990,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecLegacyContent {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1016,7 +1016,7 @@ impl serde::Serialize for MsgExecLegacyContent {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecLegacyContent {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1029,7 +1029,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContent {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1040,13 +1040,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContent {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1064,14 +1064,14 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContent {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecLegacyContent;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgExecLegacyContent")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgExecLegacyContent, V::Error>
+            ) -> core::result::Result<MsgExecLegacyContent, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1109,7 +1109,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContent {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecLegacyContentResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1123,7 +1123,7 @@ impl serde::Serialize for MsgExecLegacyContentResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecLegacyContentResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1133,7 +1133,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContentResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1144,13 +1144,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContentResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1164,14 +1164,14 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContentResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecLegacyContentResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgExecLegacyContentResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgExecLegacyContentResponse, V::Error>
+            ) -> core::result::Result<MsgExecLegacyContentResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1191,7 +1191,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecLegacyContentResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1246,7 +1246,7 @@ impl serde::Serialize for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1273,7 +1273,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1284,13 +1284,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1315,11 +1315,11 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgSubmitProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSubmitProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSubmitProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1393,7 +1393,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1408,7 +1408,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1417,7 +1417,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1429,7 +1429,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1440,13 +1440,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1463,14 +1463,14 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgSubmitProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSubmitProposalResponse, V::Error>
+            ) -> core::result::Result<MsgSubmitProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1503,7 +1503,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1528,7 +1528,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1541,7 +1541,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1552,13 +1552,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1576,11 +1576,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1614,7 +1614,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1628,7 +1628,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1638,7 +1638,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1649,13 +1649,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1669,14 +1669,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1696,7 +1696,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1719,7 +1719,7 @@ impl serde::Serialize for MsgVote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -1727,7 +1727,7 @@ impl serde::Serialize for MsgVote {
         }
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -1740,7 +1740,7 @@ impl serde::Serialize for MsgVote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1755,7 +1755,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1766,13 +1766,13 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1792,11 +1792,11 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgVote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1849,7 +1849,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1862,7 +1862,7 @@ impl serde::Serialize for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1872,7 +1872,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1883,13 +1883,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1903,11 +1903,11 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgVoteResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVoteResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVoteResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1923,7 +1923,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteWeighted {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1946,7 +1946,7 @@ impl serde::Serialize for MsgVoteWeighted {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -1964,7 +1964,7 @@ impl serde::Serialize for MsgVoteWeighted {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1979,7 +1979,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1990,13 +1990,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2016,11 +2016,11 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteWeighted;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgVoteWeighted")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVoteWeighted, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVoteWeighted, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2073,7 +2073,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteWeightedResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2087,7 +2087,7 @@ impl serde::Serialize for MsgVoteWeightedResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2097,7 +2097,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2108,13 +2108,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2128,14 +2128,14 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteWeightedResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.MsgVoteWeightedResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgVoteWeightedResponse, V::Error>
+            ) -> core::result::Result<MsgVoteWeightedResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2155,7 +2155,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2268,7 +2268,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2326,7 +2326,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2337,13 +2337,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2395,11 +2395,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2560,7 +2560,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Proposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2614,14 +2614,15 @@ impl serde::Serialize for Proposal {
         let mut struct_ser = serializer.serialize_struct("cosmos.gov.v1.Proposal", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("id", ToString::to_string(&self.id).as_str())?;
+            struct_ser
+                .serialize_field("id", alloc::string::ToString::to_string(&self.id).as_str())?;
         }
         if !self.messages.is_empty() {
             struct_ser.serialize_field("messages", &self.messages)?;
         }
         if self.status != 0 {
             let v = ProposalStatus::try_from(self.status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.status))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.status))
             })?;
             struct_ser.serialize_field("status", &v)?;
         }
@@ -2667,7 +2668,7 @@ impl serde::Serialize for Proposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Proposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2716,7 +2717,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2727,13 +2728,13 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2772,11 +2773,11 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Proposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.Proposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Proposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Proposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2917,7 +2918,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProposalStatus {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2935,7 +2936,7 @@ impl serde::Serialize for ProposalStatus {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProposalStatus {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2953,11 +2954,11 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProposalStatus;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -2969,7 +2970,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -2981,7 +2982,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -3002,7 +3003,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryConstitutionRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3016,7 +3017,7 @@ impl serde::Serialize for QueryConstitutionRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryConstitutionRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3026,7 +3027,7 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3037,13 +3038,13 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3057,14 +3058,14 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryConstitutionRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryConstitutionRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryConstitutionRequest, V::Error>
+            ) -> core::result::Result<QueryConstitutionRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3084,7 +3085,7 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryConstitutionResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3104,7 +3105,7 @@ impl serde::Serialize for QueryConstitutionResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryConstitutionResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3116,7 +3117,7 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3127,13 +3128,13 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3150,14 +3151,14 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryConstitutionResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryConstitutionResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryConstitutionResponse, V::Error>
+            ) -> core::result::Result<QueryConstitutionResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3187,7 +3188,7 @@ impl<'de> serde::Deserialize<'de> for QueryConstitutionResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3205,7 +3206,7 @@ impl serde::Serialize for QueryDepositRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -3217,7 +3218,7 @@ impl serde::Serialize for QueryDepositRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3230,7 +3231,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3241,13 +3242,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3265,11 +3266,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryDepositRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryDepositRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryDepositRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3310,7 +3314,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3330,7 +3334,7 @@ impl serde::Serialize for QueryDepositResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3342,7 +3346,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3353,13 +3357,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3376,14 +3380,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryDepositResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositResponse, V::Error>
+            ) -> core::result::Result<QueryDepositResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3411,7 +3415,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3429,7 +3433,7 @@ impl serde::Serialize for QueryDepositsRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -3441,7 +3445,7 @@ impl serde::Serialize for QueryDepositsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3454,7 +3458,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3465,13 +3469,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3489,14 +3493,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryDepositsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositsRequest, V::Error>
+            ) -> core::result::Result<QueryDepositsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3537,7 +3541,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3563,7 +3567,7 @@ impl serde::Serialize for QueryDepositsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3576,7 +3580,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3587,13 +3591,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3611,14 +3615,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryDepositsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositsResponse, V::Error>
+            ) -> core::result::Result<QueryDepositsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3656,7 +3660,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3676,7 +3680,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3688,7 +3692,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3699,13 +3703,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3722,11 +3726,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3756,7 +3760,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3794,7 +3798,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3817,7 +3821,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3828,13 +3832,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3854,11 +3858,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3912,7 +3919,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3927,7 +3934,7 @@ impl serde::Serialize for QueryProposalRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -3936,7 +3943,7 @@ impl serde::Serialize for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3948,7 +3955,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3959,13 +3966,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3982,14 +3989,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryProposalRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalRequest, V::Error>
+            ) -> core::result::Result<QueryProposalRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4022,7 +4029,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4042,7 +4049,7 @@ impl serde::Serialize for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4054,7 +4061,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4065,13 +4072,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4088,14 +4095,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalResponse, V::Error>
+            ) -> core::result::Result<QueryProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4125,7 +4132,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4147,7 +4154,10 @@ impl serde::Serialize for QueryProposalsRequest {
             serializer.serialize_struct("cosmos.gov.v1.QueryProposalsRequest", len)?;
         if self.proposal_status != 0 {
             let v = ProposalStatus::try_from(self.proposal_status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.proposal_status))
+                serde::ser::Error::custom(alloc::format!(
+                    "Invalid variant {}",
+                    self.proposal_status
+                ))
             })?;
             struct_ser.serialize_field("proposalStatus", &v)?;
         }
@@ -4166,7 +4176,7 @@ impl serde::Serialize for QueryProposalsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4187,7 +4197,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4198,13 +4208,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4226,14 +4236,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryProposalsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsRequest, V::Error>
+            ) -> core::result::Result<QueryProposalsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4287,7 +4297,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4313,7 +4323,7 @@ impl serde::Serialize for QueryProposalsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4326,7 +4336,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4337,13 +4347,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4361,14 +4371,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryProposalsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsResponse, V::Error>
+            ) -> core::result::Result<QueryProposalsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4406,7 +4416,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4421,7 +4431,7 @@ impl serde::Serialize for QueryTallyResultRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -4430,7 +4440,7 @@ impl serde::Serialize for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4442,7 +4452,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4453,13 +4463,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4476,14 +4486,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryTallyResultRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultRequest, V::Error>
+            ) -> core::result::Result<QueryTallyResultRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4516,7 +4526,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4536,7 +4546,7 @@ impl serde::Serialize for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4548,7 +4558,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4559,13 +4569,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4582,14 +4592,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryTallyResultResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultResponse, V::Error>
+            ) -> core::result::Result<QueryTallyResultResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4617,7 +4627,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4634,7 +4644,7 @@ impl serde::Serialize for QueryVoteRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -4646,7 +4656,7 @@ impl serde::Serialize for QueryVoteRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4659,7 +4669,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4670,13 +4680,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4694,11 +4704,11 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryVoteRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVoteRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVoteRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4735,7 +4745,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4754,7 +4764,7 @@ impl serde::Serialize for QueryVoteResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4766,7 +4776,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4777,13 +4787,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4800,11 +4810,11 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryVoteResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVoteResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVoteResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4828,7 +4838,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4845,7 +4855,7 @@ impl serde::Serialize for QueryVotesRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -4857,7 +4867,7 @@ impl serde::Serialize for QueryVotesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4870,7 +4880,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4881,13 +4891,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4905,11 +4915,11 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryVotesRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVotesRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVotesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4946,7 +4956,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4972,7 +4982,7 @@ impl serde::Serialize for QueryVotesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4985,7 +4995,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4996,13 +5006,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5020,11 +5030,11 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.QueryVotesResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVotesResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVotesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5062,7 +5072,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TallyParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5093,7 +5103,7 @@ impl serde::Serialize for TallyParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TallyParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5107,7 +5117,7 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5118,13 +5128,13 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5143,11 +5153,11 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TallyParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.TallyParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TallyParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TallyParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5189,7 +5199,7 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TallyResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5226,7 +5236,7 @@ impl serde::Serialize for TallyResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TallyResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5250,7 +5260,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5261,13 +5271,13 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5289,11 +5299,11 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TallyResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.TallyResult")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TallyResult, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TallyResult, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5343,7 +5353,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Vote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5366,7 +5376,7 @@ impl serde::Serialize for Vote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -5384,7 +5394,7 @@ impl serde::Serialize for Vote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Vote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5399,7 +5409,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5410,13 +5420,13 @@ impl<'de> serde::Deserialize<'de> for Vote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5436,11 +5446,11 @@ impl<'de> serde::Deserialize<'de> for Vote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Vote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.Vote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Vote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Vote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5493,7 +5503,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VoteOption {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5510,7 +5520,7 @@ impl serde::Serialize for VoteOption {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VoteOption {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5527,11 +5537,11 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VoteOption;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -5543,7 +5553,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -5555,7 +5565,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -5575,7 +5585,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VotingParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5594,7 +5604,7 @@ impl serde::Serialize for VotingParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VotingParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5606,7 +5616,7 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5617,13 +5627,13 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5640,11 +5650,11 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VotingParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.VotingParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<VotingParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<VotingParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5670,7 +5680,7 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for WeightedVoteOption {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5686,7 +5696,7 @@ impl serde::Serialize for WeightedVoteOption {
             serializer.serialize_struct("cosmos.gov.v1.WeightedVoteOption", len)?;
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -5699,7 +5709,7 @@ impl serde::Serialize for WeightedVoteOption {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5712,7 +5722,7 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5723,13 +5733,13 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5747,11 +5757,11 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = WeightedVoteOption;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1.WeightedVoteOption")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<WeightedVoteOption, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<WeightedVoteOption, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn constitution(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryConstitutionRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryConstitutionResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryConstitutionResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -124,12 +124,12 @@ pub mod query_client {
         pub async fn proposals(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -142,11 +142,12 @@ pub mod query_client {
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVoteRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -159,12 +160,12 @@ pub mod query_client {
         pub async fn votes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVotesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -177,12 +178,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -195,12 +196,12 @@ pub mod query_client {
         pub async fn deposit(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDepositRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -213,12 +214,12 @@ pub mod query_client {
         pub async fn deposits(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDepositsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -231,12 +232,12 @@ pub mod query_client {
         pub async fn tally_result(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -259,39 +260,39 @@ pub mod query_server {
         async fn constitution(
             &self,
             request: tonic::Request<super::QueryConstitutionRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryConstitutionResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryConstitutionResponse>, tonic::Status>;
         async fn proposal(
             &self,
             request: tonic::Request<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
         async fn proposals(
             &self,
             request: tonic::Request<super::QueryProposalsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>;
         async fn vote(
             &self,
             request: tonic::Request<super::QueryVoteRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>;
         async fn votes(
             &self,
             request: tonic::Request<super::QueryVotesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>;
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn deposit(
             &self,
             request: tonic::Request<super::QueryDepositRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>;
         async fn deposits(
             &self,
             request: tonic::Request<super::QueryDepositsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>;
         async fn tally_result(
             &self,
             request: tonic::Request<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -363,7 +364,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -739,8 +740,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -834,12 +835,12 @@ pub mod msg_client {
         pub async fn submit_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -852,12 +853,12 @@ pub mod msg_client {
         pub async fn exec_legacy_content(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgExecLegacyContent>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecLegacyContentResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgExecLegacyContentResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -870,11 +871,11 @@ pub mod msg_client {
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -887,12 +888,12 @@ pub mod msg_client {
         pub async fn vote_weighted(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVoteWeighted>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -905,12 +906,12 @@ pub mod msg_client {
         pub async fn deposit(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgDeposit>,
-        ) -> std::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -923,12 +924,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -941,12 +942,12 @@ pub mod msg_client {
         pub async fn cancel_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCancelProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgCancelProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgCancelProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -969,31 +970,31 @@ pub mod msg_server {
         async fn submit_proposal(
             &self,
             request: tonic::Request<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
         async fn exec_legacy_content(
             &self,
             request: tonic::Request<super::MsgExecLegacyContent>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecLegacyContentResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgExecLegacyContentResponse>, tonic::Status>;
         async fn vote(
             &self,
             request: tonic::Request<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
         async fn vote_weighted(
             &self,
             request: tonic::Request<super::MsgVoteWeighted>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>;
         async fn deposit(
             &self,
             request: tonic::Request<super::MsgDeposit>,
-        ) -> std::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
         async fn cancel_proposal(
             &self,
             request: tonic::Request<super::MsgCancelProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgCancelProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgCancelProposalResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1065,7 +1066,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1365,8 +1366,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Deposit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for Deposit {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -37,7 +37,7 @@ impl serde::Serialize for Deposit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Deposit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -51,7 +51,7 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -62,13 +62,13 @@ impl<'de> serde::Deserialize<'de> for Deposit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -87,11 +87,11 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Deposit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.Deposit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Deposit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Deposit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -136,7 +136,7 @@ impl<'de> serde::Deserialize<'de> for Deposit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DepositParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -162,7 +162,7 @@ impl serde::Serialize for DepositParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DepositParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -180,7 +180,7 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -191,13 +191,13 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -217,11 +217,11 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DepositParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.DepositParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DepositParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DepositParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -259,7 +259,7 @@ impl<'de> serde::Deserialize<'de> for DepositParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -291,7 +291,7 @@ impl serde::Serialize for GenesisState {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "startingProposalId",
-                ToString::to_string(&self.starting_proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.starting_proposal_id).as_str(),
             )?;
         }
         if !self.deposits.is_empty() {
@@ -318,7 +318,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -348,7 +348,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -359,13 +359,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -390,11 +390,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -473,7 +473,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDeposit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -493,7 +493,7 @@ impl serde::Serialize for MsgDeposit {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -508,7 +508,7 @@ impl serde::Serialize for MsgDeposit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDeposit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -522,7 +522,7 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -533,13 +533,13 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -558,11 +558,11 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDeposit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgDeposit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDeposit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDeposit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -607,7 +607,7 @@ impl<'de> serde::Deserialize<'de> for MsgDeposit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDepositResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -621,7 +621,7 @@ impl serde::Serialize for MsgDepositResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -631,7 +631,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -642,13 +642,13 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -662,11 +662,11 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDepositResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgDepositResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDepositResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDepositResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -686,7 +686,7 @@ impl<'de> serde::Deserialize<'de> for MsgDepositResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -718,7 +718,7 @@ impl serde::Serialize for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -732,7 +732,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -743,13 +743,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -770,11 +770,11 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgSubmitProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSubmitProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSubmitProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -820,7 +820,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -835,7 +835,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -844,7 +844,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -856,7 +856,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -867,13 +867,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -890,14 +890,14 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgSubmitProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSubmitProposalResponse, V::Error>
+            ) -> core::result::Result<MsgSubmitProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -930,7 +930,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -950,7 +950,7 @@ impl serde::Serialize for MsgVote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -958,7 +958,7 @@ impl serde::Serialize for MsgVote {
         }
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -968,7 +968,7 @@ impl serde::Serialize for MsgVote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -982,7 +982,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -993,13 +993,13 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1018,11 +1018,11 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgVote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1067,7 +1067,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1080,7 +1080,7 @@ impl serde::Serialize for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1090,7 +1090,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1101,13 +1101,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1121,11 +1121,11 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgVoteResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVoteResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVoteResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1145,7 +1145,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteWeighted {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1166,7 +1166,7 @@ impl serde::Serialize for MsgVoteWeighted {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -1181,7 +1181,7 @@ impl serde::Serialize for MsgVoteWeighted {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1195,7 +1195,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1206,13 +1206,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1231,11 +1231,11 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteWeighted;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgVoteWeighted")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVoteWeighted, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVoteWeighted, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1284,7 +1284,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeighted {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteWeightedResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1298,7 +1298,7 @@ impl serde::Serialize for MsgVoteWeightedResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1308,7 +1308,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1319,13 +1319,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1339,14 +1339,14 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteWeightedResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.MsgVoteWeightedResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgVoteWeightedResponse, V::Error>
+            ) -> core::result::Result<MsgVoteWeightedResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1366,7 +1366,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteWeightedResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Proposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1404,7 +1404,7 @@ impl serde::Serialize for Proposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.content.as_ref() {
@@ -1412,7 +1412,7 @@ impl serde::Serialize for Proposal {
         }
         if self.status != 0 {
             let v = ProposalStatus::try_from(self.status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.status))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.status))
             })?;
             struct_ser.serialize_field("status", &v)?;
         }
@@ -1440,7 +1440,7 @@ impl serde::Serialize for Proposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Proposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1477,7 +1477,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1488,13 +1488,13 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1527,11 +1527,11 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Proposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.Proposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Proposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Proposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1624,7 +1624,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProposalStatus {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1642,7 +1642,7 @@ impl serde::Serialize for ProposalStatus {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProposalStatus {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1660,11 +1660,11 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProposalStatus;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1676,7 +1676,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1688,7 +1688,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1709,7 +1709,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1727,7 +1727,7 @@ impl serde::Serialize for QueryDepositRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.depositor.is_empty() {
@@ -1739,7 +1739,7 @@ impl serde::Serialize for QueryDepositRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1752,7 +1752,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1763,13 +1763,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1787,11 +1787,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryDepositRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryDepositRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryDepositRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1832,7 +1835,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1852,7 +1855,7 @@ impl serde::Serialize for QueryDepositResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1864,7 +1867,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1875,13 +1878,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1898,14 +1901,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryDepositResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositResponse, V::Error>
+            ) -> core::result::Result<QueryDepositResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1933,7 +1936,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1951,7 +1954,7 @@ impl serde::Serialize for QueryDepositsRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -1963,7 +1966,7 @@ impl serde::Serialize for QueryDepositsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1976,7 +1979,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1987,13 +1990,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2011,14 +2014,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryDepositsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositsRequest, V::Error>
+            ) -> core::result::Result<QueryDepositsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2059,7 +2062,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDepositsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2085,7 +2088,7 @@ impl serde::Serialize for QueryDepositsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2098,7 +2101,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2109,13 +2112,13 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2133,14 +2136,14 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDepositsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryDepositsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDepositsResponse, V::Error>
+            ) -> core::result::Result<QueryDepositsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2178,7 +2181,7 @@ impl<'de> serde::Deserialize<'de> for QueryDepositsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2198,7 +2201,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2210,7 +2213,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2221,13 +2224,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2244,11 +2247,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2278,7 +2281,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2310,7 +2313,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2331,7 +2334,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2342,13 +2345,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2367,11 +2370,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2417,7 +2423,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2432,7 +2438,7 @@ impl serde::Serialize for QueryProposalRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -2441,7 +2447,7 @@ impl serde::Serialize for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2453,7 +2459,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2464,13 +2470,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2487,14 +2493,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryProposalRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalRequest, V::Error>
+            ) -> core::result::Result<QueryProposalRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2527,7 +2533,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2547,7 +2553,7 @@ impl serde::Serialize for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2559,7 +2565,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2570,13 +2576,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2593,14 +2599,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalResponse, V::Error>
+            ) -> core::result::Result<QueryProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2630,7 +2636,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2652,7 +2658,10 @@ impl serde::Serialize for QueryProposalsRequest {
             serializer.serialize_struct("cosmos.gov.v1beta1.QueryProposalsRequest", len)?;
         if self.proposal_status != 0 {
             let v = ProposalStatus::try_from(self.proposal_status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.proposal_status))
+                serde::ser::Error::custom(alloc::format!(
+                    "Invalid variant {}",
+                    self.proposal_status
+                ))
             })?;
             struct_ser.serialize_field("proposalStatus", &v)?;
         }
@@ -2671,7 +2680,7 @@ impl serde::Serialize for QueryProposalsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2692,7 +2701,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2703,13 +2712,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2731,14 +2740,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryProposalsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsRequest, V::Error>
+            ) -> core::result::Result<QueryProposalsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2792,7 +2801,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2818,7 +2827,7 @@ impl serde::Serialize for QueryProposalsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2831,7 +2840,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2842,13 +2851,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2866,14 +2875,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryProposalsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsResponse, V::Error>
+            ) -> core::result::Result<QueryProposalsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2911,7 +2920,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2926,7 +2935,7 @@ impl serde::Serialize for QueryTallyResultRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -2935,7 +2944,7 @@ impl serde::Serialize for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2947,7 +2956,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2958,13 +2967,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2981,14 +2990,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryTallyResultRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultRequest, V::Error>
+            ) -> core::result::Result<QueryTallyResultRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3021,7 +3030,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3041,7 +3050,7 @@ impl serde::Serialize for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3053,7 +3062,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3064,13 +3073,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3087,14 +3096,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryTallyResultResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultResponse, V::Error>
+            ) -> core::result::Result<QueryTallyResultResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3122,7 +3131,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3140,7 +3149,7 @@ impl serde::Serialize for QueryVoteRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -3152,7 +3161,7 @@ impl serde::Serialize for QueryVoteRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3165,7 +3174,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3176,13 +3185,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3200,11 +3209,11 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryVoteRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVoteRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVoteRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3245,7 +3254,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3265,7 +3274,7 @@ impl serde::Serialize for QueryVoteResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3277,7 +3286,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3288,13 +3297,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3311,11 +3320,11 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryVoteResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVoteResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVoteResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3343,7 +3352,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3361,7 +3370,7 @@ impl serde::Serialize for QueryVotesRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -3373,7 +3382,7 @@ impl serde::Serialize for QueryVotesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3386,7 +3395,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3397,13 +3406,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3421,11 +3430,11 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryVotesRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVotesRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVotesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3466,7 +3475,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3492,7 +3501,7 @@ impl serde::Serialize for QueryVotesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3505,7 +3514,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3516,13 +3525,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3540,11 +3549,11 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.QueryVotesResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryVotesResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryVotesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3582,7 +3591,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TallyParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3625,7 +3634,7 @@ impl serde::Serialize for TallyParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TallyParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3639,7 +3648,7 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3650,13 +3659,13 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3675,11 +3684,11 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TallyParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.TallyParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TallyParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TallyParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3730,7 +3739,7 @@ impl<'de> serde::Deserialize<'de> for TallyParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TallyResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3767,7 +3776,7 @@ impl serde::Serialize for TallyResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TallyResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3782,7 +3791,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3793,13 +3802,13 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3819,11 +3828,11 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TallyResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.TallyResult")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TallyResult, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TallyResult, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3873,7 +3882,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TextProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3898,7 +3907,7 @@ impl serde::Serialize for TextProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TextProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3911,7 +3920,7 @@ impl<'de> serde::Deserialize<'de> for TextProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3922,13 +3931,13 @@ impl<'de> serde::Deserialize<'de> for TextProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3946,11 +3955,11 @@ impl<'de> serde::Deserialize<'de> for TextProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TextProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.TextProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TextProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TextProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3984,7 +3993,7 @@ impl<'de> serde::Deserialize<'de> for TextProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Vote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4007,7 +4016,7 @@ impl serde::Serialize for Vote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -4015,7 +4024,7 @@ impl serde::Serialize for Vote {
         }
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -4028,7 +4037,7 @@ impl serde::Serialize for Vote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Vote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4043,7 +4052,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4054,13 +4063,13 @@ impl<'de> serde::Deserialize<'de> for Vote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4080,11 +4089,11 @@ impl<'de> serde::Deserialize<'de> for Vote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Vote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.Vote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Vote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Vote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4137,7 +4146,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VoteOption {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4154,7 +4163,7 @@ impl serde::Serialize for VoteOption {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VoteOption {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4171,11 +4180,11 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VoteOption;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -4187,7 +4196,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -4199,7 +4208,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -4219,7 +4228,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VotingParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4238,7 +4247,7 @@ impl serde::Serialize for VotingParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VotingParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4250,7 +4259,7 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4261,13 +4270,13 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4284,11 +4293,11 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VotingParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.VotingParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<VotingParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<VotingParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4314,7 +4323,7 @@ impl<'de> serde::Deserialize<'de> for VotingParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for WeightedVoteOption {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4330,7 +4339,7 @@ impl serde::Serialize for WeightedVoteOption {
             serializer.serialize_struct("cosmos.gov.v1beta1.WeightedVoteOption", len)?;
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -4343,7 +4352,7 @@ impl serde::Serialize for WeightedVoteOption {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4356,7 +4365,7 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4367,13 +4376,13 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4391,11 +4400,11 @@ impl<'de> serde::Deserialize<'de> for WeightedVoteOption {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = WeightedVoteOption;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.gov.v1beta1.WeightedVoteOption")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<WeightedVoteOption, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<WeightedVoteOption, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.gov.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn proposals(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -124,11 +124,12 @@ pub mod query_client {
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVoteRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -141,12 +142,12 @@ pub mod query_client {
         pub async fn votes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVotesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -159,12 +160,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -177,12 +178,12 @@ pub mod query_client {
         pub async fn deposit(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDepositRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -195,12 +196,12 @@ pub mod query_client {
         pub async fn deposits(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDepositsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -213,12 +214,12 @@ pub mod query_client {
         pub async fn tally_result(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -242,35 +243,35 @@ pub mod query_server {
         async fn proposal(
             &self,
             request: tonic::Request<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
         async fn proposals(
             &self,
             request: tonic::Request<super::QueryProposalsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryProposalsResponse>, tonic::Status>;
         async fn vote(
             &self,
             request: tonic::Request<super::QueryVoteRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVoteResponse>, tonic::Status>;
         async fn votes(
             &self,
             request: tonic::Request<super::QueryVotesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVotesResponse>, tonic::Status>;
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn deposit(
             &self,
             request: tonic::Request<super::QueryDepositRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDepositResponse>, tonic::Status>;
         async fn deposits(
             &self,
             request: tonic::Request<super::QueryDepositsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDepositsResponse>, tonic::Status>;
         async fn tally_result(
             &self,
             request: tonic::Request<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -342,7 +343,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -680,8 +681,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -775,12 +776,12 @@ pub mod msg_client {
         pub async fn submit_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -794,11 +795,11 @@ pub mod msg_client {
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -811,12 +812,12 @@ pub mod msg_client {
         pub async fn vote_weighted(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVoteWeighted>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -829,12 +830,12 @@ pub mod msg_client {
         pub async fn deposit(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgDeposit>,
-        ) -> std::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -857,19 +858,19 @@ pub mod msg_server {
         async fn submit_proposal(
             &self,
             request: tonic::Request<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
         async fn vote(
             &self,
             request: tonic::Request<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
         async fn vote_weighted(
             &self,
             request: tonic::Request<super::MsgVoteWeighted>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVoteWeightedResponse>, tonic::Status>;
         async fn deposit(
             &self,
             request: tonic::Request<super::MsgDeposit>,
-        ) -> std::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgDepositResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -941,7 +942,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1127,8 +1128,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for Module {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "maxMetadataLen",
-                ToString::to_string(&self.max_metadata_len).as_str(),
+                alloc::string::ToString::to_string(&self.max_metadata_len).as_str(),
             )?;
         }
         struct_ser.end()
@@ -31,7 +31,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -49,7 +49,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -60,13 +60,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -88,11 +88,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for DecisionPolicyWindows {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for DecisionPolicyWindows {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DecisionPolicyWindows {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -46,7 +46,7 @@ impl<'de> serde::Deserialize<'de> for DecisionPolicyWindows {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -57,13 +57,13 @@ impl<'de> serde::Deserialize<'de> for DecisionPolicyWindows {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -83,14 +83,14 @@ impl<'de> serde::Deserialize<'de> for DecisionPolicyWindows {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DecisionPolicyWindows;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.DecisionPolicyWindows")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DecisionPolicyWindows, V::Error>
+            ) -> core::result::Result<DecisionPolicyWindows, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -130,7 +130,7 @@ impl<'de> serde::Deserialize<'de> for DecisionPolicyWindows {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventCreateGroup {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -143,7 +143,10 @@ impl serde::Serialize for EventCreateGroup {
             serializer.serialize_struct("cosmos.group.v1.EventCreateGroup", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -151,7 +154,7 @@ impl serde::Serialize for EventCreateGroup {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventCreateGroup {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -163,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroup {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -174,13 +177,13 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroup {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -197,11 +200,11 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroup {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventCreateGroup;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventCreateGroup")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventCreateGroup, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventCreateGroup, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -234,7 +237,7 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroup {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventCreateGroupPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -254,7 +257,7 @@ impl serde::Serialize for EventCreateGroupPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventCreateGroupPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -266,7 +269,7 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroupPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -277,13 +280,13 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroupPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -300,14 +303,14 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroupPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventCreateGroupPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventCreateGroupPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<EventCreateGroupPolicy, V::Error>
+            ) -> core::result::Result<EventCreateGroupPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -337,7 +340,7 @@ impl<'de> serde::Deserialize<'de> for EventCreateGroupPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventExec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -357,12 +360,12 @@ impl serde::Serialize for EventExec {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if self.result != 0 {
             let v = ProposalExecutorResult::try_from(self.result).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.result))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.result))
             })?;
             struct_ser.serialize_field("result", &v)?;
         }
@@ -375,7 +378,7 @@ impl serde::Serialize for EventExec {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventExec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -389,7 +392,7 @@ impl<'de> serde::Deserialize<'de> for EventExec {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -400,13 +403,13 @@ impl<'de> serde::Deserialize<'de> for EventExec {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -425,11 +428,11 @@ impl<'de> serde::Deserialize<'de> for EventExec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventExec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventExec")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventExec, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventExec, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -474,7 +477,7 @@ impl<'de> serde::Deserialize<'de> for EventExec {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventLeaveGroup {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -489,7 +492,10 @@ impl serde::Serialize for EventLeaveGroup {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.EventLeaveGroup", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.address.is_empty() {
             struct_ser.serialize_field("address", &self.address)?;
@@ -500,7 +506,7 @@ impl serde::Serialize for EventLeaveGroup {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventLeaveGroup {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -513,7 +519,7 @@ impl<'de> serde::Deserialize<'de> for EventLeaveGroup {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -524,13 +530,13 @@ impl<'de> serde::Deserialize<'de> for EventLeaveGroup {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -548,11 +554,11 @@ impl<'de> serde::Deserialize<'de> for EventLeaveGroup {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventLeaveGroup;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventLeaveGroup")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventLeaveGroup, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventLeaveGroup, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -589,7 +595,7 @@ impl<'de> serde::Deserialize<'de> for EventLeaveGroup {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventProposalPruned {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -610,12 +616,12 @@ impl serde::Serialize for EventProposalPruned {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if self.status != 0 {
             let v = ProposalStatus::try_from(self.status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.status))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.status))
             })?;
             struct_ser.serialize_field("status", &v)?;
         }
@@ -628,7 +634,7 @@ impl serde::Serialize for EventProposalPruned {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventProposalPruned {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -648,7 +654,7 @@ impl<'de> serde::Deserialize<'de> for EventProposalPruned {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -659,13 +665,13 @@ impl<'de> serde::Deserialize<'de> for EventProposalPruned {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -684,11 +690,14 @@ impl<'de> serde::Deserialize<'de> for EventProposalPruned {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventProposalPruned;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventProposalPruned")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventProposalPruned, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<EventProposalPruned, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -737,7 +746,7 @@ impl<'de> serde::Deserialize<'de> for EventProposalPruned {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventSubmitProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -752,7 +761,7 @@ impl serde::Serialize for EventSubmitProposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -761,7 +770,7 @@ impl serde::Serialize for EventSubmitProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventSubmitProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -773,7 +782,7 @@ impl<'de> serde::Deserialize<'de> for EventSubmitProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -784,13 +793,13 @@ impl<'de> serde::Deserialize<'de> for EventSubmitProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -807,11 +816,14 @@ impl<'de> serde::Deserialize<'de> for EventSubmitProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventSubmitProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventSubmitProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventSubmitProposal, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<EventSubmitProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -844,7 +856,7 @@ impl<'de> serde::Deserialize<'de> for EventSubmitProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventUpdateGroup {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -857,7 +869,10 @@ impl serde::Serialize for EventUpdateGroup {
             serializer.serialize_struct("cosmos.group.v1.EventUpdateGroup", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -865,7 +880,7 @@ impl serde::Serialize for EventUpdateGroup {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventUpdateGroup {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -877,7 +892,7 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroup {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -888,13 +903,13 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroup {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -911,11 +926,11 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroup {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventUpdateGroup;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventUpdateGroup")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventUpdateGroup, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventUpdateGroup, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -948,7 +963,7 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroup {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventUpdateGroupPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -968,7 +983,7 @@ impl serde::Serialize for EventUpdateGroupPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventUpdateGroupPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -980,7 +995,7 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroupPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -991,13 +1006,13 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroupPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1014,14 +1029,14 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroupPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventUpdateGroupPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventUpdateGroupPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<EventUpdateGroupPolicy, V::Error>
+            ) -> core::result::Result<EventUpdateGroupPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1051,7 +1066,7 @@ impl<'de> serde::Deserialize<'de> for EventUpdateGroupPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventVote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1065,7 +1080,7 @@ impl serde::Serialize for EventVote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1074,7 +1089,7 @@ impl serde::Serialize for EventVote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventVote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1086,7 +1101,7 @@ impl<'de> serde::Deserialize<'de> for EventVote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1097,13 +1112,13 @@ impl<'de> serde::Deserialize<'de> for EventVote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1120,11 +1135,11 @@ impl<'de> serde::Deserialize<'de> for EventVote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventVote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventVote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventVote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventVote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1153,7 +1168,7 @@ impl<'de> serde::Deserialize<'de> for EventVote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventWithdrawProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1168,7 +1183,7 @@ impl serde::Serialize for EventWithdrawProposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1177,7 +1192,7 @@ impl serde::Serialize for EventWithdrawProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventWithdrawProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1189,7 +1204,7 @@ impl<'de> serde::Deserialize<'de> for EventWithdrawProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1200,13 +1215,13 @@ impl<'de> serde::Deserialize<'de> for EventWithdrawProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1223,14 +1238,14 @@ impl<'de> serde::Deserialize<'de> for EventWithdrawProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventWithdrawProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.EventWithdrawProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<EventWithdrawProposal, V::Error>
+            ) -> core::result::Result<EventWithdrawProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1263,7 +1278,7 @@ impl<'de> serde::Deserialize<'de> for EventWithdrawProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Exec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1277,7 +1292,7 @@ impl serde::Serialize for Exec {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Exec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1288,11 +1303,11 @@ impl<'de> serde::Deserialize<'de> for Exec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Exec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1304,7 +1319,7 @@ impl<'de> serde::Deserialize<'de> for Exec {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1316,7 +1331,7 @@ impl<'de> serde::Deserialize<'de> for Exec {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1333,7 +1348,7 @@ impl<'de> serde::Deserialize<'de> for Exec {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1366,8 +1381,10 @@ impl serde::Serialize for GenesisState {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.GenesisState", len)?;
         if self.group_seq != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("groupSeq", ToString::to_string(&self.group_seq).as_str())?;
+            struct_ser.serialize_field(
+                "groupSeq",
+                alloc::string::ToString::to_string(&self.group_seq).as_str(),
+            )?;
         }
         if !self.groups.is_empty() {
             struct_ser.serialize_field("groups", &self.groups)?;
@@ -1379,7 +1396,7 @@ impl serde::Serialize for GenesisState {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "groupPolicySeq",
-                ToString::to_string(&self.group_policy_seq).as_str(),
+                alloc::string::ToString::to_string(&self.group_policy_seq).as_str(),
             )?;
         }
         if !self.group_policies.is_empty() {
@@ -1389,7 +1406,7 @@ impl serde::Serialize for GenesisState {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalSeq",
-                ToString::to_string(&self.proposal_seq).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_seq).as_str(),
             )?;
         }
         if !self.proposals.is_empty() {
@@ -1404,7 +1421,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1437,7 +1454,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1448,13 +1465,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1480,11 +1497,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1575,7 +1592,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GroupInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1602,7 +1619,8 @@ impl serde::Serialize for GroupInfo {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.GroupInfo", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("id", ToString::to_string(&self.id).as_str())?;
+            struct_ser
+                .serialize_field("id", alloc::string::ToString::to_string(&self.id).as_str())?;
         }
         if !self.admin.is_empty() {
             struct_ser.serialize_field("admin", &self.admin)?;
@@ -1612,7 +1630,10 @@ impl serde::Serialize for GroupInfo {
         }
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         if !self.total_weight.is_empty() {
             struct_ser.serialize_field("totalWeight", &self.total_weight)?;
@@ -1626,7 +1647,7 @@ impl serde::Serialize for GroupInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GroupInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1652,7 +1673,7 @@ impl<'de> serde::Deserialize<'de> for GroupInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1663,13 +1684,13 @@ impl<'de> serde::Deserialize<'de> for GroupInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1691,11 +1712,11 @@ impl<'de> serde::Deserialize<'de> for GroupInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GroupInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.GroupInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GroupInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GroupInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1767,7 +1788,7 @@ impl<'de> serde::Deserialize<'de> for GroupInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GroupMember {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1782,7 +1803,10 @@ impl serde::Serialize for GroupMember {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.GroupMember", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if let Some(v) = self.member.as_ref() {
             struct_ser.serialize_field("member", v)?;
@@ -1793,7 +1817,7 @@ impl serde::Serialize for GroupMember {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GroupMember {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1806,7 +1830,7 @@ impl<'de> serde::Deserialize<'de> for GroupMember {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1817,13 +1841,13 @@ impl<'de> serde::Deserialize<'de> for GroupMember {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1841,11 +1865,11 @@ impl<'de> serde::Deserialize<'de> for GroupMember {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GroupMember;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.GroupMember")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GroupMember, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GroupMember, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1882,7 +1906,7 @@ impl<'de> serde::Deserialize<'de> for GroupMember {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GroupPolicyInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1915,7 +1939,10 @@ impl serde::Serialize for GroupPolicyInfo {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.admin.is_empty() {
             struct_ser.serialize_field("admin", &self.admin)?;
@@ -1925,7 +1952,10 @@ impl serde::Serialize for GroupPolicyInfo {
         }
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         if let Some(v) = self.decision_policy.as_ref() {
             struct_ser.serialize_field("decisionPolicy", v)?;
@@ -1939,7 +1969,7 @@ impl serde::Serialize for GroupPolicyInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GroupPolicyInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1968,7 +1998,7 @@ impl<'de> serde::Deserialize<'de> for GroupPolicyInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1979,13 +2009,13 @@ impl<'de> serde::Deserialize<'de> for GroupPolicyInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2010,11 +2040,11 @@ impl<'de> serde::Deserialize<'de> for GroupPolicyInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GroupPolicyInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.GroupPolicyInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GroupPolicyInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GroupPolicyInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2094,7 +2124,7 @@ impl<'de> serde::Deserialize<'de> for GroupPolicyInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Member {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2131,7 +2161,7 @@ impl serde::Serialize for Member {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Member {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2146,7 +2176,7 @@ impl<'de> serde::Deserialize<'de> for Member {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2157,13 +2187,13 @@ impl<'de> serde::Deserialize<'de> for Member {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2183,11 +2213,11 @@ impl<'de> serde::Deserialize<'de> for Member {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Member;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.Member")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Member, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Member, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2237,7 +2267,7 @@ impl<'de> serde::Deserialize<'de> for Member {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MemberRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2268,7 +2298,7 @@ impl serde::Serialize for MemberRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MemberRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2282,7 +2312,7 @@ impl<'de> serde::Deserialize<'de> for MemberRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2293,13 +2323,13 @@ impl<'de> serde::Deserialize<'de> for MemberRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2318,11 +2348,11 @@ impl<'de> serde::Deserialize<'de> for MemberRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MemberRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MemberRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MemberRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MemberRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2364,7 +2394,7 @@ impl<'de> serde::Deserialize<'de> for MemberRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroup {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2395,7 +2425,7 @@ impl serde::Serialize for MsgCreateGroup {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroup {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2409,7 +2439,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroup {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2420,13 +2450,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroup {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2445,11 +2475,11 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroup {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroup;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroup")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgCreateGroup, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgCreateGroup, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2491,7 +2521,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroup {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroupPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2516,7 +2546,10 @@ impl serde::Serialize for MsgCreateGroupPolicy {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.metadata.is_empty() {
             struct_ser.serialize_field("metadata", &self.metadata)?;
@@ -2530,7 +2563,7 @@ impl serde::Serialize for MsgCreateGroupPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2552,7 +2585,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2563,13 +2596,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2591,14 +2624,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroupPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroupPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateGroupPolicy, V::Error>
+            ) -> core::result::Result<MsgCreateGroupPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2655,7 +2688,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroupPolicyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2675,7 +2708,7 @@ impl serde::Serialize for MsgCreateGroupPolicyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2687,7 +2720,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicyResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2698,13 +2731,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicyResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2721,14 +2754,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicyResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroupPolicyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroupPolicyResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateGroupPolicyResponse, V::Error>
+            ) -> core::result::Result<MsgCreateGroupPolicyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2758,7 +2791,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupPolicyResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroupResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2771,7 +2804,10 @@ impl serde::Serialize for MsgCreateGroupResponse {
             serializer.serialize_struct("cosmos.group.v1.MsgCreateGroupResponse", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -2779,7 +2815,7 @@ impl serde::Serialize for MsgCreateGroupResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroupResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2791,7 +2827,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2802,13 +2838,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2825,14 +2861,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroupResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroupResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateGroupResponse, V::Error>
+            ) -> core::result::Result<MsgCreateGroupResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2865,7 +2901,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroupWithPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2915,7 +2951,7 @@ impl serde::Serialize for MsgCreateGroupWithPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2943,7 +2979,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2954,13 +2990,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2988,14 +3024,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroupWithPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroupWithPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateGroupWithPolicy, V::Error>
+            ) -> core::result::Result<MsgCreateGroupWithPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3069,7 +3105,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateGroupWithPolicyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3085,7 +3121,10 @@ impl serde::Serialize for MsgCreateGroupWithPolicyResponse {
             serializer.serialize_struct("cosmos.group.v1.MsgCreateGroupWithPolicyResponse", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.group_policy_address.is_empty() {
             struct_ser.serialize_field("groupPolicyAddress", &self.group_policy_address)?;
@@ -3096,7 +3135,7 @@ impl serde::Serialize for MsgCreateGroupWithPolicyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3114,7 +3153,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicyResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3125,13 +3164,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicyResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3151,14 +3190,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicyResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateGroupWithPolicyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgCreateGroupWithPolicyResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateGroupWithPolicyResponse, V::Error>
+            ) -> core::result::Result<MsgCreateGroupWithPolicyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3201,7 +3240,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateGroupWithPolicyResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3218,7 +3257,7 @@ impl serde::Serialize for MsgExec {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.executor.is_empty() {
@@ -3230,7 +3269,7 @@ impl serde::Serialize for MsgExec {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3243,7 +3282,7 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3254,13 +3293,13 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3278,11 +3317,11 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgExec")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgExec, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgExec, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3319,7 +3358,7 @@ impl<'de> serde::Deserialize<'de> for MsgExec {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3331,7 +3370,7 @@ impl serde::Serialize for MsgExecResponse {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.MsgExecResponse", len)?;
         if self.result != 0 {
             let v = ProposalExecutorResult::try_from(self.result).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.result))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.result))
             })?;
             struct_ser.serialize_field("result", &v)?;
         }
@@ -3341,7 +3380,7 @@ impl serde::Serialize for MsgExecResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3353,7 +3392,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3364,13 +3403,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3387,11 +3426,11 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgExecResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgExecResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgExecResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3417,7 +3456,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgLeaveGroup {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3435,7 +3474,10 @@ impl serde::Serialize for MsgLeaveGroup {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -3443,7 +3485,7 @@ impl serde::Serialize for MsgLeaveGroup {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgLeaveGroup {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3456,7 +3498,7 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroup {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3467,13 +3509,13 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroup {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3491,11 +3533,11 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroup {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgLeaveGroup;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgLeaveGroup")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgLeaveGroup, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgLeaveGroup, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3532,7 +3574,7 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroup {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgLeaveGroupResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3546,7 +3588,7 @@ impl serde::Serialize for MsgLeaveGroupResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgLeaveGroupResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3556,7 +3598,7 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroupResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3567,13 +3609,13 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroupResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3587,14 +3629,14 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroupResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgLeaveGroupResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgLeaveGroupResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgLeaveGroupResponse, V::Error>
+            ) -> core::result::Result<MsgLeaveGroupResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3614,7 +3656,7 @@ impl<'de> serde::Deserialize<'de> for MsgLeaveGroupResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3656,8 +3698,9 @@ impl serde::Serialize for MsgSubmitProposal {
             struct_ser.serialize_field("messages", &self.messages)?;
         }
         if self.exec != 0 {
-            let v = Exec::try_from(self.exec)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.exec)))?;
+            let v = Exec::try_from(self.exec).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.exec))
+            })?;
             struct_ser.serialize_field("exec", &v)?;
         }
         if !self.title.is_empty() {
@@ -3672,7 +3715,7 @@ impl serde::Serialize for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3699,7 +3742,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3710,13 +3753,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3741,11 +3784,11 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgSubmitProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSubmitProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSubmitProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3825,7 +3868,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3840,7 +3883,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -3849,7 +3892,7 @@ impl serde::Serialize for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3861,7 +3904,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3872,13 +3915,13 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3895,14 +3938,14 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSubmitProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgSubmitProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSubmitProposalResponse, V::Error>
+            ) -> core::result::Result<MsgSubmitProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3935,7 +3978,7 @@ impl<'de> serde::Deserialize<'de> for MsgSubmitProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupAdmin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3957,7 +4000,10 @@ impl serde::Serialize for MsgUpdateGroupAdmin {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.new_admin.is_empty() {
             struct_ser.serialize_field("newAdmin", &self.new_admin)?;
@@ -3968,7 +4014,7 @@ impl serde::Serialize for MsgUpdateGroupAdmin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdmin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3982,7 +4028,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdmin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3993,13 +4039,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdmin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4018,11 +4064,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdmin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupAdmin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupAdmin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateGroupAdmin, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<MsgUpdateGroupAdmin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4071,7 +4120,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdmin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4085,7 +4134,7 @@ impl serde::Serialize for MsgUpdateGroupAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4095,7 +4144,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdminResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4106,13 +4155,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4126,14 +4175,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupAdminResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4153,7 +4202,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupMembers {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4175,7 +4224,10 @@ impl serde::Serialize for MsgUpdateGroupMembers {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.member_updates.is_empty() {
             struct_ser.serialize_field("memberUpdates", &self.member_updates)?;
@@ -4186,7 +4238,7 @@ impl serde::Serialize for MsgUpdateGroupMembers {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembers {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4206,7 +4258,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembers {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4217,13 +4269,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembers {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4242,14 +4294,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembers {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupMembers;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupMembers")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupMembers, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupMembers, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4298,7 +4350,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembers {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupMembersResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4312,7 +4364,7 @@ impl serde::Serialize for MsgUpdateGroupMembersResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembersResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4322,7 +4374,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembersResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4333,13 +4385,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembersResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4353,14 +4405,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembersResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupMembersResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupMembersResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupMembersResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupMembersResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4380,7 +4432,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMembersResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupMetadata {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4402,7 +4454,10 @@ impl serde::Serialize for MsgUpdateGroupMetadata {
         }
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if !self.metadata.is_empty() {
             struct_ser.serialize_field("metadata", &self.metadata)?;
@@ -4413,7 +4468,7 @@ impl serde::Serialize for MsgUpdateGroupMetadata {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadata {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4427,7 +4482,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadata {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4438,13 +4493,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadata {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4463,14 +4518,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadata {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupMetadata;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupMetadata")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupMetadata, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupMetadata, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4519,7 +4574,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadata {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupMetadataResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4533,7 +4588,7 @@ impl serde::Serialize for MsgUpdateGroupMetadataResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadataResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4543,7 +4598,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadataResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4554,13 +4609,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadataResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4574,14 +4629,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadataResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupMetadataResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupMetadataResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupMetadataResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupMetadataResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4601,7 +4656,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupMetadataResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyAdmin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4633,7 +4688,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyAdmin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdmin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4653,7 +4708,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdmin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4664,13 +4719,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdmin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4691,14 +4746,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdmin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyAdmin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyAdmin")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyAdmin, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyAdmin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4746,7 +4801,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdmin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4760,7 +4815,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4770,7 +4825,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdminResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4781,13 +4836,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4801,14 +4856,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyAdminResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4828,7 +4883,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyDecisionPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4860,7 +4915,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyDecisionPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4880,7 +4935,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4891,13 +4946,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4920,14 +4975,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyDecisionPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyDecisionPolicy, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyDecisionPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4975,7 +5030,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyDecisionPolicyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4991,7 +5046,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyDecisionPolicyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5001,7 +5056,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5012,13 +5067,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5032,7 +5087,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyDecisionPolicyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicyResponse")
             }
@@ -5040,7 +5095,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyDecisionPolicyResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyDecisionPolicyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5060,7 +5115,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyDecisionPolicyResponse
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyMetadata {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5092,7 +5147,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyMetadata {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadata {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5111,7 +5166,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadata {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5122,13 +5177,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadata {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5149,14 +5204,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadata {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyMetadata;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyMetadata")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyMetadata, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyMetadata, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5204,7 +5259,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadata {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateGroupPolicyMetadataResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5218,7 +5273,7 @@ impl serde::Serialize for MsgUpdateGroupPolicyMetadataResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadataResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5228,7 +5283,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadataResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5239,13 +5294,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadataResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5259,14 +5314,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadataResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateGroupPolicyMetadataResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgUpdateGroupPolicyMetadataResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateGroupPolicyMetadataResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateGroupPolicyMetadataResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5286,7 +5341,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateGroupPolicyMetadataResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5312,7 +5367,7 @@ impl serde::Serialize for MsgVote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -5320,7 +5375,7 @@ impl serde::Serialize for MsgVote {
         }
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -5328,8 +5383,9 @@ impl serde::Serialize for MsgVote {
             struct_ser.serialize_field("metadata", &self.metadata)?;
         }
         if self.exec != 0 {
-            let v = Exec::try_from(self.exec)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.exec)))?;
+            let v = Exec::try_from(self.exec).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.exec))
+            })?;
             struct_ser.serialize_field("exec", &v)?;
         }
         struct_ser.end()
@@ -5338,7 +5394,7 @@ impl serde::Serialize for MsgVote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5361,7 +5417,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5372,13 +5428,13 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5399,11 +5455,11 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgVote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5464,7 +5520,7 @@ impl<'de> serde::Deserialize<'de> for MsgVote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgVoteResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5477,7 +5533,7 @@ impl serde::Serialize for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5487,7 +5543,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5498,13 +5554,13 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5518,11 +5574,11 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgVoteResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgVoteResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgVoteResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgVoteResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5538,7 +5594,7 @@ impl<'de> serde::Deserialize<'de> for MsgVoteResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5556,7 +5612,7 @@ impl serde::Serialize for MsgWithdrawProposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.address.is_empty() {
@@ -5568,7 +5624,7 @@ impl serde::Serialize for MsgWithdrawProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5581,7 +5637,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5592,13 +5648,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5616,11 +5672,14 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgWithdrawProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgWithdrawProposal, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<MsgWithdrawProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5661,7 +5720,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgWithdrawProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5675,7 +5734,7 @@ impl serde::Serialize for MsgWithdrawProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgWithdrawProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5685,7 +5744,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposalResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5696,13 +5755,13 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5716,14 +5775,14 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgWithdrawProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.MsgWithdrawProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgWithdrawProposalResponse, V::Error>
+            ) -> core::result::Result<MsgWithdrawProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5743,7 +5802,7 @@ impl<'de> serde::Deserialize<'de> for MsgWithdrawProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PercentageDecisionPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5769,7 +5828,7 @@ impl serde::Serialize for PercentageDecisionPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PercentageDecisionPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5782,7 +5841,7 @@ impl<'de> serde::Deserialize<'de> for PercentageDecisionPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5793,13 +5852,13 @@ impl<'de> serde::Deserialize<'de> for PercentageDecisionPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5817,14 +5876,14 @@ impl<'de> serde::Deserialize<'de> for PercentageDecisionPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PercentageDecisionPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.PercentageDecisionPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<PercentageDecisionPolicy, V::Error>
+            ) -> core::result::Result<PercentageDecisionPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5862,7 +5921,7 @@ impl<'de> serde::Deserialize<'de> for PercentageDecisionPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Proposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5913,7 +5972,8 @@ impl serde::Serialize for Proposal {
         let mut struct_ser = serializer.serialize_struct("cosmos.group.v1.Proposal", len)?;
         if self.id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("id", ToString::to_string(&self.id).as_str())?;
+            struct_ser
+                .serialize_field("id", alloc::string::ToString::to_string(&self.id).as_str())?;
         }
         if !self.group_policy_address.is_empty() {
             struct_ser.serialize_field("groupPolicyAddress", &self.group_policy_address)?;
@@ -5931,19 +5991,19 @@ impl serde::Serialize for Proposal {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "groupVersion",
-                ToString::to_string(&self.group_version).as_str(),
+                alloc::string::ToString::to_string(&self.group_version).as_str(),
             )?;
         }
         if self.group_policy_version != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "groupPolicyVersion",
-                ToString::to_string(&self.group_policy_version).as_str(),
+                alloc::string::ToString::to_string(&self.group_policy_version).as_str(),
             )?;
         }
         if self.status != 0 {
             let v = ProposalStatus::try_from(self.status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.status))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.status))
             })?;
             struct_ser.serialize_field("status", &v)?;
         }
@@ -5955,7 +6015,10 @@ impl serde::Serialize for Proposal {
         }
         if self.executor_result != 0 {
             let v = ProposalExecutorResult::try_from(self.executor_result).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.executor_result))
+                serde::ser::Error::custom(alloc::format!(
+                    "Invalid variant {}",
+                    self.executor_result
+                ))
             })?;
             struct_ser.serialize_field("executorResult", &v)?;
         }
@@ -5974,7 +6037,7 @@ impl serde::Serialize for Proposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Proposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6021,7 +6084,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6032,13 +6095,13 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6078,11 +6141,11 @@ impl<'de> serde::Deserialize<'de> for Proposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Proposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.Proposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Proposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Proposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6226,7 +6289,7 @@ impl<'de> serde::Deserialize<'de> for Proposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProposalExecutorResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6242,7 +6305,7 @@ impl serde::Serialize for ProposalExecutorResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProposalExecutorResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6258,11 +6321,11 @@ impl<'de> serde::Deserialize<'de> for ProposalExecutorResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProposalExecutorResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6274,7 +6337,7 @@ impl<'de> serde::Deserialize<'de> for ProposalExecutorResult {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6286,7 +6349,7 @@ impl<'de> serde::Deserialize<'de> for ProposalExecutorResult {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6307,7 +6370,7 @@ impl<'de> serde::Deserialize<'de> for ProposalExecutorResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ProposalStatus {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6325,7 +6388,7 @@ impl serde::Serialize for ProposalStatus {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ProposalStatus {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6343,11 +6406,11 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProposalStatus;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6359,7 +6422,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6371,7 +6434,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -6392,7 +6455,7 @@ impl<'de> serde::Deserialize<'de> for ProposalStatus {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6405,7 +6468,10 @@ impl serde::Serialize for QueryGroupInfoRequest {
             serializer.serialize_struct("cosmos.group.v1.QueryGroupInfoRequest", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -6413,7 +6479,7 @@ impl serde::Serialize for QueryGroupInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6425,7 +6491,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6436,13 +6502,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6459,14 +6525,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupInfoRequest, V::Error>
+            ) -> core::result::Result<QueryGroupInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6499,7 +6565,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6519,7 +6585,7 @@ impl serde::Serialize for QueryGroupInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6531,7 +6597,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6542,13 +6608,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6565,14 +6631,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupInfoResponse, V::Error>
+            ) -> core::result::Result<QueryGroupInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6600,7 +6666,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupMembersRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6616,7 +6682,10 @@ impl serde::Serialize for QueryGroupMembersRequest {
             serializer.serialize_struct("cosmos.group.v1.QueryGroupMembersRequest", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if let Some(v) = self.pagination.as_ref() {
             struct_ser.serialize_field("pagination", v)?;
@@ -6627,7 +6696,7 @@ impl serde::Serialize for QueryGroupMembersRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupMembersRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6640,7 +6709,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6651,13 +6720,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6675,14 +6744,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupMembersRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupMembersRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupMembersRequest, V::Error>
+            ) -> core::result::Result<QueryGroupMembersRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6723,7 +6792,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupMembersResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6749,7 +6818,7 @@ impl serde::Serialize for QueryGroupMembersResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupMembersResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6762,7 +6831,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6773,13 +6842,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6797,14 +6866,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupMembersResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupMembersResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupMembersResponse, V::Error>
+            ) -> core::result::Result<QueryGroupMembersResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6842,7 +6911,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMembersResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPoliciesByAdminRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6868,7 +6937,7 @@ impl serde::Serialize for QueryGroupPoliciesByAdminRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6881,7 +6950,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6892,13 +6961,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6916,14 +6985,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPoliciesByAdminRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPoliciesByAdminRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPoliciesByAdminRequest, V::Error>
+            ) -> core::result::Result<QueryGroupPoliciesByAdminRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6961,7 +7030,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPoliciesByAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6987,7 +7056,7 @@ impl serde::Serialize for QueryGroupPoliciesByAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7000,7 +7069,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7011,13 +7080,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7035,14 +7104,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPoliciesByAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPoliciesByAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPoliciesByAdminResponse, V::Error>
+            ) -> core::result::Result<QueryGroupPoliciesByAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7080,7 +7149,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPoliciesByGroupRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7096,7 +7165,10 @@ impl serde::Serialize for QueryGroupPoliciesByGroupRequest {
             serializer.serialize_struct("cosmos.group.v1.QueryGroupPoliciesByGroupRequest", len)?;
         if self.group_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("groupId", ToString::to_string(&self.group_id).as_str())?;
+            struct_ser.serialize_field(
+                "groupId",
+                alloc::string::ToString::to_string(&self.group_id).as_str(),
+            )?;
         }
         if let Some(v) = self.pagination.as_ref() {
             struct_ser.serialize_field("pagination", v)?;
@@ -7107,7 +7179,7 @@ impl serde::Serialize for QueryGroupPoliciesByGroupRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7120,7 +7192,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7131,13 +7203,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7155,14 +7227,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPoliciesByGroupRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPoliciesByGroupRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPoliciesByGroupRequest, V::Error>
+            ) -> core::result::Result<QueryGroupPoliciesByGroupRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7203,7 +7275,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPoliciesByGroupResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7229,7 +7301,7 @@ impl serde::Serialize for QueryGroupPoliciesByGroupResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7242,7 +7314,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7253,13 +7325,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7277,14 +7349,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPoliciesByGroupResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPoliciesByGroupResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPoliciesByGroupResponse, V::Error>
+            ) -> core::result::Result<QueryGroupPoliciesByGroupResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7322,7 +7394,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPoliciesByGroupResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPolicyInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7342,7 +7414,7 @@ impl serde::Serialize for QueryGroupPolicyInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7354,7 +7426,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7365,13 +7437,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7388,14 +7460,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPolicyInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPolicyInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPolicyInfoRequest, V::Error>
+            ) -> core::result::Result<QueryGroupPolicyInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7425,7 +7497,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupPolicyInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7445,7 +7517,7 @@ impl serde::Serialize for QueryGroupPolicyInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7457,7 +7529,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7468,13 +7540,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7491,14 +7563,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupPolicyInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupPolicyInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupPolicyInfoResponse, V::Error>
+            ) -> core::result::Result<QueryGroupPolicyInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7526,7 +7598,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupPolicyInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsByAdminRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7552,7 +7624,7 @@ impl serde::Serialize for QueryGroupsByAdminRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7565,7 +7637,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7576,13 +7648,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7600,14 +7672,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsByAdminRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsByAdminRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupsByAdminRequest, V::Error>
+            ) -> core::result::Result<QueryGroupsByAdminRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7645,7 +7717,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsByAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7671,7 +7743,7 @@ impl serde::Serialize for QueryGroupsByAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7684,7 +7756,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7695,13 +7767,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7719,14 +7791,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsByAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsByAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupsByAdminResponse, V::Error>
+            ) -> core::result::Result<QueryGroupsByAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7764,7 +7836,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsByMemberRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7790,7 +7862,7 @@ impl serde::Serialize for QueryGroupsByMemberRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7803,7 +7875,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7814,13 +7886,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7838,14 +7910,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsByMemberRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsByMemberRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupsByMemberRequest, V::Error>
+            ) -> core::result::Result<QueryGroupsByMemberRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7883,7 +7955,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsByMemberResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7909,7 +7981,7 @@ impl serde::Serialize for QueryGroupsByMemberResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7922,7 +7994,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7933,13 +8005,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7957,14 +8029,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsByMemberResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsByMemberResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryGroupsByMemberResponse, V::Error>
+            ) -> core::result::Result<QueryGroupsByMemberResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8002,7 +8074,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsByMemberResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8022,7 +8094,7 @@ impl serde::Serialize for QueryGroupsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8034,7 +8106,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8045,13 +8117,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8068,11 +8140,11 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryGroupsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryGroupsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8102,7 +8174,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryGroupsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8128,7 +8200,7 @@ impl serde::Serialize for QueryGroupsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryGroupsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8141,7 +8213,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8152,13 +8224,13 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8176,11 +8248,14 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryGroupsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryGroupsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryGroupsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryGroupsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8218,7 +8293,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8233,7 +8308,7 @@ impl serde::Serialize for QueryProposalRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -8242,7 +8317,7 @@ impl serde::Serialize for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8254,7 +8329,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8265,13 +8340,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8288,14 +8363,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryProposalRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalRequest, V::Error>
+            ) -> core::result::Result<QueryProposalRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8328,7 +8403,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8348,7 +8423,7 @@ impl serde::Serialize for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8360,7 +8435,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8371,13 +8446,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8394,14 +8469,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalResponse, V::Error>
+            ) -> core::result::Result<QueryProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8431,7 +8506,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsByGroupPolicyRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8457,7 +8532,7 @@ impl serde::Serialize for QueryProposalsByGroupPolicyRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8470,7 +8545,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8481,13 +8556,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8505,14 +8580,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsByGroupPolicyRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryProposalsByGroupPolicyRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsByGroupPolicyRequest, V::Error>
+            ) -> core::result::Result<QueryProposalsByGroupPolicyRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8550,7 +8625,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryProposalsByGroupPolicyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8576,7 +8651,7 @@ impl serde::Serialize for QueryProposalsByGroupPolicyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8589,7 +8664,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8600,13 +8675,13 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8624,14 +8699,14 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryProposalsByGroupPolicyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryProposalsByGroupPolicyResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryProposalsByGroupPolicyResponse, V::Error>
+            ) -> core::result::Result<QueryProposalsByGroupPolicyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8669,7 +8744,7 @@ impl<'de> serde::Deserialize<'de> for QueryProposalsByGroupPolicyResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8684,7 +8759,7 @@ impl serde::Serialize for QueryTallyResultRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         struct_ser.end()
@@ -8693,7 +8768,7 @@ impl serde::Serialize for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8705,7 +8780,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8716,13 +8791,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8739,14 +8814,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryTallyResultRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultRequest, V::Error>
+            ) -> core::result::Result<QueryTallyResultRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8779,7 +8854,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8799,7 +8874,7 @@ impl serde::Serialize for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8811,7 +8886,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8822,13 +8897,13 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8845,14 +8920,14 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryTallyResultResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryTallyResultResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryTallyResultResponse, V::Error>
+            ) -> core::result::Result<QueryTallyResultResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8880,7 +8955,7 @@ impl<'de> serde::Deserialize<'de> for QueryTallyResultResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteByProposalVoterRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8898,7 +8973,7 @@ impl serde::Serialize for QueryVoteByProposalVoterRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -8910,7 +8985,7 @@ impl serde::Serialize for QueryVoteByProposalVoterRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8923,7 +8998,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8934,13 +9009,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8958,14 +9033,14 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteByProposalVoterRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVoteByProposalVoterRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVoteByProposalVoterRequest, V::Error>
+            ) -> core::result::Result<QueryVoteByProposalVoterRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9006,7 +9081,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVoteByProposalVoterResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9026,7 +9101,7 @@ impl serde::Serialize for QueryVoteByProposalVoterResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9038,7 +9113,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9049,13 +9124,13 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9072,14 +9147,14 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVoteByProposalVoterResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVoteByProposalVoterResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVoteByProposalVoterResponse, V::Error>
+            ) -> core::result::Result<QueryVoteByProposalVoterResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9107,7 +9182,7 @@ impl<'de> serde::Deserialize<'de> for QueryVoteByProposalVoterResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesByProposalRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9125,7 +9200,7 @@ impl serde::Serialize for QueryVotesByProposalRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -9137,7 +9212,7 @@ impl serde::Serialize for QueryVotesByProposalRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesByProposalRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9150,7 +9225,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9161,13 +9236,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9185,14 +9260,14 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesByProposalRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVotesByProposalRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVotesByProposalRequest, V::Error>
+            ) -> core::result::Result<QueryVotesByProposalRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9233,7 +9308,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesByProposalResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9259,7 +9334,7 @@ impl serde::Serialize for QueryVotesByProposalResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesByProposalResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9272,7 +9347,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9283,13 +9358,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9307,14 +9382,14 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesByProposalResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVotesByProposalResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVotesByProposalResponse, V::Error>
+            ) -> core::result::Result<QueryVotesByProposalResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9352,7 +9427,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByProposalResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesByVoterRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9378,7 +9453,7 @@ impl serde::Serialize for QueryVotesByVoterRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesByVoterRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9391,7 +9466,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9402,13 +9477,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9426,14 +9501,14 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesByVoterRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVotesByVoterRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVotesByVoterRequest, V::Error>
+            ) -> core::result::Result<QueryVotesByVoterRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9471,7 +9546,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryVotesByVoterResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9497,7 +9572,7 @@ impl serde::Serialize for QueryVotesByVoterResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryVotesByVoterResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9510,7 +9585,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9521,13 +9596,13 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9545,14 +9620,14 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryVotesByVoterResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.QueryVotesByVoterResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryVotesByVoterResponse, V::Error>
+            ) -> core::result::Result<QueryVotesByVoterResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9590,7 +9665,7 @@ impl<'de> serde::Deserialize<'de> for QueryVotesByVoterResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TallyResult {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9627,7 +9702,7 @@ impl serde::Serialize for TallyResult {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TallyResult {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9651,7 +9726,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9662,13 +9737,13 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9690,11 +9765,11 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TallyResult;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.TallyResult")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TallyResult, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TallyResult, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9744,7 +9819,7 @@ impl<'de> serde::Deserialize<'de> for TallyResult {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ThresholdDecisionPolicy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9770,7 +9845,7 @@ impl serde::Serialize for ThresholdDecisionPolicy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ThresholdDecisionPolicy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9783,7 +9858,7 @@ impl<'de> serde::Deserialize<'de> for ThresholdDecisionPolicy {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9794,13 +9869,13 @@ impl<'de> serde::Deserialize<'de> for ThresholdDecisionPolicy {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9818,14 +9893,14 @@ impl<'de> serde::Deserialize<'de> for ThresholdDecisionPolicy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ThresholdDecisionPolicy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.ThresholdDecisionPolicy")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ThresholdDecisionPolicy, V::Error>
+            ) -> core::result::Result<ThresholdDecisionPolicy, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9863,7 +9938,7 @@ impl<'de> serde::Deserialize<'de> for ThresholdDecisionPolicy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Vote {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9889,7 +9964,7 @@ impl serde::Serialize for Vote {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "proposalId",
-                ToString::to_string(&self.proposal_id).as_str(),
+                alloc::string::ToString::to_string(&self.proposal_id).as_str(),
             )?;
         }
         if !self.voter.is_empty() {
@@ -9897,7 +9972,7 @@ impl serde::Serialize for Vote {
         }
         if self.option != 0 {
             let v = VoteOption::try_from(self.option).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.option))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.option))
             })?;
             struct_ser.serialize_field("option", &v)?;
         }
@@ -9913,7 +9988,7 @@ impl serde::Serialize for Vote {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Vote {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9937,7 +10012,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9948,13 +10023,13 @@ impl<'de> serde::Deserialize<'de> for Vote {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9975,11 +10050,11 @@ impl<'de> serde::Deserialize<'de> for Vote {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Vote;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.group.v1.Vote")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Vote, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Vote, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10040,7 +10115,7 @@ impl<'de> serde::Deserialize<'de> for Vote {
 #[cfg(feature = "serde")]
 impl serde::Serialize for VoteOption {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10057,7 +10132,7 @@ impl serde::Serialize for VoteOption {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for VoteOption {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10074,11 +10149,11 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = VoteOption;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -10090,7 +10165,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -10102,7 +10177,7 @@ impl<'de> serde::Deserialize<'de> for VoteOption {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.group.v1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn group_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn group_policy_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupPolicyInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupPolicyInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupPolicyInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -125,12 +125,12 @@ pub mod query_client {
         pub async fn group_members(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupMembersRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupMembersResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupMembersResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -143,12 +143,12 @@ pub mod query_client {
         pub async fn groups_by_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupsByAdminRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsByAdminResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsByAdminResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -161,14 +161,14 @@ pub mod query_client {
         pub async fn group_policies_by_group(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupPoliciesByGroupRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryGroupPoliciesByGroupResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -184,14 +184,14 @@ pub mod query_client {
         pub async fn group_policies_by_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupPoliciesByAdminRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryGroupPoliciesByAdminResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -207,12 +207,12 @@ pub mod query_client {
         pub async fn proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -225,14 +225,14 @@ pub mod query_client {
         pub async fn proposals_by_group_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryProposalsByGroupPolicyRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryProposalsByGroupPolicyResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -249,14 +249,14 @@ pub mod query_client {
         pub async fn vote_by_proposal_voter(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVoteByProposalVoterRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryVoteByProposalVoterResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -272,12 +272,12 @@ pub mod query_client {
         pub async fn votes_by_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVotesByProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesByProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryVotesByProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -291,12 +291,12 @@ pub mod query_client {
         pub async fn votes_by_voter(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryVotesByVoterRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesByVoterResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryVotesByVoterResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -309,12 +309,12 @@ pub mod query_client {
         pub async fn groups_by_member(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupsByMemberRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsByMemberResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsByMemberResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -328,12 +328,12 @@ pub mod query_client {
         pub async fn tally_result(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -346,12 +346,12 @@ pub mod query_client {
         pub async fn groups(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryGroupsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -374,71 +374,71 @@ pub mod query_server {
         async fn group_info(
             &self,
             request: tonic::Request<super::QueryGroupInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupInfoResponse>, tonic::Status>;
         async fn group_policy_info(
             &self,
             request: tonic::Request<super::QueryGroupPolicyInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupPolicyInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupPolicyInfoResponse>, tonic::Status>;
         async fn group_members(
             &self,
             request: tonic::Request<super::QueryGroupMembersRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupMembersResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupMembersResponse>, tonic::Status>;
         async fn groups_by_admin(
             &self,
             request: tonic::Request<super::QueryGroupsByAdminRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsByAdminResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsByAdminResponse>, tonic::Status>;
         async fn group_policies_by_group(
             &self,
             request: tonic::Request<super::QueryGroupPoliciesByGroupRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryGroupPoliciesByGroupResponse>,
             tonic::Status,
         >;
         async fn group_policies_by_admin(
             &self,
             request: tonic::Request<super::QueryGroupPoliciesByAdminRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryGroupPoliciesByAdminResponse>,
             tonic::Status,
         >;
         async fn proposal(
             &self,
             request: tonic::Request<super::QueryProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryProposalResponse>, tonic::Status>;
         async fn proposals_by_group_policy(
             &self,
             request: tonic::Request<super::QueryProposalsByGroupPolicyRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryProposalsByGroupPolicyResponse>,
             tonic::Status,
         >;
         async fn vote_by_proposal_voter(
             &self,
             request: tonic::Request<super::QueryVoteByProposalVoterRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryVoteByProposalVoterResponse>,
             tonic::Status,
         >;
         async fn votes_by_proposal(
             &self,
             request: tonic::Request<super::QueryVotesByProposalRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesByProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVotesByProposalResponse>, tonic::Status>;
         async fn votes_by_voter(
             &self,
             request: tonic::Request<super::QueryVotesByVoterRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryVotesByVoterResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryVotesByVoterResponse>, tonic::Status>;
         async fn groups_by_member(
             &self,
             request: tonic::Request<super::QueryGroupsByMemberRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsByMemberResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsByMemberResponse>, tonic::Status>;
         async fn tally_result(
             &self,
             request: tonic::Request<super::QueryTallyResultRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryTallyResultResponse>, tonic::Status>;
         async fn groups(
             &self,
             request: tonic::Request<super::QueryGroupsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryGroupsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryGroupsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -510,7 +510,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1099,8 +1099,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -1194,12 +1194,12 @@ pub mod msg_client {
         pub async fn create_group(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateGroup>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateGroupResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgCreateGroupResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1212,12 +1212,14 @@ pub mod msg_client {
         pub async fn update_group_members(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupMembers>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateGroupMembersResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::MsgUpdateGroupMembersResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1231,12 +1233,12 @@ pub mod msg_client {
         pub async fn update_group_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupAdmin>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateGroupAdminResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateGroupAdminResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1250,14 +1252,14 @@ pub mod msg_client {
         pub async fn update_group_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupMetadata>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupMetadataResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1273,12 +1275,12 @@ pub mod msg_client {
         pub async fn create_group_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateGroupPolicy>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateGroupPolicyResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgCreateGroupPolicyResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1292,14 +1294,14 @@ pub mod msg_client {
         pub async fn create_group_with_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateGroupWithPolicy>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreateGroupWithPolicyResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1315,14 +1317,14 @@ pub mod msg_client {
         pub async fn update_group_policy_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupPolicyAdmin>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyAdminResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1338,14 +1340,14 @@ pub mod msg_client {
         pub async fn update_group_policy_decision_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupPolicyDecisionPolicy>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyDecisionPolicyResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1362,14 +1364,14 @@ pub mod msg_client {
         pub async fn update_group_policy_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateGroupPolicyMetadata>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyMetadataResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1386,12 +1388,12 @@ pub mod msg_client {
         pub async fn submit_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1404,12 +1406,12 @@ pub mod msg_client {
         pub async fn withdraw_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgWithdrawProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgWithdrawProposalResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgWithdrawProposalResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1423,11 +1425,11 @@ pub mod msg_client {
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1440,11 +1442,11 @@ pub mod msg_client {
         pub async fn exec(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgExec>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1457,12 +1459,12 @@ pub mod msg_client {
         pub async fn leave_group(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgLeaveGroup>,
-        ) -> std::result::Result<tonic::Response<super::MsgLeaveGroupResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgLeaveGroupResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1485,74 +1487,77 @@ pub mod msg_server {
         async fn create_group(
             &self,
             request: tonic::Request<super::MsgCreateGroup>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateGroupResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgCreateGroupResponse>, tonic::Status>;
         async fn update_group_members(
             &self,
             request: tonic::Request<super::MsgUpdateGroupMembers>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateGroupMembersResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::MsgUpdateGroupMembersResponse>,
+            tonic::Status,
+        >;
         async fn update_group_admin(
             &self,
             request: tonic::Request<super::MsgUpdateGroupAdmin>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateGroupAdminResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateGroupAdminResponse>, tonic::Status>;
         async fn update_group_metadata(
             &self,
             request: tonic::Request<super::MsgUpdateGroupMetadata>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupMetadataResponse>,
             tonic::Status,
         >;
         async fn create_group_policy(
             &self,
             request: tonic::Request<super::MsgCreateGroupPolicy>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateGroupPolicyResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgCreateGroupPolicyResponse>, tonic::Status>;
         async fn create_group_with_policy(
             &self,
             request: tonic::Request<super::MsgCreateGroupWithPolicy>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreateGroupWithPolicyResponse>,
             tonic::Status,
         >;
         async fn update_group_policy_admin(
             &self,
             request: tonic::Request<super::MsgUpdateGroupPolicyAdmin>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyAdminResponse>,
             tonic::Status,
         >;
         async fn update_group_policy_decision_policy(
             &self,
             request: tonic::Request<super::MsgUpdateGroupPolicyDecisionPolicy>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyDecisionPolicyResponse>,
             tonic::Status,
         >;
         async fn update_group_policy_metadata(
             &self,
             request: tonic::Request<super::MsgUpdateGroupPolicyMetadata>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateGroupPolicyMetadataResponse>,
             tonic::Status,
         >;
         async fn submit_proposal(
             &self,
             request: tonic::Request<super::MsgSubmitProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSubmitProposalResponse>, tonic::Status>;
         async fn withdraw_proposal(
             &self,
             request: tonic::Request<super::MsgWithdrawProposal>,
-        ) -> std::result::Result<tonic::Response<super::MsgWithdrawProposalResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgWithdrawProposalResponse>, tonic::Status>;
         async fn vote(
             &self,
             request: tonic::Request<super::MsgVote>,
-        ) -> std::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgVoteResponse>, tonic::Status>;
         async fn exec(
             &self,
             request: tonic::Request<super::MsgExec>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgExecResponse>, tonic::Status>;
         async fn leave_group(
             &self,
             request: tonic::Request<super::MsgLeaveGroup>,
-        ) -> std::result::Result<tonic::Response<super::MsgLeaveGroupResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgLeaveGroupResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1624,7 +1629,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -2208,8 +2213,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -77,11 +77,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,11 +76,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -118,7 +118,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Minter {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -143,7 +143,7 @@ impl serde::Serialize for Minter {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Minter {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -156,7 +156,7 @@ impl<'de> serde::Deserialize<'de> for Minter {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -167,13 +167,13 @@ impl<'de> serde::Deserialize<'de> for Minter {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -193,11 +193,11 @@ impl<'de> serde::Deserialize<'de> for Minter {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Minter;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.Minter")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Minter, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Minter, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -231,7 +231,7 @@ impl<'de> serde::Deserialize<'de> for Minter {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -257,7 +257,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -270,7 +270,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -281,13 +281,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -305,11 +305,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -347,7 +347,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -361,7 +361,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -371,7 +371,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -382,13 +382,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -402,14 +402,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -429,7 +429,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -473,7 +473,7 @@ impl serde::Serialize for Params {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "blocksPerYear",
-                ToString::to_string(&self.blocks_per_year).as_str(),
+                alloc::string::ToString::to_string(&self.blocks_per_year).as_str(),
             )?;
         }
         struct_ser.end()
@@ -482,7 +482,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -512,7 +512,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -523,13 +523,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -555,11 +555,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -630,7 +630,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAnnualProvisionsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -644,7 +644,7 @@ impl serde::Serialize for QueryAnnualProvisionsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -654,7 +654,7 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -665,13 +665,13 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -685,14 +685,14 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAnnualProvisionsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryAnnualProvisionsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAnnualProvisionsRequest, V::Error>
+            ) -> core::result::Result<QueryAnnualProvisionsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -712,7 +712,7 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAnnualProvisionsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -736,7 +736,7 @@ impl serde::Serialize for QueryAnnualProvisionsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -748,7 +748,7 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -759,13 +759,13 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -784,14 +784,14 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAnnualProvisionsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryAnnualProvisionsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAnnualProvisionsResponse, V::Error>
+            ) -> core::result::Result<QueryAnnualProvisionsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -824,7 +824,7 @@ impl<'de> serde::Deserialize<'de> for QueryAnnualProvisionsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryInflationRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -838,7 +838,7 @@ impl serde::Serialize for QueryInflationRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryInflationRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -848,7 +848,7 @@ impl<'de> serde::Deserialize<'de> for QueryInflationRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -859,13 +859,13 @@ impl<'de> serde::Deserialize<'de> for QueryInflationRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -879,14 +879,14 @@ impl<'de> serde::Deserialize<'de> for QueryInflationRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryInflationRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryInflationRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryInflationRequest, V::Error>
+            ) -> core::result::Result<QueryInflationRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -906,7 +906,7 @@ impl<'de> serde::Deserialize<'de> for QueryInflationRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryInflationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -930,7 +930,7 @@ impl serde::Serialize for QueryInflationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryInflationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -942,7 +942,7 @@ impl<'de> serde::Deserialize<'de> for QueryInflationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -953,13 +953,13 @@ impl<'de> serde::Deserialize<'de> for QueryInflationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -976,14 +976,14 @@ impl<'de> serde::Deserialize<'de> for QueryInflationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryInflationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryInflationResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryInflationResponse, V::Error>
+            ) -> core::result::Result<QueryInflationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1016,7 +1016,7 @@ impl<'de> serde::Deserialize<'de> for QueryInflationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1030,7 +1030,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1040,7 +1040,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1051,13 +1051,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1071,11 +1071,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1095,7 +1095,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1115,7 +1115,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1127,7 +1127,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1138,13 +1138,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1161,11 +1161,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.mint.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.mint.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn inflation(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryInflationRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryInflationResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryInflationResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -124,12 +124,14 @@ pub mod query_client {
         pub async fn annual_provisions(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAnnualProvisionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAnnualProvisionsResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::QueryAnnualProvisionsResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -155,15 +157,18 @@ pub mod query_server {
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn inflation(
             &self,
             request: tonic::Request<super::QueryInflationRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryInflationResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryInflationResponse>, tonic::Status>;
         async fn annual_provisions(
             &self,
             request: tonic::Request<super::QueryAnnualProvisionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAnnualProvisionsResponse>, tonic::Status>;
+        ) -> core::result::Result<
+            tonic::Response<super::QueryAnnualProvisionsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -235,7 +240,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -385,8 +390,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -480,12 +485,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -509,7 +514,7 @@ pub mod msg_server {
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -581,7 +586,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -653,8 +658,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Class {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -57,7 +57,7 @@ impl serde::Serialize for Class {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Class {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -84,7 +84,7 @@ impl<'de> serde::Deserialize<'de> for Class {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -95,13 +95,13 @@ impl<'de> serde::Deserialize<'de> for Class {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -124,11 +124,11 @@ impl<'de> serde::Deserialize<'de> for Class {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Class;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.Class")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Class, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Class, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -202,7 +202,7 @@ impl<'de> serde::Deserialize<'de> for Class {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Entry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -227,7 +227,7 @@ impl serde::Serialize for Entry {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Entry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -240,7 +240,7 @@ impl<'de> serde::Deserialize<'de> for Entry {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -251,13 +251,13 @@ impl<'de> serde::Deserialize<'de> for Entry {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -275,11 +275,11 @@ impl<'de> serde::Deserialize<'de> for Entry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Entry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.Entry")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Entry, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Entry, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -313,7 +313,7 @@ impl<'de> serde::Deserialize<'de> for Entry {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventBurn {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -344,7 +344,7 @@ impl serde::Serialize for EventBurn {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventBurn {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -358,7 +358,7 @@ impl<'de> serde::Deserialize<'de> for EventBurn {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -369,13 +369,13 @@ impl<'de> serde::Deserialize<'de> for EventBurn {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -394,11 +394,11 @@ impl<'de> serde::Deserialize<'de> for EventBurn {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventBurn;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.EventBurn")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventBurn, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventBurn, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -440,7 +440,7 @@ impl<'de> serde::Deserialize<'de> for EventBurn {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventMint {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -471,7 +471,7 @@ impl serde::Serialize for EventMint {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventMint {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -485,7 +485,7 @@ impl<'de> serde::Deserialize<'de> for EventMint {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -496,13 +496,13 @@ impl<'de> serde::Deserialize<'de> for EventMint {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -521,11 +521,11 @@ impl<'de> serde::Deserialize<'de> for EventMint {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventMint;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.EventMint")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventMint, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventMint, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -567,7 +567,7 @@ impl<'de> serde::Deserialize<'de> for EventMint {
 #[cfg(feature = "serde")]
 impl serde::Serialize for EventSend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -604,7 +604,7 @@ impl serde::Serialize for EventSend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for EventSend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -619,7 +619,7 @@ impl<'de> serde::Deserialize<'de> for EventSend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -630,13 +630,13 @@ impl<'de> serde::Deserialize<'de> for EventSend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -656,11 +656,11 @@ impl<'de> serde::Deserialize<'de> for EventSend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = EventSend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.EventSend")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<EventSend, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<EventSend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -710,7 +710,7 @@ impl<'de> serde::Deserialize<'de> for EventSend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -735,7 +735,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -748,7 +748,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -759,13 +759,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -783,11 +783,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -821,7 +821,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -858,7 +858,7 @@ impl serde::Serialize for MsgSend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -873,7 +873,7 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -884,13 +884,13 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -910,11 +910,11 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.MsgSend")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSend, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -964,7 +964,7 @@ impl<'de> serde::Deserialize<'de> for MsgSend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSendResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -977,7 +977,7 @@ impl serde::Serialize for MsgSendResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSendResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -987,7 +987,7 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -998,13 +998,13 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1018,11 +1018,11 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSendResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.MsgSendResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSendResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSendResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1042,7 +1042,7 @@ impl<'de> serde::Deserialize<'de> for MsgSendResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Nft {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1085,7 +1085,7 @@ impl serde::Serialize for Nft {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Nft {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1103,7 +1103,7 @@ impl<'de> serde::Deserialize<'de> for Nft {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1114,13 +1114,13 @@ impl<'de> serde::Deserialize<'de> for Nft {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1141,11 +1141,11 @@ impl<'de> serde::Deserialize<'de> for Nft {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Nft;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.NFT")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Nft, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Nft, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1203,7 +1203,7 @@ impl<'de> serde::Deserialize<'de> for Nft {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBalanceRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1229,7 +1229,7 @@ impl serde::Serialize for QueryBalanceRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1242,7 +1242,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1253,13 +1253,13 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1277,11 +1277,14 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBalanceRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryBalanceRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryBalanceRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryBalanceRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1319,7 +1322,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBalanceResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1332,7 +1335,10 @@ impl serde::Serialize for QueryBalanceResponse {
             serializer.serialize_struct("cosmos.nft.v1beta1.QueryBalanceResponse", len)?;
         if self.amount != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("amount", ToString::to_string(&self.amount).as_str())?;
+            struct_ser.serialize_field(
+                "amount",
+                alloc::string::ToString::to_string(&self.amount).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -1340,7 +1346,7 @@ impl serde::Serialize for QueryBalanceResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1352,7 +1358,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1363,13 +1369,13 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1386,14 +1392,14 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBalanceResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryBalanceResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryBalanceResponse, V::Error>
+            ) -> core::result::Result<QueryBalanceResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1426,7 +1432,7 @@ impl<'de> serde::Deserialize<'de> for QueryBalanceResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryClassRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1446,7 +1452,7 @@ impl serde::Serialize for QueryClassRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryClassRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1458,7 +1464,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1469,13 +1475,13 @@ impl<'de> serde::Deserialize<'de> for QueryClassRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1492,11 +1498,11 @@ impl<'de> serde::Deserialize<'de> for QueryClassRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryClassRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryClassRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryClassRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryClassRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1526,7 +1532,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryClassResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1546,7 +1552,7 @@ impl serde::Serialize for QueryClassResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryClassResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1558,7 +1564,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1569,13 +1575,13 @@ impl<'de> serde::Deserialize<'de> for QueryClassResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1592,11 +1598,11 @@ impl<'de> serde::Deserialize<'de> for QueryClassResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryClassResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryClassResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryClassResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryClassResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1624,7 +1630,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryClassesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1644,7 +1650,7 @@ impl serde::Serialize for QueryClassesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryClassesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1656,7 +1662,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1667,13 +1673,13 @@ impl<'de> serde::Deserialize<'de> for QueryClassesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1690,11 +1696,14 @@ impl<'de> serde::Deserialize<'de> for QueryClassesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryClassesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryClassesRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryClassesRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryClassesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1724,7 +1733,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryClassesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1750,7 +1759,7 @@ impl serde::Serialize for QueryClassesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryClassesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1763,7 +1772,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1774,13 +1783,13 @@ impl<'de> serde::Deserialize<'de> for QueryClassesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1798,14 +1807,14 @@ impl<'de> serde::Deserialize<'de> for QueryClassesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryClassesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryClassesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryClassesResponse, V::Error>
+            ) -> core::result::Result<QueryClassesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1843,7 +1852,7 @@ impl<'de> serde::Deserialize<'de> for QueryClassesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryNftRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1869,7 +1878,7 @@ impl serde::Serialize for QueryNftRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryNftRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1882,7 +1891,7 @@ impl<'de> serde::Deserialize<'de> for QueryNftRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1893,13 +1902,13 @@ impl<'de> serde::Deserialize<'de> for QueryNftRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1917,11 +1926,11 @@ impl<'de> serde::Deserialize<'de> for QueryNftRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryNftRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryNFTRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryNftRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryNftRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1959,7 +1968,7 @@ impl<'de> serde::Deserialize<'de> for QueryNftRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryNftResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1979,7 +1988,7 @@ impl serde::Serialize for QueryNftResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryNftResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1991,7 +2000,7 @@ impl<'de> serde::Deserialize<'de> for QueryNftResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2002,13 +2011,13 @@ impl<'de> serde::Deserialize<'de> for QueryNftResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2025,11 +2034,11 @@ impl<'de> serde::Deserialize<'de> for QueryNftResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryNftResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryNFTResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryNftResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryNftResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2057,7 +2066,7 @@ impl<'de> serde::Deserialize<'de> for QueryNftResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryNfTsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2089,7 +2098,7 @@ impl serde::Serialize for QueryNfTsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryNfTsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2103,7 +2112,7 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2114,13 +2123,13 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2139,11 +2148,11 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryNfTsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryNFTsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryNfTsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryNfTsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2189,7 +2198,7 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryNfTsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2215,7 +2224,7 @@ impl serde::Serialize for QueryNfTsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryNfTsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2228,7 +2237,7 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2239,13 +2248,13 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2263,11 +2272,11 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryNfTsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryNFTsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryNfTsResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryNfTsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2305,7 +2314,7 @@ impl<'de> serde::Deserialize<'de> for QueryNfTsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryOwnerRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2331,7 +2340,7 @@ impl serde::Serialize for QueryOwnerRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryOwnerRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2344,7 +2353,7 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2355,13 +2364,13 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2379,11 +2388,11 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryOwnerRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryOwnerRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryOwnerRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryOwnerRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2421,7 +2430,7 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryOwnerResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2441,7 +2450,7 @@ impl serde::Serialize for QueryOwnerResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryOwnerResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2453,7 +2462,7 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2464,13 +2473,13 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2487,11 +2496,11 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryOwnerResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QueryOwnerResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryOwnerResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryOwnerResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2521,7 +2530,7 @@ impl<'de> serde::Deserialize<'de> for QueryOwnerResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySupplyRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2541,7 +2550,7 @@ impl serde::Serialize for QuerySupplyRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySupplyRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2553,7 +2562,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2564,13 +2573,13 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2587,11 +2596,11 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySupplyRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QuerySupplyRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QuerySupplyRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QuerySupplyRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2621,7 +2630,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySupplyResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2634,7 +2643,10 @@ impl serde::Serialize for QuerySupplyResponse {
             serializer.serialize_struct("cosmos.nft.v1beta1.QuerySupplyResponse", len)?;
         if self.amount != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("amount", ToString::to_string(&self.amount).as_str())?;
+            struct_ser.serialize_field(
+                "amount",
+                alloc::string::ToString::to_string(&self.amount).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -2642,7 +2654,7 @@ impl serde::Serialize for QuerySupplyResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySupplyResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2654,7 +2666,7 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2665,13 +2677,13 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2688,11 +2700,14 @@ impl<'de> serde::Deserialize<'de> for QuerySupplyResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySupplyResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.nft.v1beta1.QuerySupplyResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QuerySupplyResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QuerySupplyResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.nft.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn balance(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryBalanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn owner(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryOwnerRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryOwnerResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryOwnerResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -124,12 +124,12 @@ pub mod query_client {
         pub async fn supply(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySupplyRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySupplyResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySupplyResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -142,11 +142,12 @@ pub mod query_client {
         pub async fn nf_ts(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryNfTsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryNfTsResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryNfTsResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -159,11 +160,11 @@ pub mod query_client {
         pub async fn nft(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryNftRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryNftResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryNftResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -176,12 +177,12 @@ pub mod query_client {
         pub async fn class(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryClassRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryClassResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryClassResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -194,12 +195,12 @@ pub mod query_client {
         pub async fn classes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryClassesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryClassesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryClassesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -222,31 +223,31 @@ pub mod query_server {
         async fn balance(
             &self,
             request: tonic::Request<super::QueryBalanceRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryBalanceResponse>, tonic::Status>;
         async fn owner(
             &self,
             request: tonic::Request<super::QueryOwnerRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryOwnerResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryOwnerResponse>, tonic::Status>;
         async fn supply(
             &self,
             request: tonic::Request<super::QuerySupplyRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySupplyResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySupplyResponse>, tonic::Status>;
         async fn nf_ts(
             &self,
             request: tonic::Request<super::QueryNfTsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryNfTsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryNfTsResponse>, tonic::Status>;
         async fn nft(
             &self,
             request: tonic::Request<super::QueryNftRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryNftResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryNftResponse>, tonic::Status>;
         async fn class(
             &self,
             request: tonic::Request<super::QueryClassRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryClassResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryClassResponse>, tonic::Status>;
         async fn classes(
             &self,
             request: tonic::Request<super::QueryClassesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryClassesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryClassesResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -318,7 +319,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -618,8 +619,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -713,11 +714,11 @@ pub mod msg_client {
         pub async fn send(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -740,7 +741,7 @@ pub mod msg_server {
         async fn send(
             &self,
             request: tonic::Request<super::MsgSend>,
-        ) -> std::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSendResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -812,7 +813,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -884,8 +885,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.module.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.module.v1alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.module.v1alpha1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for GetRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -48,7 +48,7 @@ impl<'de> serde::Deserialize<'de> for GetRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -59,13 +59,13 @@ impl<'de> serde::Deserialize<'de> for GetRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -84,11 +84,11 @@ impl<'de> serde::Deserialize<'de> for GetRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.GetRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -134,7 +134,7 @@ impl<'de> serde::Deserialize<'de> for GetRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -154,7 +154,7 @@ impl serde::Serialize for GetResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -166,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for GetResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -177,13 +177,13 @@ impl<'de> serde::Deserialize<'de> for GetResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -200,11 +200,11 @@ impl<'de> serde::Deserialize<'de> for GetResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.GetResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -232,7 +232,7 @@ impl<'de> serde::Deserialize<'de> for GetResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for IndexValue {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -247,11 +247,13 @@ impl serde::Serialize for IndexValue {
             match v {
                 index_value::Value::Uint(v) => {
                     #[allow(clippy::needless_borrow)]
-                    struct_ser.serialize_field("uint", ToString::to_string(&v).as_str())?;
+                    struct_ser
+                        .serialize_field("uint", alloc::string::ToString::to_string(&v).as_str())?;
                 }
                 index_value::Value::Int(v) => {
                     #[allow(clippy::needless_borrow)]
-                    struct_ser.serialize_field("int", ToString::to_string(&v).as_str())?;
+                    struct_ser
+                        .serialize_field("int", alloc::string::ToString::to_string(&v).as_str())?;
                 }
                 index_value::Value::Str(v) => {
                     struct_ser.serialize_field("str", v)?;
@@ -281,7 +283,7 @@ impl serde::Serialize for IndexValue {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for IndexValue {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -309,7 +311,7 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -320,13 +322,13 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -350,11 +352,11 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = IndexValue;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.IndexValue")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IndexValue, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<IndexValue, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -365,34 +367,42 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
                             if value__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("uint"));
                             }
-                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| index_value::Value::Uint(x.0));
+                            value__ =
+                                map_.next_value::<::core::option::Option<
+                                    ::pbjson::private::NumberDeserialize<_>,
+                                >>()?
+                                .map(|x| index_value::Value::Uint(x.0));
                         }
                         GeneratedField::Int => {
                             if value__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("int"));
                             }
-                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| index_value::Value::Int(x.0));
+                            value__ =
+                                map_.next_value::<::core::option::Option<
+                                    ::pbjson::private::NumberDeserialize<_>,
+                                >>()?
+                                .map(|x| index_value::Value::Int(x.0));
                         }
                         GeneratedField::Str => {
                             if value__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("str"));
                             }
                             value__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(index_value::Value::Str);
                         }
                         GeneratedField::Bytes => {
                             if value__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("bytes"));
                             }
-                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| index_value::Value::Bytes(x.0));
+                            value__ =map_.next_value::<::core::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| index_value::Value::Bytes(x.0));
                         }
                         GeneratedField::Enum => {
                             if value__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("enum"));
                             }
                             value__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(index_value::Value::Enum);
                         }
                         GeneratedField::Bool => {
@@ -400,7 +410,7 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
                                 return Err(serde::de::Error::duplicate_field("bool"));
                             }
                             value__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(index_value::Value::Bool);
                         }
                         GeneratedField::Timestamp => {
@@ -408,7 +418,7 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
                                 return Err(serde::de::Error::duplicate_field("timestamp"));
                             }
                             value__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(index_value::Value::Timestamp);
                         }
                         GeneratedField::Duration => {
@@ -416,7 +426,7 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
                                 return Err(serde::de::Error::duplicate_field("duration"));
                             }
                             value__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(index_value::Value::Duration);
                         }
                     }
@@ -434,7 +444,7 @@ impl<'de> serde::Deserialize<'de> for IndexValue {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -479,7 +489,7 @@ impl serde::Serialize for ListRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -502,7 +512,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -513,13 +523,13 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -540,11 +550,11 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ListRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ListRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -577,7 +587,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                                 return Err(serde::de::Error::duplicate_field("prefix"));
                             }
                             query__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(list_request::Query::Prefix);
                         }
                         GeneratedField::Range => {
@@ -585,7 +595,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                                 return Err(serde::de::Error::duplicate_field("range"));
                             }
                             query__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(list_request::Query::Range);
                         }
                     }
@@ -608,7 +618,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for list_request::Prefix {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -628,7 +638,7 @@ impl serde::Serialize for list_request::Prefix {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for list_request::Prefix {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -640,7 +650,7 @@ impl<'de> serde::Deserialize<'de> for list_request::Prefix {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -651,13 +661,13 @@ impl<'de> serde::Deserialize<'de> for list_request::Prefix {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -674,14 +684,14 @@ impl<'de> serde::Deserialize<'de> for list_request::Prefix {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = list_request::Prefix;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest.Prefix")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<list_request::Prefix, V::Error>
+            ) -> core::result::Result<list_request::Prefix, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -711,7 +721,7 @@ impl<'de> serde::Deserialize<'de> for list_request::Prefix {
 #[cfg(feature = "serde")]
 impl serde::Serialize for list_request::Range {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -737,7 +747,7 @@ impl serde::Serialize for list_request::Range {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for list_request::Range {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -750,7 +760,7 @@ impl<'de> serde::Deserialize<'de> for list_request::Range {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -761,13 +771,13 @@ impl<'de> serde::Deserialize<'de> for list_request::Range {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -785,11 +795,14 @@ impl<'de> serde::Deserialize<'de> for list_request::Range {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = list_request::Range;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.ListRequest.Range")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<list_request::Range, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<list_request::Range, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -827,7 +840,7 @@ impl<'de> serde::Deserialize<'de> for list_request::Range {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -853,7 +866,7 @@ impl serde::Serialize for ListResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -866,7 +879,7 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -877,13 +890,13 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -901,11 +914,11 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.query.v1alpha1.ListResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ListResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ListResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.query.v1alpha1.tonic.rs
@@ -88,11 +88,11 @@ pub mod query_client {
         pub async fn get(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -105,11 +105,11 @@ pub mod query_client {
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<super::ListRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::ListResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -133,11 +133,11 @@ pub mod query_server {
         async fn get(
             &self,
             request: tonic::Request<super::GetRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
         async fn list(
             &self,
             request: tonic::Request<super::ListRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ListResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -209,7 +209,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -319,8 +319,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PrimaryKeyDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for PrimaryKeyDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PrimaryKeyDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for PrimaryKeyDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for PrimaryKeyDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,14 +76,14 @@ impl<'de> serde::Deserialize<'de> for PrimaryKeyDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PrimaryKeyDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1.PrimaryKeyDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<PrimaryKeyDescriptor, V::Error>
+            ) -> core::result::Result<PrimaryKeyDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -121,7 +121,7 @@ impl<'de> serde::Deserialize<'de> for PrimaryKeyDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SecondaryIndexDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -153,7 +153,7 @@ impl serde::Serialize for SecondaryIndexDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SecondaryIndexDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -167,7 +167,7 @@ impl<'de> serde::Deserialize<'de> for SecondaryIndexDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -178,13 +178,13 @@ impl<'de> serde::Deserialize<'de> for SecondaryIndexDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -203,14 +203,14 @@ impl<'de> serde::Deserialize<'de> for SecondaryIndexDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SecondaryIndexDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1.SecondaryIndexDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SecondaryIndexDescriptor, V::Error>
+            ) -> core::result::Result<SecondaryIndexDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -259,7 +259,7 @@ impl<'de> serde::Deserialize<'de> for SecondaryIndexDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SingletonDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -279,7 +279,7 @@ impl serde::Serialize for SingletonDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SingletonDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -291,7 +291,7 @@ impl<'de> serde::Deserialize<'de> for SingletonDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -302,13 +302,13 @@ impl<'de> serde::Deserialize<'de> for SingletonDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -325,11 +325,14 @@ impl<'de> serde::Deserialize<'de> for SingletonDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SingletonDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1.SingletonDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SingletonDescriptor, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<SingletonDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -362,7 +365,7 @@ impl<'de> serde::Deserialize<'de> for SingletonDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TableDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -393,7 +396,7 @@ impl serde::Serialize for TableDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TableDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -407,7 +410,7 @@ impl<'de> serde::Deserialize<'de> for TableDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -418,13 +421,13 @@ impl<'de> serde::Deserialize<'de> for TableDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -443,11 +446,11 @@ impl<'de> serde::Deserialize<'de> for TableDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TableDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1.TableDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TableDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TableDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.v1alpha1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.orm.v1alpha1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleSchemaDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -32,7 +32,7 @@ impl serde::Serialize for ModuleSchemaDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleSchemaDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -45,7 +45,7 @@ impl<'de> serde::Deserialize<'de> for ModuleSchemaDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -56,13 +56,13 @@ impl<'de> serde::Deserialize<'de> for ModuleSchemaDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -80,14 +80,14 @@ impl<'de> serde::Deserialize<'de> for ModuleSchemaDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleSchemaDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1alpha1.ModuleSchemaDescriptor")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ModuleSchemaDescriptor, V::Error>
+            ) -> core::result::Result<ModuleSchemaDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -128,7 +128,7 @@ impl<'de> serde::Deserialize<'de> for ModuleSchemaDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for module_schema_descriptor::FileEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -153,7 +153,7 @@ impl serde::Serialize for module_schema_descriptor::FileEntry {
         }
         if self.storage_type != 0 {
             let v = StorageType::try_from(self.storage_type).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.storage_type))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.storage_type))
             })?;
             struct_ser.serialize_field("storageType", &v)?;
         }
@@ -163,7 +163,7 @@ impl serde::Serialize for module_schema_descriptor::FileEntry {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for module_schema_descriptor::FileEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -183,7 +183,7 @@ impl<'de> serde::Deserialize<'de> for module_schema_descriptor::FileEntry {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -194,13 +194,13 @@ impl<'de> serde::Deserialize<'de> for module_schema_descriptor::FileEntry {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -221,14 +221,14 @@ impl<'de> serde::Deserialize<'de> for module_schema_descriptor::FileEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = module_schema_descriptor::FileEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.orm.v1alpha1.ModuleSchemaDescriptor.FileEntry")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<module_schema_descriptor::FileEntry, V::Error>
+            ) -> core::result::Result<module_schema_descriptor::FileEntry, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -277,7 +277,7 @@ impl<'de> serde::Deserialize<'de> for module_schema_descriptor::FileEntry {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StorageType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -292,7 +292,7 @@ impl serde::Serialize for StorageType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StorageType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -307,11 +307,11 @@ impl<'de> serde::Deserialize<'de> for StorageType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StorageType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -323,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for StorageType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -335,7 +335,7 @@ impl<'de> serde::Deserialize<'de> for StorageType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for ParamChange {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for ParamChange {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ParamChange {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -48,7 +48,7 @@ impl<'de> serde::Deserialize<'de> for ParamChange {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -59,13 +59,13 @@ impl<'de> serde::Deserialize<'de> for ParamChange {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -84,11 +84,11 @@ impl<'de> serde::Deserialize<'de> for ParamChange {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ParamChange;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.ParamChange")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ParamChange, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ParamChange, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -134,7 +134,7 @@ impl<'de> serde::Deserialize<'de> for ParamChange {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ParameterChangeProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -166,7 +166,7 @@ impl serde::Serialize for ParameterChangeProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ParameterChangeProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -180,7 +180,7 @@ impl<'de> serde::Deserialize<'de> for ParameterChangeProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -191,13 +191,13 @@ impl<'de> serde::Deserialize<'de> for ParameterChangeProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -216,14 +216,14 @@ impl<'de> serde::Deserialize<'de> for ParameterChangeProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ParameterChangeProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.ParameterChangeProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ParameterChangeProposal, V::Error>
+            ) -> core::result::Result<ParameterChangeProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -269,7 +269,7 @@ impl<'de> serde::Deserialize<'de> for ParameterChangeProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -295,7 +295,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -308,7 +308,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -319,13 +319,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -343,11 +343,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -385,7 +385,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -405,7 +405,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -417,7 +417,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -428,13 +428,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -451,11 +451,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -483,7 +486,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySubspacesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -497,7 +500,7 @@ impl serde::Serialize for QuerySubspacesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySubspacesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -507,7 +510,7 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -518,13 +521,13 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -538,14 +541,14 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySubspacesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.QuerySubspacesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySubspacesRequest, V::Error>
+            ) -> core::result::Result<QuerySubspacesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -565,7 +568,7 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySubspacesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -585,7 +588,7 @@ impl serde::Serialize for QuerySubspacesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySubspacesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -597,7 +600,7 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -608,13 +611,13 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -631,14 +634,14 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySubspacesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.QuerySubspacesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySubspacesResponse, V::Error>
+            ) -> core::result::Result<QuerySubspacesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -668,7 +671,7 @@ impl<'de> serde::Deserialize<'de> for QuerySubspacesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Subspace {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -693,7 +696,7 @@ impl serde::Serialize for Subspace {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Subspace {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -706,7 +709,7 @@ impl<'de> serde::Deserialize<'de> for Subspace {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -717,13 +720,13 @@ impl<'de> serde::Deserialize<'de> for Subspace {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -741,11 +744,11 @@ impl<'de> serde::Deserialize<'de> for Subspace {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Subspace;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.params.v1beta1.Subspace")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Subspace, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Subspace, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.params.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn subspaces(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySubspacesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySubspacesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySubspacesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -135,11 +135,11 @@ pub mod query_server {
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn subspaces(
             &self,
             request: tonic::Request<super::QuerySubspacesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySubspacesResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySubspacesResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -211,7 +211,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -321,8 +321,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for FileDescriptorsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -16,7 +16,7 @@ impl serde::Serialize for FileDescriptorsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -26,7 +26,7 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -37,13 +37,13 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -57,14 +57,14 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = FileDescriptorsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.reflection.v1.FileDescriptorsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<FileDescriptorsRequest, V::Error>
+            ) -> core::result::Result<FileDescriptorsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -84,7 +84,7 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for FileDescriptorsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -104,7 +104,7 @@ impl serde::Serialize for FileDescriptorsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for FileDescriptorsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -116,7 +116,7 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -127,13 +127,13 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -150,14 +150,14 @@ impl<'de> serde::Deserialize<'de> for FileDescriptorsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = FileDescriptorsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.reflection.v1.FileDescriptorsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<FileDescriptorsResponse, V::Error>
+            ) -> core::result::Result<FileDescriptorsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.reflection.v1.tonic.rs
@@ -94,12 +94,12 @@ pub mod reflection_service_client {
         pub async fn file_descriptors(
             &mut self,
             request: impl tonic::IntoRequest<super::FileDescriptorsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -129,7 +129,7 @@ pub mod reflection_service_server {
         async fn file_descriptors(
             &self,
             request: tonic::Request<super::FileDescriptorsRequest>,
-        ) -> std::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::FileDescriptorsResponse>, tonic::Status>;
     }
     /** Package cosmos.reflection.v1 provides support for inspecting protobuf
      file descriptors.
@@ -204,7 +204,7 @@ pub mod reflection_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -279,8 +279,8 @@ pub mod reflection_service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -22,7 +22,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -34,7 +34,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -45,13 +45,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -68,11 +68,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -54,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -65,13 +65,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -90,11 +90,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -140,7 +140,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MissedBlock {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -156,7 +156,10 @@ impl serde::Serialize for MissedBlock {
             serializer.serialize_struct("cosmos.slashing.v1beta1.MissedBlock", len)?;
         if self.index != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("index", ToString::to_string(&self.index).as_str())?;
+            struct_ser.serialize_field(
+                "index",
+                alloc::string::ToString::to_string(&self.index).as_str(),
+            )?;
         }
         if self.missed {
             struct_ser.serialize_field("missed", &self.missed)?;
@@ -167,7 +170,7 @@ impl serde::Serialize for MissedBlock {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MissedBlock {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -180,7 +183,7 @@ impl<'de> serde::Deserialize<'de> for MissedBlock {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -191,13 +194,13 @@ impl<'de> serde::Deserialize<'de> for MissedBlock {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -215,11 +218,11 @@ impl<'de> serde::Deserialize<'de> for MissedBlock {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MissedBlock;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.MissedBlock")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MissedBlock, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MissedBlock, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -260,7 +263,7 @@ impl<'de> serde::Deserialize<'de> for MissedBlock {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUnjail {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -280,7 +283,7 @@ impl serde::Serialize for MsgUnjail {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUnjail {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -292,7 +295,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnjail {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -303,13 +306,13 @@ impl<'de> serde::Deserialize<'de> for MsgUnjail {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -326,11 +329,11 @@ impl<'de> serde::Deserialize<'de> for MsgUnjail {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUnjail;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.MsgUnjail")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUnjail, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUnjail, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -360,7 +363,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnjail {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUnjailResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -374,7 +377,7 @@ impl serde::Serialize for MsgUnjailResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -384,7 +387,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -395,13 +398,13 @@ impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -415,11 +418,11 @@ impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUnjailResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.MsgUnjailResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUnjailResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUnjailResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -439,7 +442,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnjailResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -465,7 +468,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -478,7 +481,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -489,13 +492,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -513,11 +516,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -555,7 +558,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -569,7 +572,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -579,7 +582,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -590,13 +593,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -610,14 +613,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -637,7 +640,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -663,7 +666,7 @@ impl serde::Serialize for Params {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "signedBlocksWindow",
-                ToString::to_string(&self.signed_blocks_window).as_str(),
+                alloc::string::ToString::to_string(&self.signed_blocks_window).as_str(),
             )?;
         }
         if !self.min_signed_per_window.is_empty() {
@@ -696,7 +699,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -723,7 +726,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -734,13 +737,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -771,11 +774,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -855,7 +858,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -869,7 +872,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -879,7 +882,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -890,13 +893,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -910,11 +913,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -934,7 +937,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -954,7 +957,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -966,7 +969,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -977,13 +980,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1000,11 +1003,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1032,7 +1038,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySigningInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1052,7 +1058,7 @@ impl serde::Serialize for QuerySigningInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySigningInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1064,7 +1070,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1075,13 +1081,13 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1098,14 +1104,14 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySigningInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QuerySigningInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySigningInfoRequest, V::Error>
+            ) -> core::result::Result<QuerySigningInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1135,7 +1141,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySigningInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1155,7 +1161,7 @@ impl serde::Serialize for QuerySigningInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySigningInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1167,7 +1173,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1178,13 +1184,13 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1203,14 +1209,14 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySigningInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QuerySigningInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySigningInfoResponse, V::Error>
+            ) -> core::result::Result<QuerySigningInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1240,7 +1246,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySigningInfosRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1260,7 +1266,7 @@ impl serde::Serialize for QuerySigningInfosRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySigningInfosRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1272,7 +1278,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1283,13 +1289,13 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1306,14 +1312,14 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySigningInfosRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QuerySigningInfosRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySigningInfosRequest, V::Error>
+            ) -> core::result::Result<QuerySigningInfosRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1343,7 +1349,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySigningInfosResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1369,7 +1375,7 @@ impl serde::Serialize for QuerySigningInfosResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySigningInfosResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1382,7 +1388,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1393,13 +1399,13 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1417,14 +1423,14 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySigningInfosResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.QuerySigningInfosResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySigningInfosResponse, V::Error>
+            ) -> core::result::Result<QuerySigningInfosResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1462,7 +1468,7 @@ impl<'de> serde::Deserialize<'de> for QuerySigningInfosResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SigningInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1488,7 +1494,7 @@ impl serde::Serialize for SigningInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SigningInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1501,7 +1507,7 @@ impl<'de> serde::Deserialize<'de> for SigningInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1512,13 +1518,13 @@ impl<'de> serde::Deserialize<'de> for SigningInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1538,11 +1544,11 @@ impl<'de> serde::Deserialize<'de> for SigningInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SigningInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.SigningInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SigningInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SigningInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1582,7 +1588,7 @@ impl<'de> serde::Deserialize<'de> for SigningInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorMissedBlocks {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1608,7 +1614,7 @@ impl serde::Serialize for ValidatorMissedBlocks {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorMissedBlocks {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1621,7 +1627,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorMissedBlocks {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1632,13 +1638,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorMissedBlocks {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1656,14 +1662,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorMissedBlocks {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorMissedBlocks;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.ValidatorMissedBlocks")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorMissedBlocks, V::Error>
+            ) -> core::result::Result<ValidatorMissedBlocks, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1701,7 +1707,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorMissedBlocks {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorSigningInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1734,14 +1740,14 @@ impl serde::Serialize for ValidatorSigningInfo {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "startHeight",
-                ToString::to_string(&self.start_height).as_str(),
+                alloc::string::ToString::to_string(&self.start_height).as_str(),
             )?;
         }
         if self.index_offset != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "indexOffset",
-                ToString::to_string(&self.index_offset).as_str(),
+                alloc::string::ToString::to_string(&self.index_offset).as_str(),
             )?;
         }
         if let Some(v) = self.jailed_until.as_ref() {
@@ -1754,7 +1760,7 @@ impl serde::Serialize for ValidatorSigningInfo {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "missedBlocksCounter",
-                ToString::to_string(&self.missed_blocks_counter).as_str(),
+                alloc::string::ToString::to_string(&self.missed_blocks_counter).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1763,7 +1769,7 @@ impl serde::Serialize for ValidatorSigningInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorSigningInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1791,7 +1797,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorSigningInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1802,13 +1808,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorSigningInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1832,14 +1838,14 @@ impl<'de> serde::Deserialize<'de> for ValidatorSigningInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorSigningInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.slashing.v1beta1.ValidatorSigningInfo")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ValidatorSigningInfo, V::Error>
+            ) -> core::result::Result<ValidatorSigningInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.slashing.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -107,12 +107,12 @@ pub mod query_client {
         pub async fn signing_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySigningInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySigningInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySigningInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -128,12 +128,12 @@ pub mod query_client {
         pub async fn signing_infos(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySigningInfosRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySigningInfosResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QuerySigningInfosResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -159,15 +159,15 @@ pub mod query_server {
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
         async fn signing_info(
             &self,
             request: tonic::Request<super::QuerySigningInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySigningInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySigningInfoResponse>, tonic::Status>;
         async fn signing_infos(
             &self,
             request: tonic::Request<super::QuerySigningInfosRequest>,
-        ) -> std::result::Result<tonic::Response<super::QuerySigningInfosResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QuerySigningInfosResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -239,7 +239,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -387,8 +387,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -482,11 +482,12 @@ pub mod msg_client {
         pub async fn unjail(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUnjail>,
-        ) -> std::result::Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -499,12 +500,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -530,11 +531,11 @@ pub mod msg_server {
         async fn unjail(
             &self,
             request: tonic::Request<super::MsgUnjail>,
-        ) -> std::result::Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUnjailResponse>, tonic::Status>;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -606,7 +607,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -716,8 +717,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -39,7 +39,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -62,7 +62,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -73,13 +73,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -103,11 +103,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AuthorizationType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -19,7 +19,7 @@ impl serde::Serialize for AuthorizationType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AuthorizationType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -36,11 +36,11 @@ impl<'de> serde::Deserialize<'de> for AuthorizationType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AuthorizationType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -52,7 +52,7 @@ impl<'de> serde::Deserialize<'de> for AuthorizationType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -64,7 +64,7 @@ impl<'de> serde::Deserialize<'de> for AuthorizationType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -86,7 +86,7 @@ impl<'de> serde::Deserialize<'de> for AuthorizationType {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BondStatus {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -102,7 +102,7 @@ impl serde::Serialize for BondStatus {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BondStatus {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -118,11 +118,11 @@ impl<'de> serde::Deserialize<'de> for BondStatus {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BondStatus;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -134,7 +134,7 @@ impl<'de> serde::Deserialize<'de> for BondStatus {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -146,7 +146,7 @@ impl<'de> serde::Deserialize<'de> for BondStatus {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -165,7 +165,7 @@ impl<'de> serde::Deserialize<'de> for BondStatus {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Commission {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -191,7 +191,7 @@ impl serde::Serialize for Commission {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Commission {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -209,7 +209,7 @@ impl<'de> serde::Deserialize<'de> for Commission {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -220,13 +220,13 @@ impl<'de> serde::Deserialize<'de> for Commission {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -246,11 +246,11 @@ impl<'de> serde::Deserialize<'de> for Commission {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Commission;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Commission")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Commission, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Commission, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -288,7 +288,7 @@ impl<'de> serde::Deserialize<'de> for Commission {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CommissionRates {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -320,7 +320,7 @@ impl serde::Serialize for CommissionRates {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CommissionRates {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -340,7 +340,7 @@ impl<'de> serde::Deserialize<'de> for CommissionRates {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -351,13 +351,13 @@ impl<'de> serde::Deserialize<'de> for CommissionRates {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -378,11 +378,11 @@ impl<'de> serde::Deserialize<'de> for CommissionRates {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommissionRates;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.CommissionRates")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CommissionRates, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CommissionRates, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -428,7 +428,7 @@ impl<'de> serde::Deserialize<'de> for CommissionRates {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DvPair {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -453,7 +453,7 @@ impl serde::Serialize for DvPair {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DvPair {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -471,7 +471,7 @@ impl<'de> serde::Deserialize<'de> for DvPair {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -482,13 +482,13 @@ impl<'de> serde::Deserialize<'de> for DvPair {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -510,11 +510,11 @@ impl<'de> serde::Deserialize<'de> for DvPair {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DvPair;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.DVPair")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DvPair, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DvPair, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -548,7 +548,7 @@ impl<'de> serde::Deserialize<'de> for DvPair {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DvPairs {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -567,7 +567,7 @@ impl serde::Serialize for DvPairs {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DvPairs {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -579,7 +579,7 @@ impl<'de> serde::Deserialize<'de> for DvPairs {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -590,13 +590,13 @@ impl<'de> serde::Deserialize<'de> for DvPairs {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -613,11 +613,11 @@ impl<'de> serde::Deserialize<'de> for DvPairs {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DvPairs;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.DVPairs")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DvPairs, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DvPairs, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -643,7 +643,7 @@ impl<'de> serde::Deserialize<'de> for DvPairs {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DvvTriplet {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -675,7 +675,7 @@ impl serde::Serialize for DvvTriplet {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DvvTriplet {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -696,7 +696,7 @@ impl<'de> serde::Deserialize<'de> for DvvTriplet {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -707,13 +707,13 @@ impl<'de> serde::Deserialize<'de> for DvvTriplet {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -738,11 +738,11 @@ impl<'de> serde::Deserialize<'de> for DvvTriplet {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DvvTriplet;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.DVVTriplet")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DvvTriplet, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DvvTriplet, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -792,7 +792,7 @@ impl<'de> serde::Deserialize<'de> for DvvTriplet {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DvvTriplets {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -812,7 +812,7 @@ impl serde::Serialize for DvvTriplets {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DvvTriplets {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -824,7 +824,7 @@ impl<'de> serde::Deserialize<'de> for DvvTriplets {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -835,13 +835,13 @@ impl<'de> serde::Deserialize<'de> for DvvTriplets {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -858,11 +858,11 @@ impl<'de> serde::Deserialize<'de> for DvvTriplets {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DvvTriplets;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.DVVTriplets")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DvvTriplets, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DvvTriplets, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -892,7 +892,7 @@ impl<'de> serde::Deserialize<'de> for DvvTriplets {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Delegation {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -924,7 +924,7 @@ impl serde::Serialize for Delegation {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Delegation {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -944,7 +944,7 @@ impl<'de> serde::Deserialize<'de> for Delegation {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -955,13 +955,13 @@ impl<'de> serde::Deserialize<'de> for Delegation {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -984,11 +984,11 @@ impl<'de> serde::Deserialize<'de> for Delegation {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Delegation;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Delegation")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Delegation, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Delegation, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1034,7 +1034,7 @@ impl<'de> serde::Deserialize<'de> for Delegation {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelegationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1060,7 +1060,7 @@ impl serde::Serialize for DelegationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelegationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1073,7 +1073,7 @@ impl<'de> serde::Deserialize<'de> for DelegationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1084,13 +1084,13 @@ impl<'de> serde::Deserialize<'de> for DelegationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1108,11 +1108,11 @@ impl<'de> serde::Deserialize<'de> for DelegationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelegationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.DelegationResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DelegationResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DelegationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1150,7 +1150,7 @@ impl<'de> serde::Deserialize<'de> for DelegationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Description {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1194,7 +1194,7 @@ impl serde::Serialize for Description {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Description {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1217,7 +1217,7 @@ impl<'de> serde::Deserialize<'de> for Description {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1228,13 +1228,13 @@ impl<'de> serde::Deserialize<'de> for Description {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1257,11 +1257,11 @@ impl<'de> serde::Deserialize<'de> for Description {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Description;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Description")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Description, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Description, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1323,7 +1323,7 @@ impl<'de> serde::Deserialize<'de> for Description {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1389,7 +1389,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1420,7 +1420,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1431,13 +1431,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1467,11 +1467,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1564,7 +1564,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for HistoricalInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1590,7 +1590,7 @@ impl serde::Serialize for HistoricalInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for HistoricalInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1603,7 +1603,7 @@ impl<'de> serde::Deserialize<'de> for HistoricalInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1614,13 +1614,13 @@ impl<'de> serde::Deserialize<'de> for HistoricalInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1638,11 +1638,11 @@ impl<'de> serde::Deserialize<'de> for HistoricalInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = HistoricalInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.HistoricalInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<HistoricalInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<HistoricalInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1680,7 +1680,7 @@ impl<'de> serde::Deserialize<'de> for HistoricalInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Infraction {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1695,7 +1695,7 @@ impl serde::Serialize for Infraction {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Infraction {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1710,11 +1710,11 @@ impl<'de> serde::Deserialize<'de> for Infraction {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Infraction;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1726,7 +1726,7 @@ impl<'de> serde::Deserialize<'de> for Infraction {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1738,7 +1738,7 @@ impl<'de> serde::Deserialize<'de> for Infraction {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1756,7 +1756,7 @@ impl<'de> serde::Deserialize<'de> for Infraction {
 #[cfg(feature = "serde")]
 impl serde::Serialize for LastValidatorPower {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1775,7 +1775,10 @@ impl serde::Serialize for LastValidatorPower {
         }
         if self.power != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("power", ToString::to_string(&self.power).as_str())?;
+            struct_ser.serialize_field(
+                "power",
+                alloc::string::ToString::to_string(&self.power).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -1783,7 +1786,7 @@ impl serde::Serialize for LastValidatorPower {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for LastValidatorPower {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1796,7 +1799,7 @@ impl<'de> serde::Deserialize<'de> for LastValidatorPower {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1807,13 +1810,13 @@ impl<'de> serde::Deserialize<'de> for LastValidatorPower {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1831,11 +1834,11 @@ impl<'de> serde::Deserialize<'de> for LastValidatorPower {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = LastValidatorPower;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.LastValidatorPower")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<LastValidatorPower, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<LastValidatorPower, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1876,7 +1879,7 @@ impl<'de> serde::Deserialize<'de> for LastValidatorPower {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgBeginRedelegate {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1914,7 +1917,7 @@ impl serde::Serialize for MsgBeginRedelegate {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgBeginRedelegate {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1937,7 +1940,7 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegate {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1948,13 +1951,13 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegate {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1980,11 +1983,11 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegate {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgBeginRedelegate;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgBeginRedelegate")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgBeginRedelegate, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgBeginRedelegate, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2042,7 +2045,7 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegate {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgBeginRedelegateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2062,7 +2065,7 @@ impl serde::Serialize for MsgBeginRedelegateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgBeginRedelegateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2074,7 +2077,7 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2085,13 +2088,13 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2110,14 +2113,14 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgBeginRedelegateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgBeginRedelegateResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgBeginRedelegateResponse, V::Error>
+            ) -> core::result::Result<MsgBeginRedelegateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2147,7 +2150,7 @@ impl<'de> serde::Deserialize<'de> for MsgBeginRedelegateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelUnbondingDelegation {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2180,7 +2183,7 @@ impl serde::Serialize for MsgCancelUnbondingDelegation {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "creationHeight",
-                ToString::to_string(&self.creation_height).as_str(),
+                alloc::string::ToString::to_string(&self.creation_height).as_str(),
             )?;
         }
         struct_ser.end()
@@ -2189,7 +2192,7 @@ impl serde::Serialize for MsgCancelUnbondingDelegation {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegation {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2212,7 +2215,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegation {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2223,13 +2226,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegation {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2255,14 +2258,14 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegation {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelUnbondingDelegation;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgCancelUnbondingDelegation")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCancelUnbondingDelegation, V::Error>
+            ) -> core::result::Result<MsgCancelUnbondingDelegation, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2319,7 +2322,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegation {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelUnbondingDelegationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2335,7 +2338,7 @@ impl serde::Serialize for MsgCancelUnbondingDelegationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2345,7 +2348,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2356,13 +2359,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2376,7 +2379,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelUnbondingDelegationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.MsgCancelUnbondingDelegationResponse")
             }
@@ -2384,7 +2387,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCancelUnbondingDelegationResponse, V::Error>
+            ) -> core::result::Result<MsgCancelUnbondingDelegationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2404,7 +2407,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUnbondingDelegationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateValidator {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2460,7 +2463,7 @@ impl serde::Serialize for MsgCreateValidator {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateValidator {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2489,7 +2492,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidator {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2500,13 +2503,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidator {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2535,11 +2538,11 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidator {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateValidator;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgCreateValidator")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgCreateValidator, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgCreateValidator, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2617,7 +2620,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidator {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateValidatorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2631,7 +2634,7 @@ impl serde::Serialize for MsgCreateValidatorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateValidatorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2641,7 +2644,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidatorResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2652,13 +2655,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidatorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2672,14 +2675,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidatorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateValidatorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgCreateValidatorResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateValidatorResponse, V::Error>
+            ) -> core::result::Result<MsgCreateValidatorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2699,7 +2702,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateValidatorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDelegate {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2731,7 +2734,7 @@ impl serde::Serialize for MsgDelegate {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDelegate {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2751,7 +2754,7 @@ impl<'de> serde::Deserialize<'de> for MsgDelegate {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2762,13 +2765,13 @@ impl<'de> serde::Deserialize<'de> for MsgDelegate {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2791,11 +2794,11 @@ impl<'de> serde::Deserialize<'de> for MsgDelegate {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDelegate;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgDelegate")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDelegate, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgDelegate, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2841,7 +2844,7 @@ impl<'de> serde::Deserialize<'de> for MsgDelegate {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgDelegateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2855,7 +2858,7 @@ impl serde::Serialize for MsgDelegateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgDelegateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2865,7 +2868,7 @@ impl<'de> serde::Deserialize<'de> for MsgDelegateResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2876,13 +2879,13 @@ impl<'de> serde::Deserialize<'de> for MsgDelegateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2896,11 +2899,14 @@ impl<'de> serde::Deserialize<'de> for MsgDelegateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgDelegateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgDelegateResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgDelegateResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<MsgDelegateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2920,7 +2926,7 @@ impl<'de> serde::Deserialize<'de> for MsgDelegateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgEditValidator {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2958,7 +2964,7 @@ impl serde::Serialize for MsgEditValidator {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgEditValidator {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2981,7 +2987,7 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidator {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2992,13 +2998,13 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidator {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3024,11 +3030,11 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidator {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgEditValidator;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgEditValidator")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgEditValidator, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgEditValidator, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3082,7 +3088,7 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidator {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgEditValidatorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3096,7 +3102,7 @@ impl serde::Serialize for MsgEditValidatorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgEditValidatorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3106,7 +3112,7 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidatorResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3117,13 +3123,13 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidatorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3137,14 +3143,14 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidatorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgEditValidatorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgEditValidatorResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgEditValidatorResponse, V::Error>
+            ) -> core::result::Result<MsgEditValidatorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3164,7 +3170,7 @@ impl<'de> serde::Deserialize<'de> for MsgEditValidatorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUndelegate {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3196,7 +3202,7 @@ impl serde::Serialize for MsgUndelegate {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUndelegate {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3216,7 +3222,7 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegate {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3227,13 +3233,13 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegate {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3256,11 +3262,11 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegate {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUndelegate;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgUndelegate")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUndelegate, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUndelegate, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3306,7 +3312,7 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegate {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUndelegateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3332,7 +3338,7 @@ impl serde::Serialize for MsgUndelegateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3345,7 +3351,7 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3356,13 +3362,13 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3382,14 +3388,14 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUndelegateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgUndelegateResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUndelegateResponse, V::Error>
+            ) -> core::result::Result<MsgUndelegateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3427,7 +3433,7 @@ impl<'de> serde::Deserialize<'de> for MsgUndelegateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3453,7 +3459,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3466,7 +3472,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3477,13 +3483,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3501,11 +3507,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3543,7 +3549,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3557,7 +3563,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3567,7 +3573,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3578,13 +3584,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3598,14 +3604,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3625,7 +3631,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3674,7 +3680,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3704,7 +3710,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3715,13 +3721,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3747,11 +3753,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3826,7 +3832,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Pool {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3851,7 +3857,7 @@ impl serde::Serialize for Pool {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Pool {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3869,7 +3875,7 @@ impl<'de> serde::Deserialize<'de> for Pool {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3880,13 +3886,13 @@ impl<'de> serde::Deserialize<'de> for Pool {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3906,11 +3912,11 @@ impl<'de> serde::Deserialize<'de> for Pool {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Pool;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Pool")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Pool, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Pool, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3944,7 +3950,7 @@ impl<'de> serde::Deserialize<'de> for Pool {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3970,7 +3976,7 @@ impl serde::Serialize for QueryDelegationRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3988,7 +3994,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3999,13 +4005,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4023,14 +4029,14 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryDelegationRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationRequest, V::Error>
+            ) -> core::result::Result<QueryDelegationRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4068,7 +4074,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4088,7 +4094,7 @@ impl serde::Serialize for QueryDelegationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4100,7 +4106,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4111,13 +4117,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4136,14 +4142,14 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryDelegationResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegationResponse, V::Error>
+            ) -> core::result::Result<QueryDelegationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4175,7 +4181,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorDelegationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4203,7 +4209,7 @@ impl serde::Serialize for QueryDelegatorDelegationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4216,7 +4222,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4227,13 +4233,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4251,7 +4257,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorDelegationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryDelegatorDelegationsRequest")
             }
@@ -4259,7 +4265,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorDelegationsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorDelegationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4297,7 +4303,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorDelegationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4325,7 +4331,7 @@ impl serde::Serialize for QueryDelegatorDelegationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4338,7 +4344,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4349,13 +4355,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4375,7 +4381,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorDelegationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryDelegatorDelegationsResponse")
             }
@@ -4383,7 +4389,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorDelegationsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorDelegationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4423,7 +4429,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorDelegationsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorUnbondingDelegationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4451,7 +4457,7 @@ impl serde::Serialize for QueryDelegatorUnbondingDelegationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4464,7 +4470,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest 
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4475,13 +4481,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest 
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4499,7 +4505,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest 
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorUnbondingDelegationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsRequest",
                 )
@@ -4508,7 +4514,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorUnbondingDelegationsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorUnbondingDelegationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4546,7 +4552,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsRequest 
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorUnbondingDelegationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4574,7 +4580,7 @@ impl serde::Serialize for QueryDelegatorUnbondingDelegationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4587,7 +4593,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4598,13 +4604,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4624,7 +4630,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorUnbondingDelegationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsResponse",
                 )
@@ -4633,7 +4639,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorUnbondingDelegationsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorUnbondingDelegationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4673,7 +4679,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorUnbondingDelegationsResponse
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4699,7 +4705,7 @@ impl serde::Serialize for QueryDelegatorValidatorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4717,7 +4723,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4728,13 +4734,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4752,14 +4758,14 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryDelegatorValidatorRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4797,7 +4803,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4819,7 +4825,7 @@ impl serde::Serialize for QueryDelegatorValidatorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4831,7 +4837,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4842,13 +4848,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4865,14 +4871,14 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryDelegatorValidatorResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4902,7 +4908,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4930,7 +4936,7 @@ impl serde::Serialize for QueryDelegatorValidatorsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4943,7 +4949,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4954,13 +4960,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4978,14 +4984,14 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryDelegatorValidatorsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorsRequest, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5023,7 +5029,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryDelegatorValidatorsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5051,7 +5057,7 @@ impl serde::Serialize for QueryDelegatorValidatorsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5064,7 +5070,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5075,13 +5081,13 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5099,7 +5105,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryDelegatorValidatorsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryDelegatorValidatorsResponse")
             }
@@ -5107,7 +5113,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryDelegatorValidatorsResponse, V::Error>
+            ) -> core::result::Result<QueryDelegatorValidatorsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5145,7 +5151,7 @@ impl<'de> serde::Deserialize<'de> for QueryDelegatorValidatorsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryHistoricalInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5158,7 +5164,10 @@ impl serde::Serialize for QueryHistoricalInfoRequest {
             .serialize_struct("cosmos.staking.v1beta1.QueryHistoricalInfoRequest", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -5166,7 +5175,7 @@ impl serde::Serialize for QueryHistoricalInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5178,7 +5187,7 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5189,13 +5198,13 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5212,14 +5221,14 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryHistoricalInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryHistoricalInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryHistoricalInfoRequest, V::Error>
+            ) -> core::result::Result<QueryHistoricalInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5252,7 +5261,7 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryHistoricalInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5272,7 +5281,7 @@ impl serde::Serialize for QueryHistoricalInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5284,7 +5293,7 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5295,13 +5304,13 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5318,14 +5327,14 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryHistoricalInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryHistoricalInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryHistoricalInfoResponse, V::Error>
+            ) -> core::result::Result<QueryHistoricalInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5353,7 +5362,7 @@ impl<'de> serde::Deserialize<'de> for QueryHistoricalInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5367,7 +5376,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5377,7 +5386,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5388,13 +5397,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5408,11 +5417,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5432,7 +5441,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5452,7 +5461,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5464,7 +5473,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5475,13 +5484,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5498,11 +5507,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5530,7 +5542,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryPoolRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5544,7 +5556,7 @@ impl serde::Serialize for QueryPoolRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryPoolRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5554,7 +5566,7 @@ impl<'de> serde::Deserialize<'de> for QueryPoolRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5565,13 +5577,13 @@ impl<'de> serde::Deserialize<'de> for QueryPoolRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5585,11 +5597,11 @@ impl<'de> serde::Deserialize<'de> for QueryPoolRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryPoolRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryPoolRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryPoolRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryPoolRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5609,7 +5621,7 @@ impl<'de> serde::Deserialize<'de> for QueryPoolRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryPoolResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5629,7 +5641,7 @@ impl serde::Serialize for QueryPoolResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryPoolResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5641,7 +5653,7 @@ impl<'de> serde::Deserialize<'de> for QueryPoolResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5652,13 +5664,13 @@ impl<'de> serde::Deserialize<'de> for QueryPoolResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5675,11 +5687,11 @@ impl<'de> serde::Deserialize<'de> for QueryPoolResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryPoolResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryPoolResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryPoolResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryPoolResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5707,7 +5719,7 @@ impl<'de> serde::Deserialize<'de> for QueryPoolResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryRedelegationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5745,7 +5757,7 @@ impl serde::Serialize for QueryRedelegationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryRedelegationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5768,7 +5780,7 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5779,13 +5791,13 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5809,14 +5821,14 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryRedelegationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryRedelegationsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryRedelegationsRequest, V::Error>
+            ) -> core::result::Result<QueryRedelegationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5870,7 +5882,7 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryRedelegationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5896,7 +5908,7 @@ impl serde::Serialize for QueryRedelegationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryRedelegationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5913,7 +5925,7 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5924,13 +5936,13 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5950,14 +5962,14 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryRedelegationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryRedelegationsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryRedelegationsResponse, V::Error>
+            ) -> core::result::Result<QueryRedelegationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5997,7 +6009,7 @@ impl<'de> serde::Deserialize<'de> for QueryRedelegationsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryUnbondingDelegationRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6025,7 +6037,7 @@ impl serde::Serialize for QueryUnbondingDelegationRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6043,7 +6055,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6054,13 +6066,13 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6078,14 +6090,14 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryUnbondingDelegationRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryUnbondingDelegationRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryUnbondingDelegationRequest, V::Error>
+            ) -> core::result::Result<QueryUnbondingDelegationRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6123,7 +6135,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryUnbondingDelegationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6145,7 +6157,7 @@ impl serde::Serialize for QueryUnbondingDelegationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6157,7 +6169,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6168,13 +6180,13 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6191,7 +6203,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryUnbondingDelegationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryUnbondingDelegationResponse")
             }
@@ -6199,7 +6211,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryUnbondingDelegationResponse, V::Error>
+            ) -> core::result::Result<QueryUnbondingDelegationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6227,7 +6239,7 @@ impl<'de> serde::Deserialize<'de> for QueryUnbondingDelegationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorDelegationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6255,7 +6267,7 @@ impl serde::Serialize for QueryValidatorDelegationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6268,7 +6280,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6279,13 +6291,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6303,7 +6315,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorDelegationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryValidatorDelegationsRequest")
             }
@@ -6311,7 +6323,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorDelegationsRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorDelegationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6349,7 +6361,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorDelegationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6377,7 +6389,7 @@ impl serde::Serialize for QueryValidatorDelegationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6390,7 +6402,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6401,13 +6413,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6427,7 +6439,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorDelegationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.staking.v1beta1.QueryValidatorDelegationsResponse")
             }
@@ -6435,7 +6447,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorDelegationsResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorDelegationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6475,7 +6487,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorDelegationsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6495,7 +6507,7 @@ impl serde::Serialize for QueryValidatorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6507,7 +6519,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6518,13 +6530,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6541,14 +6553,14 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryValidatorRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6578,7 +6590,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6598,7 +6610,7 @@ impl serde::Serialize for QueryValidatorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6610,7 +6622,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6621,13 +6633,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6644,14 +6656,14 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryValidatorResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6681,7 +6693,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorUnbondingDelegationsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6709,7 +6721,7 @@ impl serde::Serialize for QueryValidatorUnbondingDelegationsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6722,7 +6734,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest 
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6733,13 +6745,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest 
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6757,7 +6769,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest 
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorUnbondingDelegationsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsRequest",
                 )
@@ -6766,7 +6778,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorUnbondingDelegationsRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorUnbondingDelegationsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6804,7 +6816,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsRequest 
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorUnbondingDelegationsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6832,7 +6844,7 @@ impl serde::Serialize for QueryValidatorUnbondingDelegationsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6845,7 +6857,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6856,13 +6868,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6882,7 +6894,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorUnbondingDelegationsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsResponse",
                 )
@@ -6891,7 +6903,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorUnbondingDelegationsResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorUnbondingDelegationsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6931,7 +6943,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorUnbondingDelegationsResponse
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6957,7 +6969,7 @@ impl serde::Serialize for QueryValidatorsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6970,7 +6982,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6981,13 +6993,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7005,14 +7017,14 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryValidatorsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorsRequest, V::Error>
+            ) -> core::result::Result<QueryValidatorsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7050,7 +7062,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryValidatorsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7076,7 +7088,7 @@ impl serde::Serialize for QueryValidatorsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryValidatorsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7089,7 +7101,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7100,13 +7112,13 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7124,14 +7136,14 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryValidatorsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.QueryValidatorsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryValidatorsResponse, V::Error>
+            ) -> core::result::Result<QueryValidatorsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7169,7 +7181,7 @@ impl<'de> serde::Deserialize<'de> for QueryValidatorsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Redelegation {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7207,7 +7219,7 @@ impl serde::Serialize for Redelegation {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Redelegation {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7230,7 +7242,7 @@ impl<'de> serde::Deserialize<'de> for Redelegation {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7241,13 +7253,13 @@ impl<'de> serde::Deserialize<'de> for Redelegation {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7273,11 +7285,11 @@ impl<'de> serde::Deserialize<'de> for Redelegation {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Redelegation;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Redelegation")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Redelegation, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Redelegation, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7335,7 +7347,7 @@ impl<'de> serde::Deserialize<'de> for Redelegation {
 #[cfg(feature = "serde")]
 impl serde::Serialize for RedelegationEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7365,7 +7377,7 @@ impl serde::Serialize for RedelegationEntry {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "creationHeight",
-                ToString::to_string(&self.creation_height).as_str(),
+                alloc::string::ToString::to_string(&self.creation_height).as_str(),
             )?;
         }
         if let Some(v) = self.completion_time.as_ref() {
@@ -7381,14 +7393,14 @@ impl serde::Serialize for RedelegationEntry {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingId",
-                ToString::to_string(&self.unbonding_id).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_id).as_str(),
             )?;
         }
         if self.unbonding_on_hold_ref_count != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingOnHoldRefCount",
-                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
             )?;
         }
         struct_ser.end()
@@ -7397,7 +7409,7 @@ impl serde::Serialize for RedelegationEntry {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for RedelegationEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7427,7 +7439,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7438,13 +7450,13 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7474,11 +7486,11 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = RedelegationEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.RedelegationEntry")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<RedelegationEntry, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<RedelegationEntry, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7559,7 +7571,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntry {
 #[cfg(feature = "serde")]
 impl serde::Serialize for RedelegationEntryResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7585,7 +7597,7 @@ impl serde::Serialize for RedelegationEntryResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for RedelegationEntryResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7598,7 +7610,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntryResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7609,13 +7621,13 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntryResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7635,14 +7647,14 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntryResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = RedelegationEntryResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.RedelegationEntryResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<RedelegationEntryResponse, V::Error>
+            ) -> core::result::Result<RedelegationEntryResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7680,7 +7692,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationEntryResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for RedelegationResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7706,7 +7718,7 @@ impl serde::Serialize for RedelegationResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for RedelegationResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7719,7 +7731,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7730,13 +7742,13 @@ impl<'de> serde::Deserialize<'de> for RedelegationResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7754,14 +7766,14 @@ impl<'de> serde::Deserialize<'de> for RedelegationResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = RedelegationResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.RedelegationResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<RedelegationResponse, V::Error>
+            ) -> core::result::Result<RedelegationResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7799,7 +7811,7 @@ impl<'de> serde::Deserialize<'de> for RedelegationResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StakeAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7821,7 +7833,10 @@ impl serde::Serialize for StakeAuthorization {
         }
         if self.authorization_type != 0 {
             let v = AuthorizationType::try_from(self.authorization_type).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.authorization_type))
+                serde::ser::Error::custom(alloc::format!(
+                    "Invalid variant {}",
+                    self.authorization_type
+                ))
             })?;
             struct_ser.serialize_field("authorizationType", &v)?;
         }
@@ -7841,7 +7856,7 @@ impl serde::Serialize for StakeAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StakeAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7865,7 +7880,7 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7876,13 +7891,13 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7904,11 +7919,11 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StakeAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.StakeAuthorization")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StakeAuthorization, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StakeAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7935,7 +7950,7 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
                                 return Err(serde::de::Error::duplicate_field("allowList"));
                             }
                             validators__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(stake_authorization::Policy::AllowList);
                         }
                         GeneratedField::DenyList => {
@@ -7943,7 +7958,7 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
                                 return Err(serde::de::Error::duplicate_field("denyList"));
                             }
                             validators__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(stake_authorization::Policy::DenyList);
                         }
                     }
@@ -7965,7 +7980,7 @@ impl<'de> serde::Deserialize<'de> for StakeAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for stake_authorization::Validators {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7985,7 +8000,7 @@ impl serde::Serialize for stake_authorization::Validators {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for stake_authorization::Validators {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7997,7 +8012,7 @@ impl<'de> serde::Deserialize<'de> for stake_authorization::Validators {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8008,13 +8023,13 @@ impl<'de> serde::Deserialize<'de> for stake_authorization::Validators {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8031,14 +8046,14 @@ impl<'de> serde::Deserialize<'de> for stake_authorization::Validators {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = stake_authorization::Validators;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.StakeAuthorization.Validators")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<stake_authorization::Validators, V::Error>
+            ) -> core::result::Result<stake_authorization::Validators, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8068,7 +8083,7 @@ impl<'de> serde::Deserialize<'de> for stake_authorization::Validators {
 #[cfg(feature = "serde")]
 impl serde::Serialize for UnbondingDelegation {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8100,7 +8115,7 @@ impl serde::Serialize for UnbondingDelegation {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for UnbondingDelegation {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8120,7 +8135,7 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegation {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8131,13 +8146,13 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegation {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8160,11 +8175,14 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegation {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = UnbondingDelegation;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.UnbondingDelegation")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<UnbondingDelegation, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<UnbondingDelegation, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8210,7 +8228,7 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegation {
 #[cfg(feature = "serde")]
 impl serde::Serialize for UnbondingDelegationEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8240,7 +8258,7 @@ impl serde::Serialize for UnbondingDelegationEntry {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "creationHeight",
-                ToString::to_string(&self.creation_height).as_str(),
+                alloc::string::ToString::to_string(&self.creation_height).as_str(),
             )?;
         }
         if let Some(v) = self.completion_time.as_ref() {
@@ -8256,14 +8274,14 @@ impl serde::Serialize for UnbondingDelegationEntry {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingId",
-                ToString::to_string(&self.unbonding_id).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_id).as_str(),
             )?;
         }
         if self.unbonding_on_hold_ref_count != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingOnHoldRefCount",
-                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
             )?;
         }
         struct_ser.end()
@@ -8272,7 +8290,7 @@ impl serde::Serialize for UnbondingDelegationEntry {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8301,7 +8319,7 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8312,13 +8330,13 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8348,14 +8366,14 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = UnbondingDelegationEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.UnbondingDelegationEntry")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<UnbondingDelegationEntry, V::Error>
+            ) -> core::result::Result<UnbondingDelegationEntry, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8436,7 +8454,7 @@ impl<'de> serde::Deserialize<'de> for UnbondingDelegationEntry {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValAddresses {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8456,7 +8474,7 @@ impl serde::Serialize for ValAddresses {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValAddresses {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8468,7 +8486,7 @@ impl<'de> serde::Deserialize<'de> for ValAddresses {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8479,13 +8497,13 @@ impl<'de> serde::Deserialize<'de> for ValAddresses {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8502,11 +8520,11 @@ impl<'de> serde::Deserialize<'de> for ValAddresses {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValAddresses;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.ValAddresses")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ValAddresses, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ValAddresses, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8536,7 +8554,7 @@ impl<'de> serde::Deserialize<'de> for ValAddresses {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Validator {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8594,7 +8612,7 @@ impl serde::Serialize for Validator {
         }
         if self.status != 0 {
             let v = BondStatus::try_from(self.status).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.status))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.status))
             })?;
             struct_ser.serialize_field("status", &v)?;
         }
@@ -8611,7 +8629,7 @@ impl serde::Serialize for Validator {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingHeight",
-                ToString::to_string(&self.unbonding_height).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_height).as_str(),
             )?;
         }
         if let Some(v) = self.unbonding_time.as_ref() {
@@ -8627,7 +8645,7 @@ impl serde::Serialize for Validator {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "unbondingOnHoldRefCount",
-                ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
+                alloc::string::ToString::to_string(&self.unbonding_on_hold_ref_count).as_str(),
             )?;
         }
         if !self.unbonding_ids.is_empty() {
@@ -8636,8 +8654,8 @@ impl serde::Serialize for Validator {
                 &self
                     .unbonding_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -8646,7 +8664,7 @@ impl serde::Serialize for Validator {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Validator {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8692,7 +8710,7 @@ impl<'de> serde::Deserialize<'de> for Validator {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8703,13 +8721,13 @@ impl<'de> serde::Deserialize<'de> for Validator {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8750,11 +8768,11 @@ impl<'de> serde::Deserialize<'de> for Validator {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Validator;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.Validator")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Validator, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Validator, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8857,12 +8875,10 @@ impl<'de> serde::Deserialize<'de> for Validator {
                             if unbonding_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("unbondingIds"));
                             }
-                            unbonding_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            unbonding_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -8893,7 +8909,7 @@ impl<'de> serde::Deserialize<'de> for Validator {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ValidatorUpdates {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8913,7 +8929,7 @@ impl serde::Serialize for ValidatorUpdates {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ValidatorUpdates {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8925,7 +8941,7 @@ impl<'de> serde::Deserialize<'de> for ValidatorUpdates {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8936,13 +8952,13 @@ impl<'de> serde::Deserialize<'de> for ValidatorUpdates {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8959,11 +8975,11 @@ impl<'de> serde::Deserialize<'de> for ValidatorUpdates {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ValidatorUpdates;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.staking.v1beta1.ValidatorUpdates")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ValidatorUpdates, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ValidatorUpdates, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.staking.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn validators(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryValidatorsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -109,12 +109,12 @@ pub mod query_client {
         pub async fn validator(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryValidatorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -128,14 +128,14 @@ pub mod query_client {
         pub async fn validator_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorDelegationsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -152,14 +152,14 @@ pub mod query_client {
         pub async fn validator_unbonding_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryValidatorUnbondingDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -176,12 +176,12 @@ pub mod query_client {
         pub async fn delegation(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegationRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDelegationResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryDelegationResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -197,14 +197,14 @@ pub mod query_client {
         pub async fn unbonding_delegation(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUnbondingDelegationRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryUnbondingDelegationResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -221,14 +221,14 @@ pub mod query_client {
         pub async fn delegator_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorDelegationsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -245,14 +245,14 @@ pub mod query_client {
         pub async fn delegator_unbonding_delegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorUnbondingDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -269,12 +269,12 @@ pub mod query_client {
         pub async fn redelegations(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryRedelegationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryRedelegationsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryRedelegationsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -290,14 +290,14 @@ pub mod query_client {
         pub async fn delegator_validators(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -314,14 +314,14 @@ pub mod query_client {
         pub async fn delegator_validator(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDelegatorValidatorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -338,12 +338,12 @@ pub mod query_client {
         pub async fn historical_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryHistoricalInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryHistoricalInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryHistoricalInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -360,11 +360,12 @@ pub mod query_client {
         pub async fn pool(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryPoolResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryPoolResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -377,12 +378,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -405,80 +406,80 @@ pub mod query_server {
         async fn validators(
             &self,
             request: tonic::Request<super::QueryValidatorsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryValidatorsResponse>, tonic::Status>;
         async fn validator(
             &self,
             request: tonic::Request<super::QueryValidatorRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryValidatorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryValidatorResponse>, tonic::Status>;
         async fn validator_delegations(
             &self,
             request: tonic::Request<super::QueryValidatorDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorDelegationsResponse>,
             tonic::Status,
         >;
         async fn validator_unbonding_delegations(
             &self,
             request: tonic::Request<super::QueryValidatorUnbondingDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryValidatorUnbondingDelegationsResponse>,
             tonic::Status,
         >;
         async fn delegation(
             &self,
             request: tonic::Request<super::QueryDelegationRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryDelegationResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryDelegationResponse>, tonic::Status>;
         async fn unbonding_delegation(
             &self,
             request: tonic::Request<super::QueryUnbondingDelegationRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryUnbondingDelegationResponse>,
             tonic::Status,
         >;
         async fn delegator_delegations(
             &self,
             request: tonic::Request<super::QueryDelegatorDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorDelegationsResponse>,
             tonic::Status,
         >;
         async fn delegator_unbonding_delegations(
             &self,
             request: tonic::Request<super::QueryDelegatorUnbondingDelegationsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorUnbondingDelegationsResponse>,
             tonic::Status,
         >;
         async fn redelegations(
             &self,
             request: tonic::Request<super::QueryRedelegationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryRedelegationsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryRedelegationsResponse>, tonic::Status>;
         async fn delegator_validators(
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorsRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorsResponse>,
             tonic::Status,
         >;
         async fn delegator_validator(
             &self,
             request: tonic::Request<super::QueryDelegatorValidatorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryDelegatorValidatorResponse>,
             tonic::Status,
         >;
         async fn historical_info(
             &self,
             request: tonic::Request<super::QueryHistoricalInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryHistoricalInfoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryHistoricalInfoResponse>, tonic::Status>;
         async fn pool(
             &self,
             request: tonic::Request<super::QueryPoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryPoolResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryPoolResponse>, tonic::Status>;
         async fn params(
             &self,
             request: tonic::Request<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -550,7 +551,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1151,8 +1152,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -1246,12 +1247,12 @@ pub mod msg_client {
         pub async fn create_validator(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateValidator>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1267,12 +1268,12 @@ pub mod msg_client {
         pub async fn edit_validator(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgEditValidator>,
-        ) -> std::result::Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1288,12 +1289,12 @@ pub mod msg_client {
         pub async fn delegate(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgDelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1306,12 +1307,12 @@ pub mod msg_client {
         pub async fn begin_redelegate(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgBeginRedelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1327,12 +1328,12 @@ pub mod msg_client {
         pub async fn undelegate(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUndelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1346,14 +1347,14 @@ pub mod msg_client {
         pub async fn cancel_unbonding_delegation(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCancelUnbondingDelegation>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCancelUnbondingDelegationResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1370,12 +1371,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -1401,34 +1402,34 @@ pub mod msg_server {
         async fn create_validator(
             &self,
             request: tonic::Request<super::MsgCreateValidator>,
-        ) -> std::result::Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgCreateValidatorResponse>, tonic::Status>;
         async fn edit_validator(
             &self,
             request: tonic::Request<super::MsgEditValidator>,
-        ) -> std::result::Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgEditValidatorResponse>, tonic::Status>;
         async fn delegate(
             &self,
             request: tonic::Request<super::MsgDelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgDelegateResponse>, tonic::Status>;
         async fn begin_redelegate(
             &self,
             request: tonic::Request<super::MsgBeginRedelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgBeginRedelegateResponse>, tonic::Status>;
         async fn undelegate(
             &self,
             request: tonic::Request<super::MsgUndelegate>,
-        ) -> std::result::Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUndelegateResponse>, tonic::Status>;
         async fn cancel_unbonding_delegation(
             &self,
             request: tonic::Request<super::MsgCancelUnbondingDelegation>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCancelUnbondingDelegationResponse>,
             tonic::Status,
         >;
         async fn update_params(
             &self,
             request: tonic::Request<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -1500,7 +1501,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1803,8 +1804,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.internal.kv.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.internal.kv.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Pair {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for Pair {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Pair {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -47,7 +47,7 @@ impl<'de> serde::Deserialize<'de> for Pair {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -58,13 +58,13 @@ impl<'de> serde::Deserialize<'de> for Pair {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -82,11 +82,11 @@ impl<'de> serde::Deserialize<'de> for Pair {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Pair;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.internal.kv.v1beta1.Pair")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Pair, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Pair, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -130,7 +130,7 @@ impl<'de> serde::Deserialize<'de> for Pair {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Pairs {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -150,7 +150,7 @@ impl serde::Serialize for Pairs {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Pairs {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -162,7 +162,7 @@ impl<'de> serde::Deserialize<'de> for Pairs {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -173,13 +173,13 @@ impl<'de> serde::Deserialize<'de> for Pairs {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -196,11 +196,11 @@ impl<'de> serde::Deserialize<'de> for Pairs {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Pairs;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.internal.kv.v1beta1.Pairs")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Pairs, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Pairs, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.snapshots.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.snapshots.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Metadata {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -20,7 +20,7 @@ impl serde::Serialize for Metadata {
                     .chunk_hashes
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -29,7 +29,7 @@ impl serde::Serialize for Metadata {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Metadata {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for Metadata {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for Metadata {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -75,11 +75,11 @@ impl<'de> serde::Deserialize<'de> for Metadata {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Metadata;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.Metadata")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Metadata, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Metadata, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -90,12 +90,10 @@ impl<'de> serde::Deserialize<'de> for Metadata {
                             if chunk_hashes__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("chunkHashes"));
                             }
-                            chunk_hashes__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            chunk_hashes__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -114,7 +112,7 @@ impl<'de> serde::Deserialize<'de> for Metadata {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Snapshot {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -139,7 +137,10 @@ impl serde::Serialize for Snapshot {
             serializer.serialize_struct("cosmos.store.snapshots.v1.Snapshot", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if self.format != 0 {
             struct_ser.serialize_field("format", &self.format)?;
@@ -161,7 +162,7 @@ impl serde::Serialize for Snapshot {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Snapshot {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -177,7 +178,7 @@ impl<'de> serde::Deserialize<'de> for Snapshot {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -188,13 +189,13 @@ impl<'de> serde::Deserialize<'de> for Snapshot {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -215,11 +216,11 @@ impl<'de> serde::Deserialize<'de> for Snapshot {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Snapshot;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.Snapshot")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Snapshot, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Snapshot, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -293,7 +294,7 @@ impl<'de> serde::Deserialize<'de> for Snapshot {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SnapshotExtensionMeta {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -319,7 +320,7 @@ impl serde::Serialize for SnapshotExtensionMeta {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SnapshotExtensionMeta {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -332,7 +333,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionMeta {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -343,13 +344,13 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionMeta {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -367,14 +368,14 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionMeta {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SnapshotExtensionMeta;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.SnapshotExtensionMeta")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SnapshotExtensionMeta, V::Error>
+            ) -> core::result::Result<SnapshotExtensionMeta, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -415,7 +416,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionMeta {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SnapshotExtensionPayload {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -439,7 +440,7 @@ impl serde::Serialize for SnapshotExtensionPayload {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SnapshotExtensionPayload {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -451,7 +452,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionPayload {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -462,13 +463,13 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionPayload {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -485,14 +486,14 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionPayload {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SnapshotExtensionPayload;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.SnapshotExtensionPayload")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SnapshotExtensionPayload, V::Error>
+            ) -> core::result::Result<SnapshotExtensionPayload, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -525,7 +526,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotExtensionPayload {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SnapshotIavlItem {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -559,7 +560,10 @@ impl serde::Serialize for SnapshotIavlItem {
         }
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         if self.height != 0 {
             struct_ser.serialize_field("height", &self.height)?;
@@ -570,7 +574,7 @@ impl serde::Serialize for SnapshotIavlItem {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SnapshotIavlItem {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -585,7 +589,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotIavlItem {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -596,13 +600,13 @@ impl<'de> serde::Deserialize<'de> for SnapshotIavlItem {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -622,11 +626,11 @@ impl<'de> serde::Deserialize<'de> for SnapshotIavlItem {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SnapshotIavlItem;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.SnapshotIAVLItem")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SnapshotIavlItem, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SnapshotIavlItem, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -692,7 +696,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotIavlItem {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SnapshotItem {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -725,7 +729,7 @@ impl serde::Serialize for SnapshotItem {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SnapshotItem {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -746,7 +750,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -757,13 +761,13 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -785,11 +789,11 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SnapshotItem;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.SnapshotItem")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SnapshotItem, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SnapshotItem, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -801,7 +805,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
                                 return Err(serde::de::Error::duplicate_field("store"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(snapshot_item::Item::Store);
                         }
                         GeneratedField::Iavl => {
@@ -809,7 +813,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
                                 return Err(serde::de::Error::duplicate_field("iavl"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(snapshot_item::Item::Iavl);
                         }
                         GeneratedField::Extension => {
@@ -817,7 +821,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
                                 return Err(serde::de::Error::duplicate_field("extension"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(snapshot_item::Item::Extension);
                         }
                         GeneratedField::ExtensionPayload => {
@@ -825,7 +829,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
                                 return Err(serde::de::Error::duplicate_field("extensionPayload"));
                             }
                             item__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(snapshot_item::Item::ExtensionPayload);
                         }
                     }
@@ -843,7 +847,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotItem {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SnapshotStoreItem {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -863,7 +867,7 @@ impl serde::Serialize for SnapshotStoreItem {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SnapshotStoreItem {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -875,7 +879,7 @@ impl<'de> serde::Deserialize<'de> for SnapshotStoreItem {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -886,13 +890,13 @@ impl<'de> serde::Deserialize<'de> for SnapshotStoreItem {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -909,11 +913,11 @@ impl<'de> serde::Deserialize<'de> for SnapshotStoreItem {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SnapshotStoreItem;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.snapshots.v1.SnapshotStoreItem")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SnapshotStoreItem, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SnapshotStoreItem, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.streaming.abci.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.streaming.abci.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListenCommitRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -23,7 +23,7 @@ impl serde::Serialize for ListenCommitRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "blockHeight",
-                ToString::to_string(&self.block_height).as_str(),
+                alloc::string::ToString::to_string(&self.block_height).as_str(),
             )?;
         }
         if let Some(v) = self.res.as_ref() {
@@ -38,7 +38,7 @@ impl serde::Serialize for ListenCommitRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListenCommitRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -58,7 +58,7 @@ impl<'de> serde::Deserialize<'de> for ListenCommitRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -69,13 +69,13 @@ impl<'de> serde::Deserialize<'de> for ListenCommitRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -94,11 +94,14 @@ impl<'de> serde::Deserialize<'de> for ListenCommitRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListenCommitRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.streaming.abci.ListenCommitRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ListenCommitRequest, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<ListenCommitRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -147,7 +150,7 @@ impl<'de> serde::Deserialize<'de> for ListenCommitRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListenCommitResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -161,7 +164,7 @@ impl serde::Serialize for ListenCommitResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListenCommitResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -171,7 +174,7 @@ impl<'de> serde::Deserialize<'de> for ListenCommitResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -182,13 +185,13 @@ impl<'de> serde::Deserialize<'de> for ListenCommitResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -202,14 +205,14 @@ impl<'de> serde::Deserialize<'de> for ListenCommitResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListenCommitResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.streaming.abci.ListenCommitResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListenCommitResponse, V::Error>
+            ) -> core::result::Result<ListenCommitResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -229,7 +232,7 @@ impl<'de> serde::Deserialize<'de> for ListenCommitResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListenFinalizeBlockRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -257,7 +260,7 @@ impl serde::Serialize for ListenFinalizeBlockRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -270,7 +273,7 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -281,13 +284,13 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -305,14 +308,14 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListenFinalizeBlockRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.streaming.abci.ListenFinalizeBlockRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListenFinalizeBlockRequest, V::Error>
+            ) -> core::result::Result<ListenFinalizeBlockRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -350,7 +353,7 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ListenFinalizeBlockResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -366,7 +369,7 @@ impl serde::Serialize for ListenFinalizeBlockResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -376,7 +379,7 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -387,13 +390,13 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -407,7 +410,7 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ListenFinalizeBlockResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.store.streaming.abci.ListenFinalizeBlockResponse")
             }
@@ -415,7 +418,7 @@ impl<'de> serde::Deserialize<'de> for ListenFinalizeBlockResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ListenFinalizeBlockResponse, V::Error>
+            ) -> core::result::Result<ListenFinalizeBlockResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.streaming.abci.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.streaming.abci.tonic.rs
@@ -92,12 +92,12 @@ pub mod abci_listener_service_client {
         pub async fn listen_finalize_block(
             &mut self,
             request: impl tonic::IntoRequest<super::ListenFinalizeBlockRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListenFinalizeBlockResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::ListenFinalizeBlockResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -116,12 +116,12 @@ pub mod abci_listener_service_client {
         pub async fn listen_commit(
             &mut self,
             request: impl tonic::IntoRequest<super::ListenCommitRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListenCommitResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::ListenCommitResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -150,13 +150,13 @@ pub mod abci_listener_service_server {
         async fn listen_finalize_block(
             &self,
             request: tonic::Request<super::ListenFinalizeBlockRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListenFinalizeBlockResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ListenFinalizeBlockResponse>, tonic::Status>;
         /** ListenCommit is the corresponding endpoint for ABCIListener.ListenCommit
         */
         async fn listen_commit(
             &self,
             request: tonic::Request<super::ListenCommitRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListenCommitResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::ListenCommitResponse>, tonic::Status>;
     }
     /** ABCIListenerService is the service for the BaseApp ABCIListener interface
     */
@@ -230,7 +230,7 @@ pub mod abci_listener_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -346,8 +346,8 @@ pub mod abci_listener_service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.store.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for BlockMetadata {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -34,7 +34,7 @@ impl serde::Serialize for BlockMetadata {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BlockMetadata {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -55,7 +55,7 @@ impl<'de> serde::Deserialize<'de> for BlockMetadata {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -66,13 +66,13 @@ impl<'de> serde::Deserialize<'de> for BlockMetadata {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -97,11 +97,11 @@ impl<'de> serde::Deserialize<'de> for BlockMetadata {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BlockMetadata;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.v1beta1.BlockMetadata")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BlockMetadata, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<BlockMetadata, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -151,7 +151,7 @@ impl<'de> serde::Deserialize<'de> for BlockMetadata {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CommitId {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -166,7 +166,10 @@ impl serde::Serialize for CommitId {
         let mut struct_ser = serializer.serialize_struct("cosmos.store.v1beta1.CommitID", len)?;
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         if !self.hash.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -179,7 +182,7 @@ impl serde::Serialize for CommitId {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CommitId {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -192,7 +195,7 @@ impl<'de> serde::Deserialize<'de> for CommitId {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -203,13 +206,13 @@ impl<'de> serde::Deserialize<'de> for CommitId {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -227,11 +230,11 @@ impl<'de> serde::Deserialize<'de> for CommitId {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommitId;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.v1beta1.CommitID")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CommitId, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CommitId, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -271,7 +274,7 @@ impl<'de> serde::Deserialize<'de> for CommitId {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CommitInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -289,7 +292,10 @@ impl serde::Serialize for CommitInfo {
         let mut struct_ser = serializer.serialize_struct("cosmos.store.v1beta1.CommitInfo", len)?;
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         if !self.store_infos.is_empty() {
             struct_ser.serialize_field("storeInfos", &self.store_infos)?;
@@ -303,7 +309,7 @@ impl serde::Serialize for CommitInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CommitInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -317,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -328,13 +334,13 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -353,11 +359,11 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommitInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.v1beta1.CommitInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CommitInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CommitInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -402,7 +408,7 @@ impl<'de> serde::Deserialize<'de> for CommitInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -427,7 +433,7 @@ impl serde::Serialize for StoreInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -440,7 +446,7 @@ impl<'de> serde::Deserialize<'de> for StoreInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -451,13 +457,13 @@ impl<'de> serde::Deserialize<'de> for StoreInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -475,11 +481,11 @@ impl<'de> serde::Deserialize<'de> for StoreInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.v1beta1.StoreInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StoreInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StoreInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -513,7 +519,7 @@ impl<'de> serde::Deserialize<'de> for StoreInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreKvPair {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -557,7 +563,7 @@ impl serde::Serialize for StoreKvPair {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreKvPair {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -572,7 +578,7 @@ impl<'de> serde::Deserialize<'de> for StoreKvPair {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -583,13 +589,13 @@ impl<'de> serde::Deserialize<'de> for StoreKvPair {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -609,11 +615,11 @@ impl<'de> serde::Deserialize<'de> for StoreKvPair {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreKvPair;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.store.v1beta1.StoreKVPair")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StoreKvPair, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StoreKvPair, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.config.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Config {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Config {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Config {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -45,7 +45,7 @@ impl<'de> serde::Deserialize<'de> for Config {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -56,13 +56,13 @@ impl<'de> serde::Deserialize<'de> for Config {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -84,11 +84,11 @@ impl<'de> serde::Deserialize<'de> for Config {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Config;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.config.v1.Config")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Config, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Config, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.signing.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.signing.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignMode {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -20,7 +20,7 @@ impl serde::Serialize for SignMode {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignMode {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -38,11 +38,11 @@ impl<'de> serde::Deserialize<'de> for SignMode {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignMode;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -54,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for SignMode {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -66,7 +66,7 @@ impl<'de> serde::Deserialize<'de> for SignMode {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -87,7 +87,7 @@ impl<'de> serde::Deserialize<'de> for SignMode {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignatureDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -112,7 +112,10 @@ impl serde::Serialize for SignatureDescriptor {
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequence", ToString::to_string(&self.sequence).as_str())?;
+            struct_ser.serialize_field(
+                "sequence",
+                alloc::string::ToString::to_string(&self.sequence).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -120,7 +123,7 @@ impl serde::Serialize for SignatureDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignatureDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -134,7 +137,7 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -145,13 +148,13 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -170,11 +173,14 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignatureDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.signing.v1beta1.SignatureDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SignatureDescriptor, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<SignatureDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -223,7 +229,7 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for signature_descriptor::Data {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -250,7 +256,7 @@ impl serde::Serialize for signature_descriptor::Data {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -263,7 +269,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -274,13 +280,13 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -298,14 +304,14 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = signature_descriptor::Data;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.signing.v1beta1.SignatureDescriptor.Data")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<signature_descriptor::Data, V::Error>
+            ) -> core::result::Result<signature_descriptor::Data, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -317,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
                                 return Err(serde::de::Error::duplicate_field("single"));
                             }
                             sum__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(signature_descriptor::data::Sum::Single);
                         }
                         GeneratedField::Multi => {
@@ -325,7 +331,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
                                 return Err(serde::de::Error::duplicate_field("multi"));
                             }
                             sum__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(signature_descriptor::data::Sum::Multi);
                         }
                     }
@@ -343,7 +349,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::Data {
 #[cfg(feature = "serde")]
 impl serde::Serialize for signature_descriptor::data::Multi {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -371,7 +377,7 @@ impl serde::Serialize for signature_descriptor::data::Multi {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -384,7 +390,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -395,13 +401,13 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -419,7 +425,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = signature_descriptor::data::Multi;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.tx.signing.v1beta1.SignatureDescriptor.Data.Multi")
             }
@@ -427,7 +433,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<signature_descriptor::data::Multi, V::Error>
+            ) -> core::result::Result<signature_descriptor::data::Multi, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -465,7 +471,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Multi {
 #[cfg(feature = "serde")]
 impl serde::Serialize for signature_descriptor::data::Single {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -482,8 +488,9 @@ impl serde::Serialize for signature_descriptor::data::Single {
             len,
         )?;
         if self.mode != 0 {
-            let v = SignMode::try_from(self.mode)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.mode)))?;
+            let v = SignMode::try_from(self.mode).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.mode))
+            })?;
             struct_ser.serialize_field("mode", &v)?;
         }
         if !self.signature.is_empty() {
@@ -499,7 +506,7 @@ impl serde::Serialize for signature_descriptor::data::Single {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -512,7 +519,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -523,13 +530,13 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -547,7 +554,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = signature_descriptor::data::Single;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.tx.signing.v1beta1.SignatureDescriptor.Data.Single")
             }
@@ -555,7 +562,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<signature_descriptor::data::Single, V::Error>
+            ) -> core::result::Result<signature_descriptor::data::Single, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -596,7 +603,7 @@ impl<'de> serde::Deserialize<'de> for signature_descriptor::data::Single {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignatureDescriptors {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -616,7 +623,7 @@ impl serde::Serialize for SignatureDescriptors {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignatureDescriptors {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -628,7 +635,7 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptors {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -639,13 +646,13 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptors {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -662,14 +669,14 @@ impl<'de> serde::Deserialize<'de> for SignatureDescriptors {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignatureDescriptors;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.signing.v1beta1.SignatureDescriptors")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SignatureDescriptors, V::Error>
+            ) -> core::result::Result<SignatureDescriptors, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AuthInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -33,7 +33,7 @@ impl serde::Serialize for AuthInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AuthInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -47,7 +47,7 @@ impl<'de> serde::Deserialize<'de> for AuthInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -58,13 +58,13 @@ impl<'de> serde::Deserialize<'de> for AuthInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -83,11 +83,11 @@ impl<'de> serde::Deserialize<'de> for AuthInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AuthInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.AuthInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AuthInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AuthInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -129,7 +129,7 @@ impl<'de> serde::Deserialize<'de> for AuthInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AuxSignerData {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -155,8 +155,9 @@ impl serde::Serialize for AuxSignerData {
             struct_ser.serialize_field("signDoc", v)?;
         }
         if self.mode != 0 {
-            let v = super::signing::v1beta1::SignMode::try_from(self.mode)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.mode)))?;
+            let v = super::signing::v1beta1::SignMode::try_from(self.mode).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.mode))
+            })?;
             struct_ser.serialize_field("mode", &v)?;
         }
         if !self.sig.is_empty() {
@@ -170,7 +171,7 @@ impl serde::Serialize for AuxSignerData {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AuxSignerData {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -185,7 +186,7 @@ impl<'de> serde::Deserialize<'de> for AuxSignerData {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -196,13 +197,13 @@ impl<'de> serde::Deserialize<'de> for AuxSignerData {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -222,11 +223,11 @@ impl<'de> serde::Deserialize<'de> for AuxSignerData {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AuxSignerData;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.AuxSignerData")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AuxSignerData, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AuxSignerData, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -281,7 +282,7 @@ impl<'de> serde::Deserialize<'de> for AuxSignerData {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BroadcastMode {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -297,7 +298,7 @@ impl serde::Serialize for BroadcastMode {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BroadcastMode {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -313,11 +314,11 @@ impl<'de> serde::Deserialize<'de> for BroadcastMode {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BroadcastMode;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -329,7 +330,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastMode {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -341,7 +342,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastMode {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -360,7 +361,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastMode {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BroadcastTxRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -382,8 +383,9 @@ impl serde::Serialize for BroadcastTxRequest {
             )?;
         }
         if self.mode != 0 {
-            let v = BroadcastMode::try_from(self.mode)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.mode)))?;
+            let v = BroadcastMode::try_from(self.mode).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.mode))
+            })?;
             struct_ser.serialize_field("mode", &v)?;
         }
         struct_ser.end()
@@ -392,7 +394,7 @@ impl serde::Serialize for BroadcastTxRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BroadcastTxRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -405,7 +407,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -416,13 +418,13 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -440,11 +442,11 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BroadcastTxRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.BroadcastTxRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BroadcastTxRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<BroadcastTxRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -485,7 +487,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for BroadcastTxResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -505,7 +507,7 @@ impl serde::Serialize for BroadcastTxResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BroadcastTxResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -517,7 +519,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -528,13 +530,13 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -551,11 +553,14 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BroadcastTxResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.BroadcastTxResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BroadcastTxResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<BroadcastTxResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -585,7 +590,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTxResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Fee {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -609,8 +614,10 @@ impl serde::Serialize for Fee {
         }
         if self.gas_limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("gasLimit", ToString::to_string(&self.gas_limit).as_str())?;
+            struct_ser.serialize_field(
+                "gasLimit",
+                alloc::string::ToString::to_string(&self.gas_limit).as_str(),
+            )?;
         }
         if !self.payer.is_empty() {
             struct_ser.serialize_field("payer", &self.payer)?;
@@ -624,7 +631,7 @@ impl serde::Serialize for Fee {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Fee {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -639,7 +646,7 @@ impl<'de> serde::Deserialize<'de> for Fee {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -650,13 +657,13 @@ impl<'de> serde::Deserialize<'de> for Fee {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -676,11 +683,11 @@ impl<'de> serde::Deserialize<'de> for Fee {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Fee;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.Fee")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Fee, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Fee, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -733,7 +740,7 @@ impl<'de> serde::Deserialize<'de> for Fee {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetBlockWithTxsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -749,7 +756,10 @@ impl serde::Serialize for GetBlockWithTxsRequest {
             serializer.serialize_struct("cosmos.tx.v1beta1.GetBlockWithTxsRequest", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if let Some(v) = self.pagination.as_ref() {
             struct_ser.serialize_field("pagination", v)?;
@@ -760,7 +770,7 @@ impl serde::Serialize for GetBlockWithTxsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetBlockWithTxsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -773,7 +783,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -784,13 +794,13 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -808,14 +818,14 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetBlockWithTxsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetBlockWithTxsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetBlockWithTxsRequest, V::Error>
+            ) -> core::result::Result<GetBlockWithTxsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -856,7 +866,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetBlockWithTxsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -894,7 +904,7 @@ impl serde::Serialize for GetBlockWithTxsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetBlockWithTxsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -909,7 +919,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -920,13 +930,13 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -946,14 +956,14 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetBlockWithTxsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetBlockWithTxsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<GetBlockWithTxsResponse, V::Error>
+            ) -> core::result::Result<GetBlockWithTxsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1007,7 +1017,7 @@ impl<'de> serde::Deserialize<'de> for GetBlockWithTxsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1026,7 +1036,7 @@ impl serde::Serialize for GetTxRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1038,7 +1048,7 @@ impl<'de> serde::Deserialize<'de> for GetTxRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1049,13 +1059,13 @@ impl<'de> serde::Deserialize<'de> for GetTxRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1072,11 +1082,11 @@ impl<'de> serde::Deserialize<'de> for GetTxRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetTxRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetTxRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetTxRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1102,7 +1112,7 @@ impl<'de> serde::Deserialize<'de> for GetTxRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1127,7 +1137,7 @@ impl serde::Serialize for GetTxResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1140,7 +1150,7 @@ impl<'de> serde::Deserialize<'de> for GetTxResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1151,13 +1161,13 @@ impl<'de> serde::Deserialize<'de> for GetTxResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1175,11 +1185,11 @@ impl<'de> serde::Deserialize<'de> for GetTxResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetTxResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetTxResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetTxResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1213,7 +1223,7 @@ impl<'de> serde::Deserialize<'de> for GetTxResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxsEventRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1247,17 +1257,23 @@ impl serde::Serialize for GetTxsEventRequest {
         }
         if self.order_by != 0 {
             let v = OrderBy::try_from(self.order_by).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.order_by))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.order_by))
             })?;
             struct_ser.serialize_field("orderBy", &v)?;
         }
         if self.page != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("page", ToString::to_string(&self.page).as_str())?;
+            struct_ser.serialize_field(
+                "page",
+                alloc::string::ToString::to_string(&self.page).as_str(),
+            )?;
         }
         if self.limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("limit", ToString::to_string(&self.limit).as_str())?;
+            struct_ser.serialize_field(
+                "limit",
+                alloc::string::ToString::to_string(&self.limit).as_str(),
+            )?;
         }
         if !self.query.is_empty() {
             struct_ser.serialize_field("query", &self.query)?;
@@ -1268,7 +1284,7 @@ impl serde::Serialize for GetTxsEventRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxsEventRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1293,7 +1309,7 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1304,13 +1320,13 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1332,11 +1348,11 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxsEventRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetTxsEventRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetTxsEventRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GetTxsEventRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1412,7 +1428,7 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GetTxsEventResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1443,7 +1459,10 @@ impl serde::Serialize for GetTxsEventResponse {
         }
         if self.total != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("total", ToString::to_string(&self.total).as_str())?;
+            struct_ser.serialize_field(
+                "total",
+                alloc::string::ToString::to_string(&self.total).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -1451,7 +1470,7 @@ impl serde::Serialize for GetTxsEventResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GetTxsEventResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1466,7 +1485,7 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1477,13 +1496,13 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1503,11 +1522,14 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GetTxsEventResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.GetTxsEventResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetTxsEventResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<GetTxsEventResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1564,7 +1586,7 @@ impl<'de> serde::Deserialize<'de> for GetTxsEventResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModeInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1590,7 +1612,7 @@ impl serde::Serialize for ModeInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModeInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1603,7 +1625,7 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1614,13 +1636,13 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1638,11 +1660,11 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModeInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.ModeInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModeInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModeInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1654,7 +1676,7 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
                                 return Err(serde::de::Error::duplicate_field("single"));
                             }
                             sum__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(mode_info::Sum::Single);
                         }
                         GeneratedField::Multi => {
@@ -1662,7 +1684,7 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
                                 return Err(serde::de::Error::duplicate_field("multi"));
                             }
                             sum__ = map_
-                                .next_value::<::std::option::Option<_>>()?
+                                .next_value::<::core::option::Option<_>>()?
                                 .map(mode_info::Sum::Multi);
                         }
                     }
@@ -1676,7 +1698,7 @@ impl<'de> serde::Deserialize<'de> for ModeInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for mode_info::Multi {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1702,7 +1724,7 @@ impl serde::Serialize for mode_info::Multi {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for mode_info::Multi {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1715,7 +1737,7 @@ impl<'de> serde::Deserialize<'de> for mode_info::Multi {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1726,13 +1748,13 @@ impl<'de> serde::Deserialize<'de> for mode_info::Multi {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1750,11 +1772,11 @@ impl<'de> serde::Deserialize<'de> for mode_info::Multi {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = mode_info::Multi;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.ModeInfo.Multi")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<mode_info::Multi, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<mode_info::Multi, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1792,7 +1814,7 @@ impl<'de> serde::Deserialize<'de> for mode_info::Multi {
 #[cfg(feature = "serde")]
 impl serde::Serialize for mode_info::Single {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1804,8 +1826,9 @@ impl serde::Serialize for mode_info::Single {
         let mut struct_ser =
             serializer.serialize_struct("cosmos.tx.v1beta1.ModeInfo.Single", len)?;
         if self.mode != 0 {
-            let v = super::signing::v1beta1::SignMode::try_from(self.mode)
-                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.mode)))?;
+            let v = super::signing::v1beta1::SignMode::try_from(self.mode).map_err(|_| {
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.mode))
+            })?;
             struct_ser.serialize_field("mode", &v)?;
         }
         struct_ser.end()
@@ -1814,7 +1837,7 @@ impl serde::Serialize for mode_info::Single {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for mode_info::Single {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1826,7 +1849,7 @@ impl<'de> serde::Deserialize<'de> for mode_info::Single {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1837,13 +1860,13 @@ impl<'de> serde::Deserialize<'de> for mode_info::Single {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1860,11 +1883,11 @@ impl<'de> serde::Deserialize<'de> for mode_info::Single {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = mode_info::Single;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.ModeInfo.Single")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<mode_info::Single, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<mode_info::Single, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1896,7 +1919,7 @@ impl<'de> serde::Deserialize<'de> for mode_info::Single {
 #[cfg(feature = "serde")]
 impl serde::Serialize for OrderBy {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1911,7 +1934,7 @@ impl serde::Serialize for OrderBy {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for OrderBy {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1922,11 +1945,11 @@ impl<'de> serde::Deserialize<'de> for OrderBy {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = OrderBy;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1938,7 +1961,7 @@ impl<'de> serde::Deserialize<'de> for OrderBy {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1950,7 +1973,7 @@ impl<'de> serde::Deserialize<'de> for OrderBy {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1968,7 +1991,7 @@ impl<'de> serde::Deserialize<'de> for OrderBy {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignDoc {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2008,7 +2031,7 @@ impl serde::Serialize for SignDoc {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "accountNumber",
-                ToString::to_string(&self.account_number).as_str(),
+                alloc::string::ToString::to_string(&self.account_number).as_str(),
             )?;
         }
         struct_ser.end()
@@ -2017,7 +2040,7 @@ impl serde::Serialize for SignDoc {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignDoc {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2041,7 +2064,7 @@ impl<'de> serde::Deserialize<'de> for SignDoc {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2052,13 +2075,13 @@ impl<'de> serde::Deserialize<'de> for SignDoc {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2080,11 +2103,11 @@ impl<'de> serde::Deserialize<'de> for SignDoc {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignDoc;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.SignDoc")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SignDoc, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SignDoc, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2143,7 +2166,7 @@ impl<'de> serde::Deserialize<'de> for SignDoc {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignDocDirectAux {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2186,12 +2209,15 @@ impl serde::Serialize for SignDocDirectAux {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "accountNumber",
-                ToString::to_string(&self.account_number).as_str(),
+                alloc::string::ToString::to_string(&self.account_number).as_str(),
             )?;
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequence", ToString::to_string(&self.sequence).as_str())?;
+            struct_ser.serialize_field(
+                "sequence",
+                alloc::string::ToString::to_string(&self.sequence).as_str(),
+            )?;
         }
         if let Some(v) = self.tip.as_ref() {
             struct_ser.serialize_field("tip", v)?;
@@ -2202,7 +2228,7 @@ impl serde::Serialize for SignDocDirectAux {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignDocDirectAux {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2230,7 +2256,7 @@ impl<'de> serde::Deserialize<'de> for SignDocDirectAux {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2241,13 +2267,13 @@ impl<'de> serde::Deserialize<'de> for SignDocDirectAux {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2269,11 +2295,11 @@ impl<'de> serde::Deserialize<'de> for SignDocDirectAux {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignDocDirectAux;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.SignDocDirectAux")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SignDocDirectAux, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SignDocDirectAux, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2352,7 +2378,7 @@ impl<'de> serde::Deserialize<'de> for SignDocDirectAux {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SignerInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2376,7 +2402,10 @@ impl serde::Serialize for SignerInfo {
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequence", ToString::to_string(&self.sequence).as_str())?;
+            struct_ser.serialize_field(
+                "sequence",
+                alloc::string::ToString::to_string(&self.sequence).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -2384,7 +2413,7 @@ impl serde::Serialize for SignerInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SignerInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2404,7 +2433,7 @@ impl<'de> serde::Deserialize<'de> for SignerInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2415,13 +2444,13 @@ impl<'de> serde::Deserialize<'de> for SignerInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2440,11 +2469,11 @@ impl<'de> serde::Deserialize<'de> for SignerInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SignerInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.SignerInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SignerInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SignerInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2489,7 +2518,7 @@ impl<'de> serde::Deserialize<'de> for SignerInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SimulateRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2519,7 +2548,7 @@ impl serde::Serialize for SimulateRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SimulateRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2532,7 +2561,7 @@ impl<'de> serde::Deserialize<'de> for SimulateRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2543,13 +2572,13 @@ impl<'de> serde::Deserialize<'de> for SimulateRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2567,11 +2596,11 @@ impl<'de> serde::Deserialize<'de> for SimulateRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SimulateRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.SimulateRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SimulateRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SimulateRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2612,7 +2641,7 @@ impl<'de> serde::Deserialize<'de> for SimulateRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SimulateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2638,7 +2667,7 @@ impl serde::Serialize for SimulateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SimulateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2651,7 +2680,7 @@ impl<'de> serde::Deserialize<'de> for SimulateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2662,13 +2691,13 @@ impl<'de> serde::Deserialize<'de> for SimulateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2686,11 +2715,11 @@ impl<'de> serde::Deserialize<'de> for SimulateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SimulateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.SimulateResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SimulateResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<SimulateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2728,7 +2757,7 @@ impl<'de> serde::Deserialize<'de> for SimulateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Tip {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2753,7 +2782,7 @@ impl serde::Serialize for Tip {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Tip {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2766,7 +2795,7 @@ impl<'de> serde::Deserialize<'de> for Tip {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2777,13 +2806,13 @@ impl<'de> serde::Deserialize<'de> for Tip {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2801,11 +2830,11 @@ impl<'de> serde::Deserialize<'de> for Tip {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Tip;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.Tip")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Tip, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Tip, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2839,7 +2868,7 @@ impl<'de> serde::Deserialize<'de> for Tip {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Tx {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2868,7 +2897,7 @@ impl serde::Serialize for Tx {
                     .signatures
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -2877,7 +2906,7 @@ impl serde::Serialize for Tx {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Tx {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2891,7 +2920,7 @@ impl<'de> serde::Deserialize<'de> for Tx {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2902,13 +2931,13 @@ impl<'de> serde::Deserialize<'de> for Tx {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2927,11 +2956,11 @@ impl<'de> serde::Deserialize<'de> for Tx {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Tx;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.Tx")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Tx, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Tx, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2956,12 +2985,10 @@ impl<'de> serde::Deserialize<'de> for Tx {
                             if signatures__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("signatures"));
                             }
-                            signatures__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            signatures__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -2978,7 +3005,7 @@ impl<'de> serde::Deserialize<'de> for Tx {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxBody {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3010,7 +3037,7 @@ impl serde::Serialize for TxBody {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "timeoutHeight",
-                ToString::to_string(&self.timeout_height).as_str(),
+                alloc::string::ToString::to_string(&self.timeout_height).as_str(),
             )?;
         }
         if !self.extension_options.is_empty() {
@@ -3028,7 +3055,7 @@ impl serde::Serialize for TxBody {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxBody {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3053,7 +3080,7 @@ impl<'de> serde::Deserialize<'de> for TxBody {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3064,13 +3091,13 @@ impl<'de> serde::Deserialize<'de> for TxBody {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3095,11 +3122,11 @@ impl<'de> serde::Deserialize<'de> for TxBody {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxBody;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxBody")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxBody, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxBody, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3163,7 +3190,7 @@ impl<'de> serde::Deserialize<'de> for TxBody {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxDecodeAminoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3187,7 +3214,7 @@ impl serde::Serialize for TxDecodeAminoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3199,7 +3226,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3210,13 +3237,13 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3233,14 +3260,14 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxDecodeAminoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeAminoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<TxDecodeAminoRequest, V::Error>
+            ) -> core::result::Result<TxDecodeAminoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3273,7 +3300,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxDecodeAminoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3293,7 +3320,7 @@ impl serde::Serialize for TxDecodeAminoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3305,7 +3332,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3316,13 +3343,13 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3339,14 +3366,14 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxDecodeAminoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeAminoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<TxDecodeAminoResponse, V::Error>
+            ) -> core::result::Result<TxDecodeAminoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3376,7 +3403,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeAminoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxDecodeRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3400,7 +3427,7 @@ impl serde::Serialize for TxDecodeRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3412,7 +3439,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3423,13 +3450,13 @@ impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3446,11 +3473,11 @@ impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxDecodeRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxDecodeRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxDecodeRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3483,7 +3510,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxDecodeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3503,7 +3530,7 @@ impl serde::Serialize for TxDecodeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3515,7 +3542,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3526,13 +3553,13 @@ impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3549,11 +3576,11 @@ impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxDecodeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxDecodeResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxDecodeResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxDecodeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3581,7 +3608,7 @@ impl<'de> serde::Deserialize<'de> for TxDecodeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxEncodeAminoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3601,7 +3628,7 @@ impl serde::Serialize for TxEncodeAminoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3613,7 +3640,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3624,13 +3651,13 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3647,14 +3674,14 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxEncodeAminoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeAminoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<TxEncodeAminoRequest, V::Error>
+            ) -> core::result::Result<TxEncodeAminoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3684,7 +3711,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxEncodeAminoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3708,7 +3735,7 @@ impl serde::Serialize for TxEncodeAminoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3720,7 +3747,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3731,13 +3758,13 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3754,14 +3781,14 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxEncodeAminoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeAminoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<TxEncodeAminoResponse, V::Error>
+            ) -> core::result::Result<TxEncodeAminoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3794,7 +3821,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeAminoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxEncodeRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3814,7 +3841,7 @@ impl serde::Serialize for TxEncodeRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3826,7 +3853,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3837,13 +3864,13 @@ impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3860,11 +3887,11 @@ impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxEncodeRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxEncodeRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxEncodeRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3892,7 +3919,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxEncodeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3916,7 +3943,7 @@ impl serde::Serialize for TxEncodeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3928,7 +3955,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3939,13 +3966,13 @@ impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3962,11 +3989,11 @@ impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxEncodeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxEncodeResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxEncodeResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxEncodeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3999,7 +4026,7 @@ impl<'de> serde::Deserialize<'de> for TxEncodeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for TxRaw {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4036,7 +4063,7 @@ impl serde::Serialize for TxRaw {
                     .signatures
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -4045,7 +4072,7 @@ impl serde::Serialize for TxRaw {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxRaw {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4065,7 +4092,7 @@ impl<'de> serde::Deserialize<'de> for TxRaw {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4076,13 +4103,13 @@ impl<'de> serde::Deserialize<'de> for TxRaw {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4103,11 +4130,11 @@ impl<'de> serde::Deserialize<'de> for TxRaw {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = TxRaw;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.tx.v1beta1.TxRaw")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TxRaw, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<TxRaw, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4138,12 +4165,10 @@ impl<'de> serde::Deserialize<'de> for TxRaw {
                             if signatures__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("signatures"));
                             }
-                            signatures__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            signatures__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.tx.v1beta1.tonic.rs
@@ -88,11 +88,11 @@ pub mod service_client {
         pub async fn simulate(
             &mut self,
             request: impl tonic::IntoRequest<super::SimulateRequest>,
-        ) -> std::result::Result<tonic::Response<super::SimulateResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::SimulateResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -105,11 +105,11 @@ pub mod service_client {
         pub async fn get_tx(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTxRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -122,12 +122,12 @@ pub mod service_client {
         pub async fn broadcast_tx(
             &mut self,
             request: impl tonic::IntoRequest<super::BroadcastTxRequest>,
-        ) -> std::result::Result<tonic::Response<super::BroadcastTxResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::BroadcastTxResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -141,12 +141,12 @@ pub mod service_client {
         pub async fn get_txs_event(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTxsEventRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxsEventResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetTxsEventResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -160,12 +160,12 @@ pub mod service_client {
         pub async fn get_block_with_txs(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBlockWithTxsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetBlockWithTxsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::GetBlockWithTxsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -181,11 +181,11 @@ pub mod service_client {
         pub async fn tx_decode(
             &mut self,
             request: impl tonic::IntoRequest<super::TxDecodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -198,11 +198,11 @@ pub mod service_client {
         pub async fn tx_encode(
             &mut self,
             request: impl tonic::IntoRequest<super::TxEncodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -215,12 +215,12 @@ pub mod service_client {
         pub async fn tx_encode_amino(
             &mut self,
             request: impl tonic::IntoRequest<super::TxEncodeAminoRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -236,12 +236,12 @@ pub mod service_client {
         pub async fn tx_decode_amino(
             &mut self,
             request: impl tonic::IntoRequest<super::TxDecodeAminoRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -267,39 +267,39 @@ pub mod service_server {
         async fn simulate(
             &self,
             request: tonic::Request<super::SimulateRequest>,
-        ) -> std::result::Result<tonic::Response<super::SimulateResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::SimulateResponse>, tonic::Status>;
         async fn get_tx(
             &self,
             request: tonic::Request<super::GetTxRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status>;
         async fn broadcast_tx(
             &self,
             request: tonic::Request<super::BroadcastTxRequest>,
-        ) -> std::result::Result<tonic::Response<super::BroadcastTxResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::BroadcastTxResponse>, tonic::Status>;
         async fn get_txs_event(
             &self,
             request: tonic::Request<super::GetTxsEventRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetTxsEventResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetTxsEventResponse>, tonic::Status>;
         async fn get_block_with_txs(
             &self,
             request: tonic::Request<super::GetBlockWithTxsRequest>,
-        ) -> std::result::Result<tonic::Response<super::GetBlockWithTxsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::GetBlockWithTxsResponse>, tonic::Status>;
         async fn tx_decode(
             &self,
             request: tonic::Request<super::TxDecodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::TxDecodeResponse>, tonic::Status>;
         async fn tx_encode(
             &self,
             request: tonic::Request<super::TxEncodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::TxEncodeResponse>, tonic::Status>;
         async fn tx_encode_amino(
             &self,
             request: tonic::Request<super::TxEncodeAminoRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::TxEncodeAminoResponse>, tonic::Status>;
         async fn tx_decode_amino(
             &self,
             request: tonic::Request<super::TxDecodeAminoRequest>,
-        ) -> std::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::TxDecodeAminoResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ServiceServer<T: Service> {
@@ -371,7 +371,7 @@ pub mod service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -749,8 +749,8 @@ pub mod service_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -21,7 +21,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -33,7 +33,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -44,13 +44,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -67,11 +67,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for CancelSoftwareUpgradeProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for CancelSoftwareUpgradeProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CancelSoftwareUpgradeProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for CancelSoftwareUpgradeProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for CancelSoftwareUpgradeProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,14 +76,14 @@ impl<'de> serde::Deserialize<'de> for CancelSoftwareUpgradeProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CancelSoftwareUpgradeProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<CancelSoftwareUpgradeProposal, V::Error>
+            ) -> core::result::Result<CancelSoftwareUpgradeProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -121,7 +121,7 @@ impl<'de> serde::Deserialize<'de> for CancelSoftwareUpgradeProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ModuleVersion {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -140,7 +140,10 @@ impl serde::Serialize for ModuleVersion {
         }
         if self.version != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("version", ToString::to_string(&self.version).as_str())?;
+            struct_ser.serialize_field(
+                "version",
+                alloc::string::ToString::to_string(&self.version).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -148,7 +151,7 @@ impl serde::Serialize for ModuleVersion {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ModuleVersion {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -161,7 +164,7 @@ impl<'de> serde::Deserialize<'de> for ModuleVersion {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -172,13 +175,13 @@ impl<'de> serde::Deserialize<'de> for ModuleVersion {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -196,11 +199,11 @@ impl<'de> serde::Deserialize<'de> for ModuleVersion {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ModuleVersion;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.ModuleVersion")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ModuleVersion, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ModuleVersion, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -241,7 +244,7 @@ impl<'de> serde::Deserialize<'de> for ModuleVersion {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelUpgrade {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -261,7 +264,7 @@ impl serde::Serialize for MsgCancelUpgrade {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelUpgrade {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -273,7 +276,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgrade {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -284,13 +287,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgrade {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -307,11 +310,11 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgrade {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelUpgrade;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.MsgCancelUpgrade")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgCancelUpgrade, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgCancelUpgrade, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -341,7 +344,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgrade {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCancelUpgradeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -355,7 +358,7 @@ impl serde::Serialize for MsgCancelUpgradeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCancelUpgradeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -365,7 +368,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgradeResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -376,13 +379,13 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgradeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -396,14 +399,14 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgradeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCancelUpgradeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.MsgCancelUpgradeResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCancelUpgradeResponse, V::Error>
+            ) -> core::result::Result<MsgCancelUpgradeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -423,7 +426,7 @@ impl<'de> serde::Deserialize<'de> for MsgCancelUpgradeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSoftwareUpgrade {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -449,7 +452,7 @@ impl serde::Serialize for MsgSoftwareUpgrade {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgrade {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -462,7 +465,7 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgrade {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -473,13 +476,13 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgrade {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -497,11 +500,11 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgrade {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSoftwareUpgrade;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.MsgSoftwareUpgrade")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSoftwareUpgrade, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSoftwareUpgrade, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -539,7 +542,7 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgrade {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSoftwareUpgradeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -553,7 +556,7 @@ impl serde::Serialize for MsgSoftwareUpgradeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgradeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -563,7 +566,7 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgradeResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -574,13 +577,13 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgradeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -594,14 +597,14 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgradeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSoftwareUpgradeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.MsgSoftwareUpgradeResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSoftwareUpgradeResponse, V::Error>
+            ) -> core::result::Result<MsgSoftwareUpgradeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -621,7 +624,7 @@ impl<'de> serde::Deserialize<'de> for MsgSoftwareUpgradeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Plan {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -651,7 +654,10 @@ impl serde::Serialize for Plan {
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         if !self.info.is_empty() {
             struct_ser.serialize_field("info", &self.info)?;
@@ -665,7 +671,7 @@ impl serde::Serialize for Plan {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Plan {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -688,7 +694,7 @@ impl<'de> serde::Deserialize<'de> for Plan {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -699,13 +705,13 @@ impl<'de> serde::Deserialize<'de> for Plan {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -728,11 +734,11 @@ impl<'de> serde::Deserialize<'de> for Plan {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Plan;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.Plan")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Plan, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Plan, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -795,7 +801,7 @@ impl<'de> serde::Deserialize<'de> for Plan {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAppliedPlanRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -815,7 +821,7 @@ impl serde::Serialize for QueryAppliedPlanRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAppliedPlanRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -827,7 +833,7 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -838,13 +844,13 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -861,14 +867,14 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAppliedPlanRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryAppliedPlanRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAppliedPlanRequest, V::Error>
+            ) -> core::result::Result<QueryAppliedPlanRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -898,7 +904,7 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAppliedPlanResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -911,7 +917,10 @@ impl serde::Serialize for QueryAppliedPlanResponse {
             serializer.serialize_struct("cosmos.upgrade.v1beta1.QueryAppliedPlanResponse", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+            struct_ser.serialize_field(
+                "height",
+                alloc::string::ToString::to_string(&self.height).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -919,7 +928,7 @@ impl serde::Serialize for QueryAppliedPlanResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAppliedPlanResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -931,7 +940,7 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -942,13 +951,13 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -965,14 +974,14 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAppliedPlanResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryAppliedPlanResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAppliedPlanResponse, V::Error>
+            ) -> core::result::Result<QueryAppliedPlanResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1005,7 +1014,7 @@ impl<'de> serde::Deserialize<'de> for QueryAppliedPlanResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAuthorityRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1019,7 +1028,7 @@ impl serde::Serialize for QueryAuthorityRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAuthorityRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1029,7 +1038,7 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1040,13 +1049,13 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1060,14 +1069,14 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAuthorityRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryAuthorityRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAuthorityRequest, V::Error>
+            ) -> core::result::Result<QueryAuthorityRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1087,7 +1096,7 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAuthorityResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1107,7 +1116,7 @@ impl serde::Serialize for QueryAuthorityResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAuthorityResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1119,7 +1128,7 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1130,13 +1139,13 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1153,14 +1162,14 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAuthorityResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryAuthorityResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAuthorityResponse, V::Error>
+            ) -> core::result::Result<QueryAuthorityResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1190,7 +1199,7 @@ impl<'de> serde::Deserialize<'de> for QueryAuthorityResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCurrentPlanRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1204,7 +1213,7 @@ impl serde::Serialize for QueryCurrentPlanRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCurrentPlanRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1214,7 +1223,7 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1225,13 +1234,13 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1245,14 +1254,14 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCurrentPlanRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryCurrentPlanRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryCurrentPlanRequest, V::Error>
+            ) -> core::result::Result<QueryCurrentPlanRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1272,7 +1281,7 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCurrentPlanResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1292,7 +1301,7 @@ impl serde::Serialize for QueryCurrentPlanResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCurrentPlanResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1304,7 +1313,7 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1315,13 +1324,13 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1338,14 +1347,14 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCurrentPlanResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryCurrentPlanResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryCurrentPlanResponse, V::Error>
+            ) -> core::result::Result<QueryCurrentPlanResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1373,7 +1382,7 @@ impl<'de> serde::Deserialize<'de> for QueryCurrentPlanResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleVersionsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1393,7 +1402,7 @@ impl serde::Serialize for QueryModuleVersionsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleVersionsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1405,7 +1414,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1416,13 +1425,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1439,14 +1448,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleVersionsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryModuleVersionsRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleVersionsRequest, V::Error>
+            ) -> core::result::Result<QueryModuleVersionsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1476,7 +1485,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryModuleVersionsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1496,7 +1505,7 @@ impl serde::Serialize for QueryModuleVersionsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryModuleVersionsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1508,7 +1517,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1519,13 +1528,13 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1544,14 +1553,14 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryModuleVersionsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.QueryModuleVersionsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryModuleVersionsResponse, V::Error>
+            ) -> core::result::Result<QueryModuleVersionsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1581,7 +1590,7 @@ impl<'de> serde::Deserialize<'de> for QueryModuleVersionsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryUpgradedConsensusStateRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1598,7 +1607,7 @@ impl serde::Serialize for QueryUpgradedConsensusStateRequest {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "lastHeight",
-                ToString::to_string(&self.last_height).as_str(),
+                alloc::string::ToString::to_string(&self.last_height).as_str(),
             )?;
         }
         struct_ser.end()
@@ -1607,7 +1616,7 @@ impl serde::Serialize for QueryUpgradedConsensusStateRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1619,7 +1628,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1630,13 +1639,13 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1653,7 +1662,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryUpgradedConsensusStateRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateRequest")
             }
@@ -1661,7 +1670,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryUpgradedConsensusStateRequest, V::Error>
+            ) -> core::result::Result<QueryUpgradedConsensusStateRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1694,7 +1703,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryUpgradedConsensusStateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1720,7 +1729,7 @@ impl serde::Serialize for QueryUpgradedConsensusStateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1732,7 +1741,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1743,13 +1752,13 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1768,7 +1777,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryUpgradedConsensusStateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateResponse")
             }
@@ -1776,7 +1785,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryUpgradedConsensusStateResponse, V::Error>
+            ) -> core::result::Result<QueryUpgradedConsensusStateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1811,7 +1820,7 @@ impl<'de> serde::Deserialize<'de> for QueryUpgradedConsensusStateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SoftwareUpgradeProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1843,7 +1852,7 @@ impl serde::Serialize for SoftwareUpgradeProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SoftwareUpgradeProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1857,7 +1866,7 @@ impl<'de> serde::Deserialize<'de> for SoftwareUpgradeProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1868,13 +1877,13 @@ impl<'de> serde::Deserialize<'de> for SoftwareUpgradeProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1893,14 +1902,14 @@ impl<'de> serde::Deserialize<'de> for SoftwareUpgradeProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SoftwareUpgradeProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.upgrade.v1beta1.SoftwareUpgradeProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SoftwareUpgradeProposal, V::Error>
+            ) -> core::result::Result<SoftwareUpgradeProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.upgrade.v1beta1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn current_plan(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCurrentPlanRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCurrentPlanResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryCurrentPlanResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -109,12 +109,12 @@ pub mod query_client {
         pub async fn applied_plan(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAppliedPlanRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAppliedPlanResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAppliedPlanResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -130,14 +130,14 @@ pub mod query_client {
         pub async fn upgraded_consensus_state(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryUpgradedConsensusStateRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryUpgradedConsensusStateResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -154,12 +154,12 @@ pub mod query_client {
         pub async fn module_versions(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryModuleVersionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryModuleVersionsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryModuleVersionsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -176,12 +176,12 @@ pub mod query_client {
         pub async fn authority(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAuthorityRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAuthorityResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryAuthorityResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -205,26 +205,26 @@ pub mod query_server {
         async fn current_plan(
             &self,
             request: tonic::Request<super::QueryCurrentPlanRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCurrentPlanResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryCurrentPlanResponse>, tonic::Status>;
         async fn applied_plan(
             &self,
             request: tonic::Request<super::QueryAppliedPlanRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAppliedPlanResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAppliedPlanResponse>, tonic::Status>;
         async fn upgraded_consensus_state(
             &self,
             request: tonic::Request<super::QueryUpgradedConsensusStateRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryUpgradedConsensusStateResponse>,
             tonic::Status,
         >;
         async fn module_versions(
             &self,
             request: tonic::Request<super::QueryModuleVersionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryModuleVersionsResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryModuleVersionsResponse>, tonic::Status>;
         async fn authority(
             &self,
             request: tonic::Request<super::QueryAuthorityRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAuthorityResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::QueryAuthorityResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct QueryServer<T: Query> {
@@ -296,7 +296,7 @@ pub mod query_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -526,8 +526,8 @@ pub mod query_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }
@@ -621,12 +621,12 @@ pub mod msg_client {
         pub async fn software_upgrade(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSoftwareUpgrade>,
-        ) -> std::result::Result<tonic::Response<super::MsgSoftwareUpgradeResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSoftwareUpgradeResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -642,12 +642,12 @@ pub mod msg_client {
         pub async fn cancel_upgrade(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCancelUpgrade>,
-        ) -> std::result::Result<tonic::Response<super::MsgCancelUpgradeResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgCancelUpgradeResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -673,11 +673,11 @@ pub mod msg_server {
         async fn software_upgrade(
             &self,
             request: tonic::Request<super::MsgSoftwareUpgrade>,
-        ) -> std::result::Result<tonic::Response<super::MsgSoftwareUpgradeResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgSoftwareUpgradeResponse>, tonic::Status>;
         async fn cancel_upgrade(
             &self,
             request: tonic::Request<super::MsgCancelUpgrade>,
-        ) -> std::result::Result<tonic::Response<super::MsgCancelUpgradeResponse>, tonic::Status>;
+        ) -> core::result::Result<tonic::Response<super::MsgCancelUpgradeResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MsgServer<T: Msg> {
@@ -749,7 +749,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -859,8 +859,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.module.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Module {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -15,7 +15,7 @@ impl serde::Serialize for Module {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Module {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -25,7 +25,7 @@ impl<'de> serde::Deserialize<'de> for Module {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -36,13 +36,13 @@ impl<'de> serde::Deserialize<'de> for Module {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -56,11 +56,11 @@ impl<'de> serde::Deserialize<'de> for Module {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Module;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.module.v1.Module")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Module, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Module, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for BaseVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -39,7 +39,10 @@ impl serde::Serialize for BaseVestingAccount {
         }
         if self.end_time != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("endTime", ToString::to_string(&self.end_time).as_str())?;
+            struct_ser.serialize_field(
+                "endTime",
+                alloc::string::ToString::to_string(&self.end_time).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -47,7 +50,7 @@ impl serde::Serialize for BaseVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for BaseVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -74,7 +77,7 @@ impl<'de> serde::Deserialize<'de> for BaseVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -85,13 +88,13 @@ impl<'de> serde::Deserialize<'de> for BaseVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -116,11 +119,11 @@ impl<'de> serde::Deserialize<'de> for BaseVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BaseVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.BaseVestingAccount")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BaseVestingAccount, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<BaseVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -185,7 +188,7 @@ impl<'de> serde::Deserialize<'de> for BaseVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContinuousVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -204,8 +207,10 @@ impl serde::Serialize for ContinuousVestingAccount {
         }
         if self.start_time != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("startTime", ToString::to_string(&self.start_time).as_str())?;
+            struct_ser.serialize_field(
+                "startTime",
+                alloc::string::ToString::to_string(&self.start_time).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -213,7 +218,7 @@ impl serde::Serialize for ContinuousVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContinuousVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -231,7 +236,7 @@ impl<'de> serde::Deserialize<'de> for ContinuousVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -242,13 +247,13 @@ impl<'de> serde::Deserialize<'de> for ContinuousVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -268,14 +273,14 @@ impl<'de> serde::Deserialize<'de> for ContinuousVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContinuousVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.ContinuousVestingAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ContinuousVestingAccount, V::Error>
+            ) -> core::result::Result<ContinuousVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -318,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for ContinuousVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DelayedVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -338,7 +343,7 @@ impl serde::Serialize for DelayedVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DelayedVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -350,7 +355,7 @@ impl<'de> serde::Deserialize<'de> for DelayedVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -361,13 +366,13 @@ impl<'de> serde::Deserialize<'de> for DelayedVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -386,14 +391,14 @@ impl<'de> serde::Deserialize<'de> for DelayedVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DelayedVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.DelayedVestingAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<DelayedVestingAccount, V::Error>
+            ) -> core::result::Result<DelayedVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -425,7 +430,7 @@ impl<'de> serde::Deserialize<'de> for DelayedVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreatePeriodicVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -455,8 +460,10 @@ impl serde::Serialize for MsgCreatePeriodicVestingAccount {
         }
         if self.start_time != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("startTime", ToString::to_string(&self.start_time).as_str())?;
+            struct_ser.serialize_field(
+                "startTime",
+                alloc::string::ToString::to_string(&self.start_time).as_str(),
+            )?;
         }
         if !self.vesting_periods.is_empty() {
             struct_ser.serialize_field("vestingPeriods", &self.vesting_periods)?;
@@ -467,7 +474,7 @@ impl serde::Serialize for MsgCreatePeriodicVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -491,7 +498,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -502,13 +509,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -530,14 +537,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreatePeriodicVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreatePeriodicVestingAccount, V::Error>
+            ) -> core::result::Result<MsgCreatePeriodicVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -594,7 +601,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreatePeriodicVestingAccountResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -610,7 +617,7 @@ impl serde::Serialize for MsgCreatePeriodicVestingAccountResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -620,7 +627,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -631,13 +638,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -651,7 +658,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreatePeriodicVestingAccountResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccountResponse",
                 )
@@ -660,7 +667,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreatePeriodicVestingAccountResponse, V::Error>
+            ) -> core::result::Result<MsgCreatePeriodicVestingAccountResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -680,7 +687,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePeriodicVestingAccountResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreatePermanentLockedAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -714,7 +721,7 @@ impl serde::Serialize for MsgCreatePermanentLockedAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -734,7 +741,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -745,13 +752,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -770,14 +777,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreatePermanentLockedAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreatePermanentLockedAccount, V::Error>
+            ) -> core::result::Result<MsgCreatePermanentLockedAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -823,7 +830,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreatePermanentLockedAccountResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -839,7 +846,7 @@ impl serde::Serialize for MsgCreatePermanentLockedAccountResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -849,7 +856,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -860,13 +867,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -880,7 +887,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreatePermanentLockedAccountResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str(
                     "struct cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccountResponse",
                 )
@@ -889,7 +896,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreatePermanentLockedAccountResponse, V::Error>
+            ) -> core::result::Result<MsgCreatePermanentLockedAccountResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -909,7 +916,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreatePermanentLockedAccountResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -943,7 +950,10 @@ impl serde::Serialize for MsgCreateVestingAccount {
         }
         if self.end_time != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("endTime", ToString::to_string(&self.end_time).as_str())?;
+            struct_ser.serialize_field(
+                "endTime",
+                alloc::string::ToString::to_string(&self.end_time).as_str(),
+            )?;
         }
         if self.delayed {
             struct_ser.serialize_field("delayed", &self.delayed)?;
@@ -954,7 +964,7 @@ impl serde::Serialize for MsgCreateVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -979,7 +989,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -990,13 +1000,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1017,14 +1027,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.MsgCreateVestingAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateVestingAccount, V::Error>
+            ) -> core::result::Result<MsgCreateVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1089,7 +1099,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgCreateVestingAccountResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1105,7 +1115,7 @@ impl serde::Serialize for MsgCreateVestingAccountResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccountResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1115,7 +1125,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccountResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1126,13 +1136,13 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccountResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1146,14 +1156,14 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccountResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgCreateVestingAccountResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.MsgCreateVestingAccountResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgCreateVestingAccountResponse, V::Error>
+            ) -> core::result::Result<MsgCreateVestingAccountResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1173,7 +1183,7 @@ impl<'de> serde::Deserialize<'de> for MsgCreateVestingAccountResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Period {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1188,7 +1198,10 @@ impl serde::Serialize for Period {
         let mut struct_ser = serializer.serialize_struct("cosmos.vesting.v1beta1.Period", len)?;
         if self.length != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("length", ToString::to_string(&self.length).as_str())?;
+            struct_ser.serialize_field(
+                "length",
+                alloc::string::ToString::to_string(&self.length).as_str(),
+            )?;
         }
         if !self.amount.is_empty() {
             struct_ser.serialize_field("amount", &self.amount)?;
@@ -1199,7 +1212,7 @@ impl serde::Serialize for Period {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Period {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1212,7 +1225,7 @@ impl<'de> serde::Deserialize<'de> for Period {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1223,13 +1236,13 @@ impl<'de> serde::Deserialize<'de> for Period {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1247,11 +1260,11 @@ impl<'de> serde::Deserialize<'de> for Period {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Period;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.Period")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Period, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Period, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1288,7 +1301,7 @@ impl<'de> serde::Deserialize<'de> for Period {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PeriodicVestingAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1310,8 +1323,10 @@ impl serde::Serialize for PeriodicVestingAccount {
         }
         if self.start_time != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("startTime", ToString::to_string(&self.start_time).as_str())?;
+            struct_ser.serialize_field(
+                "startTime",
+                alloc::string::ToString::to_string(&self.start_time).as_str(),
+            )?;
         }
         if !self.vesting_periods.is_empty() {
             struct_ser.serialize_field("vestingPeriods", &self.vesting_periods)?;
@@ -1322,7 +1337,7 @@ impl serde::Serialize for PeriodicVestingAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PeriodicVestingAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1343,7 +1358,7 @@ impl<'de> serde::Deserialize<'de> for PeriodicVestingAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1354,13 +1369,13 @@ impl<'de> serde::Deserialize<'de> for PeriodicVestingAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1383,14 +1398,14 @@ impl<'de> serde::Deserialize<'de> for PeriodicVestingAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PeriodicVestingAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.PeriodicVestingAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<PeriodicVestingAccount, V::Error>
+            ) -> core::result::Result<PeriodicVestingAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1441,7 +1456,7 @@ impl<'de> serde::Deserialize<'de> for PeriodicVestingAccount {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PermanentLockedAccount {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1461,7 +1476,7 @@ impl serde::Serialize for PermanentLockedAccount {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PermanentLockedAccount {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1473,7 +1488,7 @@ impl<'de> serde::Deserialize<'de> for PermanentLockedAccount {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1484,13 +1499,13 @@ impl<'de> serde::Deserialize<'de> for PermanentLockedAccount {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1509,14 +1524,14 @@ impl<'de> serde::Deserialize<'de> for PermanentLockedAccount {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PermanentLockedAccount;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.vesting.v1beta1.PermanentLockedAccount")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<PermanentLockedAccount, V::Error>
+            ) -> core::result::Result<PermanentLockedAccount, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos.vesting.v1beta1.tonic.rs
@@ -85,14 +85,14 @@ pub mod msg_client {
         pub async fn create_vesting_account(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreateVestingAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreateVestingAccountResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -109,14 +109,14 @@ pub mod msg_client {
         pub async fn create_permanent_locked_account(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreatePermanentLockedAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreatePermanentLockedAccountResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -133,14 +133,14 @@ pub mod msg_client {
         pub async fn create_periodic_vesting_account(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgCreatePeriodicVestingAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreatePeriodicVestingAccountResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -167,21 +167,21 @@ pub mod msg_server {
         async fn create_vesting_account(
             &self,
             request: tonic::Request<super::MsgCreateVestingAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreateVestingAccountResponse>,
             tonic::Status,
         >;
         async fn create_permanent_locked_account(
             &self,
             request: tonic::Request<super::MsgCreatePermanentLockedAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreatePermanentLockedAccountResponse>,
             tonic::Status,
         >;
         async fn create_periodic_vesting_account(
             &self,
             request: tonic::Request<super::MsgCreatePeriodicVestingAccount>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgCreatePeriodicVestingAccountResponse>,
             tonic::Status,
         >;
@@ -256,7 +256,7 @@ pub mod msg_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
+        ) -> Poll<core::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -414,8 +414,8 @@ pub mod msg_server {
             Self(Arc::clone(&self.0))
         }
     }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl<T: core::fmt::Debug> core::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos_proto.serde.rs
+++ b/cosmos-sdk-proto/src/prost/cosmos-sdk/cosmos_proto.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,11 +76,14 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InterfaceDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos_proto.InterfaceDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InterfaceDescriptor, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<InterfaceDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -118,7 +121,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ScalarDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -146,10 +149,11 @@ impl serde::Serialize for ScalarDescriptor {
                 .iter()
                 .cloned()
                 .map(|v| {
-                    ScalarType::try_from(v)
-                        .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", v)))
+                    ScalarType::try_from(v).map_err(|_| {
+                        serde::ser::Error::custom(alloc::format!("Invalid variant {}", v))
+                    })
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<alloc::vec::Vec<_>, _>>()?;
             struct_ser.serialize_field("fieldType", &v)?;
         }
         struct_ser.end()
@@ -158,7 +162,7 @@ impl serde::Serialize for ScalarDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -172,7 +176,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -183,13 +187,13 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -208,11 +212,11 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ScalarDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos_proto.ScalarDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ScalarDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ScalarDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -238,7 +242,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
                                 return Err(serde::de::Error::duplicate_field("fieldType"));
                             }
                             field_type__ = Some(
-                                map_.next_value::<Vec<ScalarType>>()?
+                                map_.next_value::<alloc::vec::Vec<ScalarType>>()?
                                     .into_iter()
                                     .map(|x| x as i32)
                                     .collect(),
@@ -259,7 +263,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ScalarType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -274,7 +278,7 @@ impl serde::Serialize for ScalarType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ScalarType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -289,11 +293,11 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ScalarType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -305,7 +309,7 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -317,7 +321,7 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.query.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.query.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for PageRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -32,11 +32,17 @@ impl serde::Serialize for PageRequest {
         }
         if self.offset != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("offset", ToString::to_string(&self.offset).as_str())?;
+            struct_ser.serialize_field(
+                "offset",
+                alloc::string::ToString::to_string(&self.offset).as_str(),
+            )?;
         }
         if self.limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("limit", ToString::to_string(&self.limit).as_str())?;
+            struct_ser.serialize_field(
+                "limit",
+                alloc::string::ToString::to_string(&self.limit).as_str(),
+            )?;
         }
         if self.count_total {
             struct_ser.serialize_field("countTotal", &self.count_total)?;
@@ -50,7 +56,7 @@ impl serde::Serialize for PageRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PageRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -73,7 +79,7 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -84,13 +90,13 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -111,11 +117,11 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PageRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.query.v1beta1.PageRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PageRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PageRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -186,7 +192,7 @@ impl<'de> serde::Deserialize<'de> for PageRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PageResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -209,7 +215,10 @@ impl serde::Serialize for PageResponse {
         }
         if self.total != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("total", ToString::to_string(&self.total).as_str())?;
+            struct_ser.serialize_field(
+                "total",
+                alloc::string::ToString::to_string(&self.total).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -217,7 +226,7 @@ impl serde::Serialize for PageResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PageResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -230,7 +239,7 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -241,13 +250,13 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -265,11 +274,11 @@ impl<'de> serde::Deserialize<'de> for PageResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PageResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.query.v1beta1.PageResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PageResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PageResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.v1beta1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmos.base.v1beta1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for Coin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -27,7 +27,7 @@ impl serde::Serialize for Coin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Coin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for Coin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -51,13 +51,13 @@ impl<'de> serde::Deserialize<'de> for Coin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -75,11 +75,11 @@ impl<'de> serde::Deserialize<'de> for Coin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Coin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.Coin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Coin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Coin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -113,7 +113,7 @@ impl<'de> serde::Deserialize<'de> for Coin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DecCoin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -138,7 +138,7 @@ impl serde::Serialize for DecCoin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DecCoin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -151,7 +151,7 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -162,13 +162,13 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -186,11 +186,11 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DecCoin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.DecCoin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DecCoin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DecCoin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -224,7 +224,7 @@ impl<'de> serde::Deserialize<'de> for DecCoin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for DecProto {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -243,7 +243,7 @@ impl serde::Serialize for DecProto {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for DecProto {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -255,7 +255,7 @@ impl<'de> serde::Deserialize<'de> for DecProto {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -266,13 +266,13 @@ impl<'de> serde::Deserialize<'de> for DecProto {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -289,11 +289,11 @@ impl<'de> serde::Deserialize<'de> for DecProto {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = DecProto;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.DecProto")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DecProto, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<DecProto, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -319,7 +319,7 @@ impl<'de> serde::Deserialize<'de> for DecProto {
 #[cfg(feature = "serde")]
 impl serde::Serialize for IntProto {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -338,7 +338,7 @@ impl serde::Serialize for IntProto {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for IntProto {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -350,7 +350,7 @@ impl<'de> serde::Deserialize<'de> for IntProto {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -361,13 +361,13 @@ impl<'de> serde::Deserialize<'de> for IntProto {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -384,11 +384,11 @@ impl<'de> serde::Deserialize<'de> for IntProto {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = IntProto;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.base.v1beta1.IntProto")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IntProto, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<IntProto, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmos_proto.serde.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmos_proto.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -28,7 +28,7 @@ impl serde::Serialize for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -41,7 +41,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -52,13 +52,13 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -76,11 +76,14 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InterfaceDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos_proto.InterfaceDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InterfaceDescriptor, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<InterfaceDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -118,7 +121,7 @@ impl<'de> serde::Deserialize<'de> for InterfaceDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ScalarDescriptor {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -146,10 +149,11 @@ impl serde::Serialize for ScalarDescriptor {
                 .iter()
                 .cloned()
                 .map(|v| {
-                    ScalarType::try_from(v)
-                        .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", v)))
+                    ScalarType::try_from(v).map_err(|_| {
+                        serde::ser::Error::custom(alloc::format!("Invalid variant {}", v))
+                    })
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<alloc::vec::Vec<_>, _>>()?;
             struct_ser.serialize_field("fieldType", &v)?;
         }
         struct_ser.end()
@@ -158,7 +162,7 @@ impl serde::Serialize for ScalarDescriptor {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -172,7 +176,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -183,13 +187,13 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -208,11 +212,11 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ScalarDescriptor;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos_proto.ScalarDescriptor")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ScalarDescriptor, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ScalarDescriptor, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -238,7 +242,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
                                 return Err(serde::de::Error::duplicate_field("fieldType"));
                             }
                             field_type__ = Some(
-                                map_.next_value::<Vec<ScalarType>>()?
+                                map_.next_value::<alloc::vec::Vec<ScalarType>>()?
                                     .into_iter()
                                     .map(|x| x as i32)
                                     .collect(),
@@ -259,7 +263,7 @@ impl<'de> serde::Deserialize<'de> for ScalarDescriptor {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ScalarType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -274,7 +278,7 @@ impl serde::Serialize for ScalarType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ScalarType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -289,11 +293,11 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ScalarType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -305,7 +309,7 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -317,7 +321,7 @@ impl<'de> serde::Deserialize<'de> for ScalarType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.serde.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.serde.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 impl serde::Serialize for AbsoluteTxPosition {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -20,12 +20,15 @@ impl serde::Serialize for AbsoluteTxPosition {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "blockHeight",
-                ToString::to_string(&self.block_height).as_str(),
+                alloc::string::ToString::to_string(&self.block_height).as_str(),
             )?;
         }
         if self.tx_index != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("txIndex", ToString::to_string(&self.tx_index).as_str())?;
+            struct_ser.serialize_field(
+                "txIndex",
+                alloc::string::ToString::to_string(&self.tx_index).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -33,7 +36,7 @@ impl serde::Serialize for AbsoluteTxPosition {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AbsoluteTxPosition {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -46,7 +49,7 @@ impl<'de> serde::Deserialize<'de> for AbsoluteTxPosition {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -57,13 +60,13 @@ impl<'de> serde::Deserialize<'de> for AbsoluteTxPosition {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -81,11 +84,11 @@ impl<'de> serde::Deserialize<'de> for AbsoluteTxPosition {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AbsoluteTxPosition;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AbsoluteTxPosition")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AbsoluteTxPosition, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AbsoluteTxPosition, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -129,7 +132,7 @@ impl<'de> serde::Deserialize<'de> for AbsoluteTxPosition {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AcceptedMessageKeysFilter {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -149,7 +152,7 @@ impl serde::Serialize for AcceptedMessageKeysFilter {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AcceptedMessageKeysFilter {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -161,7 +164,7 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessageKeysFilter {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -172,13 +175,13 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessageKeysFilter {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -195,14 +198,14 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessageKeysFilter {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AcceptedMessageKeysFilter;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AcceptedMessageKeysFilter")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AcceptedMessageKeysFilter, V::Error>
+            ) -> core::result::Result<AcceptedMessageKeysFilter, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -232,7 +235,7 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessageKeysFilter {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AcceptedMessagesFilter {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -250,7 +253,7 @@ impl serde::Serialize for AcceptedMessagesFilter {
                     .messages
                     .iter()
                     .map(pbjson::private::base64::encode)
-                    .collect::<Vec<_>>(),
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -259,7 +262,7 @@ impl serde::Serialize for AcceptedMessagesFilter {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -271,7 +274,7 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -282,13 +285,13 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -305,14 +308,14 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AcceptedMessagesFilter;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AcceptedMessagesFilter")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AcceptedMessagesFilter, V::Error>
+            ) -> core::result::Result<AcceptedMessagesFilter, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -323,12 +326,10 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
                             if messages__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("messages"));
                             }
-                            messages__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            messages__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -347,7 +348,7 @@ impl<'de> serde::Deserialize<'de> for AcceptedMessagesFilter {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccessConfig {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -362,7 +363,7 @@ impl serde::Serialize for AccessConfig {
         let mut struct_ser = serializer.serialize_struct("cosmwasm.wasm.v1.AccessConfig", len)?;
         if self.permission != 0 {
             let v = AccessType::try_from(self.permission).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.permission))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.permission))
             })?;
             struct_ser.serialize_field("permission", &v)?;
         }
@@ -375,7 +376,7 @@ impl serde::Serialize for AccessConfig {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccessConfig {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -388,7 +389,7 @@ impl<'de> serde::Deserialize<'de> for AccessConfig {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -399,13 +400,13 @@ impl<'de> serde::Deserialize<'de> for AccessConfig {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -423,11 +424,11 @@ impl<'de> serde::Deserialize<'de> for AccessConfig {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccessConfig;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AccessConfig")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccessConfig, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AccessConfig, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -461,7 +462,7 @@ impl<'de> serde::Deserialize<'de> for AccessConfig {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccessConfigUpdate {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -477,7 +478,10 @@ impl serde::Serialize for AccessConfigUpdate {
             serializer.serialize_struct("cosmwasm.wasm.v1.AccessConfigUpdate", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if let Some(v) = self.instantiate_permission.as_ref() {
             struct_ser.serialize_field("instantiatePermission", v)?;
@@ -488,7 +492,7 @@ impl serde::Serialize for AccessConfigUpdate {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccessConfigUpdate {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -506,7 +510,7 @@ impl<'de> serde::Deserialize<'de> for AccessConfigUpdate {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -517,13 +521,13 @@ impl<'de> serde::Deserialize<'de> for AccessConfigUpdate {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -543,11 +547,11 @@ impl<'de> serde::Deserialize<'de> for AccessConfigUpdate {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccessConfigUpdate;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AccessConfigUpdate")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccessConfigUpdate, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AccessConfigUpdate, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -590,7 +594,7 @@ impl<'de> serde::Deserialize<'de> for AccessConfigUpdate {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccessType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -606,7 +610,7 @@ impl serde::Serialize for AccessType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccessType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -622,11 +626,11 @@ impl<'de> serde::Deserialize<'de> for AccessType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccessType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -638,7 +642,7 @@ impl<'de> serde::Deserialize<'de> for AccessType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -650,7 +654,7 @@ impl<'de> serde::Deserialize<'de> for AccessType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -669,7 +673,7 @@ impl<'de> serde::Deserialize<'de> for AccessType {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AccessTypeParam {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -682,7 +686,7 @@ impl serde::Serialize for AccessTypeParam {
             serializer.serialize_struct("cosmwasm.wasm.v1.AccessTypeParam", len)?;
         if self.value != 0 {
             let v = AccessType::try_from(self.value).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.value))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.value))
             })?;
             struct_ser.serialize_field("value", &v)?;
         }
@@ -692,7 +696,7 @@ impl serde::Serialize for AccessTypeParam {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AccessTypeParam {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -704,7 +708,7 @@ impl<'de> serde::Deserialize<'de> for AccessTypeParam {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -715,13 +719,13 @@ impl<'de> serde::Deserialize<'de> for AccessTypeParam {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -738,11 +742,11 @@ impl<'de> serde::Deserialize<'de> for AccessTypeParam {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AccessTypeParam;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AccessTypeParam")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccessTypeParam, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<AccessTypeParam, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -772,7 +776,7 @@ impl<'de> serde::Deserialize<'de> for AccessTypeParam {
 #[cfg(feature = "serde")]
 impl serde::Serialize for AllowAllMessagesFilter {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -786,7 +790,7 @@ impl serde::Serialize for AllowAllMessagesFilter {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for AllowAllMessagesFilter {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -796,7 +800,7 @@ impl<'de> serde::Deserialize<'de> for AllowAllMessagesFilter {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -807,13 +811,13 @@ impl<'de> serde::Deserialize<'de> for AllowAllMessagesFilter {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -827,14 +831,14 @@ impl<'de> serde::Deserialize<'de> for AllowAllMessagesFilter {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = AllowAllMessagesFilter;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.AllowAllMessagesFilter")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<AllowAllMessagesFilter, V::Error>
+            ) -> core::result::Result<AllowAllMessagesFilter, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -854,7 +858,7 @@ impl<'de> serde::Deserialize<'de> for AllowAllMessagesFilter {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ClearAdminProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -886,7 +890,7 @@ impl serde::Serialize for ClearAdminProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ClearAdminProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -900,7 +904,7 @@ impl<'de> serde::Deserialize<'de> for ClearAdminProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -911,13 +915,13 @@ impl<'de> serde::Deserialize<'de> for ClearAdminProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -936,11 +940,11 @@ impl<'de> serde::Deserialize<'de> for ClearAdminProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ClearAdminProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ClearAdminProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ClearAdminProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ClearAdminProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -986,7 +990,7 @@ impl<'de> serde::Deserialize<'de> for ClearAdminProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Code {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1007,7 +1011,10 @@ impl serde::Serialize for Code {
         let mut struct_ser = serializer.serialize_struct("cosmwasm.wasm.v1.Code", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if let Some(v) = self.code_info.as_ref() {
             struct_ser.serialize_field("codeInfo", v)?;
@@ -1028,7 +1035,7 @@ impl serde::Serialize for Code {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Code {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1051,7 +1058,7 @@ impl<'de> serde::Deserialize<'de> for Code {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1062,13 +1069,13 @@ impl<'de> serde::Deserialize<'de> for Code {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1088,11 +1095,11 @@ impl<'de> serde::Deserialize<'de> for Code {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Code;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.Code")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Code, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Code, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1148,7 +1155,7 @@ impl<'de> serde::Deserialize<'de> for Code {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CodeGrant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1177,7 +1184,7 @@ impl serde::Serialize for CodeGrant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CodeGrant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1195,7 +1202,7 @@ impl<'de> serde::Deserialize<'de> for CodeGrant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1206,13 +1213,13 @@ impl<'de> serde::Deserialize<'de> for CodeGrant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1232,11 +1239,11 @@ impl<'de> serde::Deserialize<'de> for CodeGrant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CodeGrant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.CodeGrant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CodeGrant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CodeGrant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1275,7 +1282,7 @@ impl<'de> serde::Deserialize<'de> for CodeGrant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CodeInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1310,7 +1317,7 @@ impl serde::Serialize for CodeInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CodeInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1330,7 +1337,7 @@ impl<'de> serde::Deserialize<'de> for CodeInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1341,13 +1348,13 @@ impl<'de> serde::Deserialize<'de> for CodeInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1368,11 +1375,11 @@ impl<'de> serde::Deserialize<'de> for CodeInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CodeInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.CodeInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CodeInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CodeInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1417,7 +1424,7 @@ impl<'de> serde::Deserialize<'de> for CodeInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CodeInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1439,7 +1446,10 @@ impl serde::Serialize for CodeInfoResponse {
             serializer.serialize_struct("cosmwasm.wasm.v1.CodeInfoResponse", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.creator.is_empty() {
             struct_ser.serialize_field("creator", &self.creator)?;
@@ -1460,7 +1470,7 @@ impl serde::Serialize for CodeInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CodeInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1483,7 +1493,7 @@ impl<'de> serde::Deserialize<'de> for CodeInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1494,13 +1504,13 @@ impl<'de> serde::Deserialize<'de> for CodeInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1522,11 +1532,11 @@ impl<'de> serde::Deserialize<'de> for CodeInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CodeInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.CodeInfoResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CodeInfoResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CodeInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1588,7 +1598,7 @@ impl<'de> serde::Deserialize<'de> for CodeInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CombinedLimit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1605,7 +1615,7 @@ impl serde::Serialize for CombinedLimit {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "callsRemaining",
-                ToString::to_string(&self.calls_remaining).as_str(),
+                alloc::string::ToString::to_string(&self.calls_remaining).as_str(),
             )?;
         }
         if !self.amounts.is_empty() {
@@ -1617,7 +1627,7 @@ impl serde::Serialize for CombinedLimit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CombinedLimit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1630,7 +1640,7 @@ impl<'de> serde::Deserialize<'de> for CombinedLimit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1641,13 +1651,13 @@ impl<'de> serde::Deserialize<'de> for CombinedLimit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1667,11 +1677,11 @@ impl<'de> serde::Deserialize<'de> for CombinedLimit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CombinedLimit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.CombinedLimit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CombinedLimit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<CombinedLimit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1708,7 +1718,7 @@ impl<'de> serde::Deserialize<'de> for CombinedLimit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Contract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1745,7 +1755,7 @@ impl serde::Serialize for Contract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Contract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1769,7 +1779,7 @@ impl<'de> serde::Deserialize<'de> for Contract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1780,13 +1790,13 @@ impl<'de> serde::Deserialize<'de> for Contract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1810,11 +1820,11 @@ impl<'de> serde::Deserialize<'de> for Contract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Contract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.Contract")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Contract, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Contract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -1866,7 +1876,7 @@ impl<'de> serde::Deserialize<'de> for Contract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractCodeHistoryEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1888,13 +1898,16 @@ impl serde::Serialize for ContractCodeHistoryEntry {
             serializer.serialize_struct("cosmwasm.wasm.v1.ContractCodeHistoryEntry", len)?;
         if self.operation != 0 {
             let v = ContractCodeHistoryOperationType::try_from(self.operation).map_err(|_| {
-                serde::ser::Error::custom(format!("Invalid variant {}", self.operation))
+                serde::ser::Error::custom(alloc::format!("Invalid variant {}", self.operation))
             })?;
             struct_ser.serialize_field("operation", &v)?;
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if let Some(v) = self.updated.as_ref() {
             struct_ser.serialize_field("updated", v)?;
@@ -1910,7 +1923,7 @@ impl serde::Serialize for ContractCodeHistoryEntry {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractCodeHistoryEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1925,7 +1938,7 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryEntry {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1936,13 +1949,13 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryEntry {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1962,14 +1975,14 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractCodeHistoryEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ContractCodeHistoryEntry")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ContractCodeHistoryEntry, V::Error>
+            ) -> core::result::Result<ContractCodeHistoryEntry, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2030,7 +2043,7 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryEntry {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractCodeHistoryOperationType {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2046,7 +2059,7 @@ impl serde::Serialize for ContractCodeHistoryOperationType {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractCodeHistoryOperationType {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2062,11 +2075,11 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryOperationType {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractCodeHistoryOperationType;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -2078,7 +2091,7 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryOperationType {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -2090,7 +2103,7 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryOperationType {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -2117,7 +2130,7 @@ impl<'de> serde::Deserialize<'de> for ContractCodeHistoryOperationType {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractExecutionAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2137,7 +2150,7 @@ impl serde::Serialize for ContractExecutionAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractExecutionAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2149,7 +2162,7 @@ impl<'de> serde::Deserialize<'de> for ContractExecutionAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2160,13 +2173,13 @@ impl<'de> serde::Deserialize<'de> for ContractExecutionAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2183,14 +2196,14 @@ impl<'de> serde::Deserialize<'de> for ContractExecutionAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractExecutionAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ContractExecutionAuthorization")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ContractExecutionAuthorization, V::Error>
+            ) -> core::result::Result<ContractExecutionAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2220,7 +2233,7 @@ impl<'de> serde::Deserialize<'de> for ContractExecutionAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractGrant {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2251,7 +2264,7 @@ impl serde::Serialize for ContractGrant {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractGrant {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2265,7 +2278,7 @@ impl<'de> serde::Deserialize<'de> for ContractGrant {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2276,13 +2289,13 @@ impl<'de> serde::Deserialize<'de> for ContractGrant {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2301,11 +2314,11 @@ impl<'de> serde::Deserialize<'de> for ContractGrant {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractGrant;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ContractGrant")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ContractGrant, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ContractGrant, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2347,7 +2360,7 @@ impl<'de> serde::Deserialize<'de> for ContractGrant {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractInfo {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2377,7 +2390,10 @@ impl serde::Serialize for ContractInfo {
         let mut struct_ser = serializer.serialize_struct("cosmwasm.wasm.v1.ContractInfo", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.creator.is_empty() {
             struct_ser.serialize_field("creator", &self.creator)?;
@@ -2403,7 +2419,7 @@ impl serde::Serialize for ContractInfo {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractInfo {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2431,7 +2447,7 @@ impl<'de> serde::Deserialize<'de> for ContractInfo {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2442,13 +2458,13 @@ impl<'de> serde::Deserialize<'de> for ContractInfo {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2471,11 +2487,11 @@ impl<'de> serde::Deserialize<'de> for ContractInfo {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractInfo;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ContractInfo")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ContractInfo, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<ContractInfo, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2552,7 +2568,7 @@ impl<'de> serde::Deserialize<'de> for ContractInfo {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ContractMigrationAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2572,7 +2588,7 @@ impl serde::Serialize for ContractMigrationAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ContractMigrationAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2584,7 +2600,7 @@ impl<'de> serde::Deserialize<'de> for ContractMigrationAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2595,13 +2611,13 @@ impl<'de> serde::Deserialize<'de> for ContractMigrationAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2618,14 +2634,14 @@ impl<'de> serde::Deserialize<'de> for ContractMigrationAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ContractMigrationAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ContractMigrationAuthorization")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ContractMigrationAuthorization, V::Error>
+            ) -> core::result::Result<ContractMigrationAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2655,7 +2671,7 @@ impl<'de> serde::Deserialize<'de> for ContractMigrationAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for ExecuteContractProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2707,7 +2723,7 @@ impl serde::Serialize for ExecuteContractProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ExecuteContractProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2732,7 +2748,7 @@ impl<'de> serde::Deserialize<'de> for ExecuteContractProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2743,13 +2759,13 @@ impl<'de> serde::Deserialize<'de> for ExecuteContractProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2771,14 +2787,14 @@ impl<'de> serde::Deserialize<'de> for ExecuteContractProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ExecuteContractProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.ExecuteContractProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<ExecuteContractProposal, V::Error>
+            ) -> core::result::Result<ExecuteContractProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2851,7 +2867,7 @@ impl<'de> serde::Deserialize<'de> for ExecuteContractProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for GenesisState {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -2888,7 +2904,7 @@ impl serde::Serialize for GenesisState {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for GenesisState {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -2903,7 +2919,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -2914,13 +2930,13 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -2940,11 +2956,11 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = GenesisState;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.GenesisState")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GenesisState, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<GenesisState, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -2994,7 +3010,7 @@ impl<'de> serde::Deserialize<'de> for GenesisState {
 #[cfg(feature = "serde")]
 impl serde::Serialize for InstantiateContract2Proposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3046,7 +3062,10 @@ impl serde::Serialize for InstantiateContract2Proposal {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.label.is_empty() {
             struct_ser.serialize_field("label", &self.label)?;
@@ -3073,7 +3092,7 @@ impl serde::Serialize for InstantiateContract2Proposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InstantiateContract2Proposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3108,7 +3127,7 @@ impl<'de> serde::Deserialize<'de> for InstantiateContract2Proposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3119,13 +3138,13 @@ impl<'de> serde::Deserialize<'de> for InstantiateContract2Proposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3151,14 +3170,14 @@ impl<'de> serde::Deserialize<'de> for InstantiateContract2Proposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InstantiateContract2Proposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.InstantiateContract2Proposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<InstantiateContract2Proposal, V::Error>
+            ) -> core::result::Result<InstantiateContract2Proposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3269,7 +3288,7 @@ impl<'de> serde::Deserialize<'de> for InstantiateContract2Proposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for InstantiateContractProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3315,7 +3334,10 @@ impl serde::Serialize for InstantiateContractProposal {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.label.is_empty() {
             struct_ser.serialize_field("label", &self.label)?;
@@ -3334,7 +3356,7 @@ impl serde::Serialize for InstantiateContractProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InstantiateContractProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3364,7 +3386,7 @@ impl<'de> serde::Deserialize<'de> for InstantiateContractProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3375,13 +3397,13 @@ impl<'de> serde::Deserialize<'de> for InstantiateContractProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3405,14 +3427,14 @@ impl<'de> serde::Deserialize<'de> for InstantiateContractProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InstantiateContractProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.InstantiateContractProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<InstantiateContractProposal, V::Error>
+            ) -> core::result::Result<InstantiateContractProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3504,7 +3526,7 @@ impl<'de> serde::Deserialize<'de> for InstantiateContractProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MaxCallsLimit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3516,8 +3538,10 @@ impl serde::Serialize for MaxCallsLimit {
         let mut struct_ser = serializer.serialize_struct("cosmwasm.wasm.v1.MaxCallsLimit", len)?;
         if self.remaining != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser
-                .serialize_field("remaining", ToString::to_string(&self.remaining).as_str())?;
+            struct_ser.serialize_field(
+                "remaining",
+                alloc::string::ToString::to_string(&self.remaining).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -3525,7 +3549,7 @@ impl serde::Serialize for MaxCallsLimit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MaxCallsLimit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3537,7 +3561,7 @@ impl<'de> serde::Deserialize<'de> for MaxCallsLimit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3548,13 +3572,13 @@ impl<'de> serde::Deserialize<'de> for MaxCallsLimit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3571,11 +3595,11 @@ impl<'de> serde::Deserialize<'de> for MaxCallsLimit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MaxCallsLimit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MaxCallsLimit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MaxCallsLimit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MaxCallsLimit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3604,7 +3628,7 @@ impl<'de> serde::Deserialize<'de> for MaxCallsLimit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MaxFundsLimit {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3623,7 +3647,7 @@ impl serde::Serialize for MaxFundsLimit {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MaxFundsLimit {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3635,7 +3659,7 @@ impl<'de> serde::Deserialize<'de> for MaxFundsLimit {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3646,13 +3670,13 @@ impl<'de> serde::Deserialize<'de> for MaxFundsLimit {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3669,11 +3693,11 @@ impl<'de> serde::Deserialize<'de> for MaxFundsLimit {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MaxFundsLimit;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MaxFundsLimit")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MaxFundsLimit, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MaxFundsLimit, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3699,7 +3723,7 @@ impl<'de> serde::Deserialize<'de> for MaxFundsLimit {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MigrateContractProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3733,7 +3757,10 @@ impl serde::Serialize for MigrateContractProposal {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.msg.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -3746,7 +3773,7 @@ impl serde::Serialize for MigrateContractProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MigrateContractProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3769,7 +3796,7 @@ impl<'de> serde::Deserialize<'de> for MigrateContractProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3780,13 +3807,13 @@ impl<'de> serde::Deserialize<'de> for MigrateContractProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3807,14 +3834,14 @@ impl<'de> serde::Deserialize<'de> for MigrateContractProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MigrateContractProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MigrateContractProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MigrateContractProposal, V::Error>
+            ) -> core::result::Result<MigrateContractProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -3882,7 +3909,7 @@ impl<'de> serde::Deserialize<'de> for MigrateContractProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Model {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -3913,7 +3940,7 @@ impl serde::Serialize for Model {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Model {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -3926,7 +3953,7 @@ impl<'de> serde::Deserialize<'de> for Model {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -3937,13 +3964,13 @@ impl<'de> serde::Deserialize<'de> for Model {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -3961,11 +3988,11 @@ impl<'de> serde::Deserialize<'de> for Model {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Model;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.Model")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Model, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Model, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4005,7 +4032,7 @@ impl<'de> serde::Deserialize<'de> for Model {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgAddCodeUploadParamsAddresses {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4031,7 +4058,7 @@ impl serde::Serialize for MsgAddCodeUploadParamsAddresses {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddresses {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4044,7 +4071,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddresses {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4055,13 +4082,13 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddresses {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4079,14 +4106,14 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddresses {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgAddCodeUploadParamsAddresses;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgAddCodeUploadParamsAddresses")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgAddCodeUploadParamsAddresses, V::Error>
+            ) -> core::result::Result<MsgAddCodeUploadParamsAddresses, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4124,7 +4151,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddresses {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgAddCodeUploadParamsAddressesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4140,7 +4167,7 @@ impl serde::Serialize for MsgAddCodeUploadParamsAddressesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4150,7 +4177,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4161,13 +4188,13 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4181,7 +4208,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgAddCodeUploadParamsAddressesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmwasm.wasm.v1.MsgAddCodeUploadParamsAddressesResponse")
             }
@@ -4189,7 +4216,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgAddCodeUploadParamsAddressesResponse, V::Error>
+            ) -> core::result::Result<MsgAddCodeUploadParamsAddressesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4209,7 +4236,7 @@ impl<'de> serde::Deserialize<'de> for MsgAddCodeUploadParamsAddressesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgClearAdmin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4234,7 +4261,7 @@ impl serde::Serialize for MsgClearAdmin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgClearAdmin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4247,7 +4274,7 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdmin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4258,13 +4285,13 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdmin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4282,11 +4309,11 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdmin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgClearAdmin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgClearAdmin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgClearAdmin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgClearAdmin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4320,7 +4347,7 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdmin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgClearAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4334,7 +4361,7 @@ impl serde::Serialize for MsgClearAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgClearAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4344,7 +4371,7 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdminResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4355,13 +4382,13 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4375,14 +4402,14 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgClearAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgClearAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgClearAdminResponse, V::Error>
+            ) -> core::result::Result<MsgClearAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4402,7 +4429,7 @@ impl<'de> serde::Deserialize<'de> for MsgClearAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecuteContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4442,7 +4469,7 @@ impl serde::Serialize for MsgExecuteContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecuteContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4457,7 +4484,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4468,13 +4495,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4494,11 +4521,11 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecuteContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgExecuteContract")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgExecuteContract, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgExecuteContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4555,7 +4582,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgExecuteContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4577,7 +4604,7 @@ impl serde::Serialize for MsgExecuteContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgExecuteContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4589,7 +4616,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4600,13 +4627,13 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4623,14 +4650,14 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgExecuteContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgExecuteContractResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgExecuteContractResponse, V::Error>
+            ) -> core::result::Result<MsgExecuteContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4663,7 +4690,7 @@ impl<'de> serde::Deserialize<'de> for MsgExecuteContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgIbcCloseChannel {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4683,7 +4710,7 @@ impl serde::Serialize for MsgIbcCloseChannel {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgIbcCloseChannel {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4695,7 +4722,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcCloseChannel {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4706,13 +4733,13 @@ impl<'de> serde::Deserialize<'de> for MsgIbcCloseChannel {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4729,11 +4756,11 @@ impl<'de> serde::Deserialize<'de> for MsgIbcCloseChannel {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgIbcCloseChannel;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgIBCCloseChannel")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgIbcCloseChannel, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgIbcCloseChannel, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4763,7 +4790,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcCloseChannel {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgIbcSend {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4789,14 +4816,14 @@ impl serde::Serialize for MsgIbcSend {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "timeoutHeight",
-                ToString::to_string(&self.timeout_height).as_str(),
+                alloc::string::ToString::to_string(&self.timeout_height).as_str(),
             )?;
         }
         if self.timeout_timestamp != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field(
                 "timeoutTimestamp",
-                ToString::to_string(&self.timeout_timestamp).as_str(),
+                alloc::string::ToString::to_string(&self.timeout_timestamp).as_str(),
             )?;
         }
         if !self.data.is_empty() {
@@ -4810,7 +4837,7 @@ impl serde::Serialize for MsgIbcSend {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgIbcSend {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4832,7 +4859,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSend {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4843,13 +4870,13 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSend {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -4871,11 +4898,11 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSend {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgIbcSend;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgIBCSend")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgIbcSend, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgIbcSend, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -4934,7 +4961,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSend {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgIbcSendResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -4947,7 +4974,10 @@ impl serde::Serialize for MsgIbcSendResponse {
             serializer.serialize_struct("cosmwasm.wasm.v1.MsgIBCSendResponse", len)?;
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequence", ToString::to_string(&self.sequence).as_str())?;
+            struct_ser.serialize_field(
+                "sequence",
+                alloc::string::ToString::to_string(&self.sequence).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -4955,7 +4985,7 @@ impl serde::Serialize for MsgIbcSendResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgIbcSendResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -4967,7 +4997,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSendResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -4978,13 +5008,13 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSendResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5001,11 +5031,11 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSendResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgIbcSendResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgIBCSendResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgIbcSendResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgIbcSendResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5038,7 +5068,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcSendResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgIbcWriteAcknowledgementResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5052,7 +5082,7 @@ impl serde::Serialize for MsgIbcWriteAcknowledgementResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgIbcWriteAcknowledgementResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5062,7 +5092,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcWriteAcknowledgementResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5073,13 +5103,13 @@ impl<'de> serde::Deserialize<'de> for MsgIbcWriteAcknowledgementResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5093,14 +5123,14 @@ impl<'de> serde::Deserialize<'de> for MsgIbcWriteAcknowledgementResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgIbcWriteAcknowledgementResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgIBCWriteAcknowledgementResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgIbcWriteAcknowledgementResponse, V::Error>
+            ) -> core::result::Result<MsgIbcWriteAcknowledgementResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5120,7 +5150,7 @@ impl<'de> serde::Deserialize<'de> for MsgIbcWriteAcknowledgementResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgInstantiateContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5154,7 +5184,10 @@ impl serde::Serialize for MsgInstantiateContract {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.label.is_empty() {
             struct_ser.serialize_field("label", &self.label)?;
@@ -5173,7 +5206,7 @@ impl serde::Serialize for MsgInstantiateContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgInstantiateContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5192,7 +5225,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5203,13 +5236,13 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5231,14 +5264,14 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgInstantiateContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgInstantiateContract")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgInstantiateContract, V::Error>
+            ) -> core::result::Result<MsgInstantiateContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5314,7 +5347,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgInstantiateContract2 {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5354,7 +5387,10 @@ impl serde::Serialize for MsgInstantiateContract2 {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.label.is_empty() {
             struct_ser.serialize_field("label", &self.label)?;
@@ -5381,7 +5417,7 @@ impl serde::Serialize for MsgInstantiateContract2 {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2 {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5403,7 +5439,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2 {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5414,13 +5450,13 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2 {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5444,14 +5480,14 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2 {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgInstantiateContract2;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgInstantiateContract2")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgInstantiateContract2, V::Error>
+            ) -> core::result::Result<MsgInstantiateContract2, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5546,7 +5582,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2 {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgInstantiateContract2Response {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5574,7 +5610,7 @@ impl serde::Serialize for MsgInstantiateContract2Response {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2Response {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5587,7 +5623,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2Response {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5598,13 +5634,13 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2Response {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5622,14 +5658,14 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2Response {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgInstantiateContract2Response;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgInstantiateContract2Response")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgInstantiateContract2Response, V::Error>
+            ) -> core::result::Result<MsgInstantiateContract2Response, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5670,7 +5706,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContract2Response {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgInstantiateContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5698,7 +5734,7 @@ impl serde::Serialize for MsgInstantiateContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgInstantiateContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5711,7 +5747,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5722,13 +5758,13 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5746,14 +5782,14 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgInstantiateContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgInstantiateContractResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgInstantiateContractResponse, V::Error>
+            ) -> core::result::Result<MsgInstantiateContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5794,7 +5830,7 @@ impl<'de> serde::Deserialize<'de> for MsgInstantiateContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgMigrateContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5822,7 +5858,10 @@ impl serde::Serialize for MsgMigrateContract {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.msg.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -5835,7 +5874,7 @@ impl serde::Serialize for MsgMigrateContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgMigrateContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5850,7 +5889,7 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5861,13 +5900,13 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -5887,11 +5926,11 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgMigrateContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgMigrateContract")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgMigrateContract, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgMigrateContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -5951,7 +5990,7 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgMigrateContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -5973,7 +6012,7 @@ impl serde::Serialize for MsgMigrateContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgMigrateContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -5985,7 +6024,7 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -5996,13 +6035,13 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6019,14 +6058,14 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgMigrateContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgMigrateContractResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgMigrateContractResponse, V::Error>
+            ) -> core::result::Result<MsgMigrateContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6059,7 +6098,7 @@ impl<'de> serde::Deserialize<'de> for MsgMigrateContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgPinCodes {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6081,8 +6120,8 @@ impl serde::Serialize for MsgPinCodes {
                 &self
                     .code_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -6091,7 +6130,7 @@ impl serde::Serialize for MsgPinCodes {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgPinCodes {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6104,7 +6143,7 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodes {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6115,13 +6154,13 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodes {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6139,11 +6178,11 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodes {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgPinCodes;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgPinCodes")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgPinCodes, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgPinCodes, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6161,12 +6200,10 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodes {
                             if code_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("codeIds"));
                             }
-                            code_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            code_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -6182,7 +6219,7 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodes {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgPinCodesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6196,7 +6233,7 @@ impl serde::Serialize for MsgPinCodesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgPinCodesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6206,7 +6243,7 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodesResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6217,13 +6254,13 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6237,11 +6274,14 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgPinCodesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgPinCodesResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgPinCodesResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<MsgPinCodesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6261,7 +6301,7 @@ impl<'de> serde::Deserialize<'de> for MsgPinCodesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRemoveCodeUploadParamsAddresses {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6287,7 +6327,7 @@ impl serde::Serialize for MsgRemoveCodeUploadParamsAddresses {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddresses {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6300,7 +6340,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddresses {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6311,13 +6351,13 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddresses {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6335,14 +6375,14 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddresses {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRemoveCodeUploadParamsAddresses;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgRemoveCodeUploadParamsAddresses")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgRemoveCodeUploadParamsAddresses, V::Error>
+            ) -> core::result::Result<MsgRemoveCodeUploadParamsAddresses, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6380,7 +6420,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddresses {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgRemoveCodeUploadParamsAddressesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6396,7 +6436,7 @@ impl serde::Serialize for MsgRemoveCodeUploadParamsAddressesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6406,7 +6446,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6417,13 +6457,13 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6437,7 +6477,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgRemoveCodeUploadParamsAddressesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmwasm.wasm.v1.MsgRemoveCodeUploadParamsAddressesResponse")
             }
@@ -6445,7 +6485,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgRemoveCodeUploadParamsAddressesResponse, V::Error>
+            ) -> core::result::Result<MsgRemoveCodeUploadParamsAddressesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6465,7 +6505,7 @@ impl<'de> serde::Deserialize<'de> for MsgRemoveCodeUploadParamsAddressesResponse
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreAndInstantiateContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6555,7 +6595,7 @@ impl serde::Serialize for MsgStoreAndInstantiateContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6593,7 +6633,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6604,13 +6644,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6639,14 +6679,14 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreAndInstantiateContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgStoreAndInstantiateContract")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgStoreAndInstantiateContract, V::Error>
+            ) -> core::result::Result<MsgStoreAndInstantiateContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6767,7 +6807,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreAndInstantiateContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6797,7 +6837,7 @@ impl serde::Serialize for MsgStoreAndInstantiateContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6810,7 +6850,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6821,13 +6861,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -6845,7 +6885,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreAndInstantiateContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter
                     .write_str("struct cosmwasm.wasm.v1.MsgStoreAndInstantiateContractResponse")
             }
@@ -6853,7 +6893,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgStoreAndInstantiateContractResponse, V::Error>
+            ) -> core::result::Result<MsgStoreAndInstantiateContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -6894,7 +6934,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndInstantiateContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreAndMigrateContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -6944,7 +6984,7 @@ impl serde::Serialize for MsgStoreAndMigrateContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -6968,7 +7008,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -6979,13 +7019,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7008,14 +7048,14 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreAndMigrateContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgStoreAndMigrateContract")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgStoreAndMigrateContract, V::Error>
+            ) -> core::result::Result<MsgStoreAndMigrateContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7085,7 +7125,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreAndMigrateContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7104,7 +7144,10 @@ impl serde::Serialize for MsgStoreAndMigrateContractResponse {
             .serialize_struct("cosmwasm.wasm.v1.MsgStoreAndMigrateContractResponse", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.checksum.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -7124,7 +7167,7 @@ impl serde::Serialize for MsgStoreAndMigrateContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7138,7 +7181,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7149,13 +7192,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7174,14 +7217,14 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreAndMigrateContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgStoreAndMigrateContractResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgStoreAndMigrateContractResponse, V::Error>
+            ) -> core::result::Result<MsgStoreAndMigrateContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7236,7 +7279,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreAndMigrateContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreCode {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7271,7 +7314,7 @@ impl serde::Serialize for MsgStoreCode {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreCode {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7291,7 +7334,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCode {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7302,13 +7345,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCode {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7329,11 +7372,11 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCode {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreCode;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgStoreCode")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgStoreCode, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgStoreCode, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7380,7 +7423,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCode {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgStoreCodeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7396,7 +7439,10 @@ impl serde::Serialize for MsgStoreCodeResponse {
             serializer.serialize_struct("cosmwasm.wasm.v1.MsgStoreCodeResponse", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if !self.checksum.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -7411,7 +7457,7 @@ impl serde::Serialize for MsgStoreCodeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgStoreCodeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7424,7 +7470,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCodeResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7435,13 +7481,13 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCodeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7459,14 +7505,14 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCodeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgStoreCodeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgStoreCodeResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgStoreCodeResponse, V::Error>
+            ) -> core::result::Result<MsgStoreCodeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7510,7 +7556,7 @@ impl<'de> serde::Deserialize<'de> for MsgStoreCodeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSudoContract {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7544,7 +7590,7 @@ impl serde::Serialize for MsgSudoContract {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSudoContract {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7558,7 +7604,7 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContract {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7569,13 +7615,13 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContract {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7594,11 +7640,11 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContract {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSudoContract;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgSudoContract")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgSudoContract, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgSudoContract, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7647,7 +7693,7 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContract {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgSudoContractResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7669,7 +7715,7 @@ impl serde::Serialize for MsgSudoContractResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgSudoContractResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7681,7 +7727,7 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContractResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7692,13 +7738,13 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContractResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7715,14 +7761,14 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContractResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgSudoContractResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgSudoContractResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgSudoContractResponse, V::Error>
+            ) -> core::result::Result<MsgSudoContractResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7755,7 +7801,7 @@ impl<'de> serde::Deserialize<'de> for MsgSudoContractResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUnpinCodes {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7777,8 +7823,8 @@ impl serde::Serialize for MsgUnpinCodes {
                 &self
                     .code_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -7787,7 +7833,7 @@ impl serde::Serialize for MsgUnpinCodes {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7800,7 +7846,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7811,13 +7857,13 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7835,11 +7881,11 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUnpinCodes;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUnpinCodes")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUnpinCodes, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUnpinCodes, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7857,12 +7903,10 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
                             if code_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("codeIds"));
                             }
-                            code_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            code_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -7878,7 +7922,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodes {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUnpinCodesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7892,7 +7936,7 @@ impl serde::Serialize for MsgUnpinCodesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUnpinCodesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -7902,7 +7946,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodesResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -7913,13 +7957,13 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -7933,14 +7977,14 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUnpinCodesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUnpinCodesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUnpinCodesResponse, V::Error>
+            ) -> core::result::Result<MsgUnpinCodesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -7960,7 +8004,7 @@ impl<'de> serde::Deserialize<'de> for MsgUnpinCodesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateAdmin {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -7991,7 +8035,7 @@ impl serde::Serialize for MsgUpdateAdmin {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateAdmin {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8005,7 +8049,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdmin {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8016,13 +8060,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdmin {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8041,11 +8085,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdmin {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateAdmin;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateAdmin")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateAdmin, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateAdmin, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8087,7 +8131,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdmin {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateAdminResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8101,7 +8145,7 @@ impl serde::Serialize for MsgUpdateAdminResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateAdminResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8111,7 +8155,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdminResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8122,13 +8166,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdminResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8142,14 +8186,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdminResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateAdminResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateAdminResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateAdminResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateAdminResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8169,7 +8213,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateAdminResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateContractLabel {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8201,7 +8245,7 @@ impl serde::Serialize for MsgUpdateContractLabel {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabel {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8215,7 +8259,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabel {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8226,13 +8270,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabel {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8251,14 +8295,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabel {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateContractLabel;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateContractLabel")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateContractLabel, V::Error>
+            ) -> core::result::Result<MsgUpdateContractLabel, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8304,7 +8348,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabel {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateContractLabelResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8318,7 +8362,7 @@ impl serde::Serialize for MsgUpdateContractLabelResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabelResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8328,7 +8372,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabelResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8339,13 +8383,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabelResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8359,14 +8403,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabelResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateContractLabelResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateContractLabelResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateContractLabelResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateContractLabelResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8386,7 +8430,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateContractLabelResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateInstantiateConfig {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8408,7 +8452,10 @@ impl serde::Serialize for MsgUpdateInstantiateConfig {
         }
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if let Some(v) = self.new_instantiate_permission.as_ref() {
             struct_ser.serialize_field("newInstantiatePermission", v)?;
@@ -8419,7 +8466,7 @@ impl serde::Serialize for MsgUpdateInstantiateConfig {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfig {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8439,7 +8486,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfig {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8450,13 +8497,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfig {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8477,14 +8524,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfig {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateInstantiateConfig;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateInstantiateConfig")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateInstantiateConfig, V::Error>
+            ) -> core::result::Result<MsgUpdateInstantiateConfig, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8535,7 +8582,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfig {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateInstantiateConfigResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8549,7 +8596,7 @@ impl serde::Serialize for MsgUpdateInstantiateConfigResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfigResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8559,7 +8606,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfigResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8570,13 +8617,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfigResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8590,14 +8637,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfigResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateInstantiateConfigResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateInstantiateConfigResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateInstantiateConfigResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateInstantiateConfigResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8617,7 +8664,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateInstantiateConfigResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParams {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8643,7 +8690,7 @@ impl serde::Serialize for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8656,7 +8703,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8667,13 +8714,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8691,11 +8738,11 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParams;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateParams")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MsgUpdateParams, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<MsgUpdateParams, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8733,7 +8780,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParams {
 #[cfg(feature = "serde")]
 impl serde::Serialize for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8747,7 +8794,7 @@ impl serde::Serialize for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8757,7 +8804,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8768,13 +8815,13 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8788,14 +8835,14 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = MsgUpdateParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.MsgUpdateParamsResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<MsgUpdateParamsResponse, V::Error>
+            ) -> core::result::Result<MsgUpdateParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8815,7 +8862,7 @@ impl<'de> serde::Deserialize<'de> for MsgUpdateParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Params {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8833,7 +8880,7 @@ impl serde::Serialize for Params {
         }
         if self.instantiate_default_permission != 0 {
             let v = AccessType::try_from(self.instantiate_default_permission).map_err(|_| {
-                serde::ser::Error::custom(format!(
+                serde::ser::Error::custom(alloc::format!(
                     "Invalid variant {}",
                     self.instantiate_default_permission
                 ))
@@ -8846,7 +8893,7 @@ impl serde::Serialize for Params {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Params {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8864,7 +8911,7 @@ impl<'de> serde::Deserialize<'de> for Params {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -8875,13 +8922,13 @@ impl<'de> serde::Deserialize<'de> for Params {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -8903,11 +8950,11 @@ impl<'de> serde::Deserialize<'de> for Params {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Params;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.Params")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Params, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Params, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -8945,7 +8992,7 @@ impl<'de> serde::Deserialize<'de> for Params {
 #[cfg(feature = "serde")]
 impl serde::Serialize for PinCodesProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -8974,8 +9021,8 @@ impl serde::Serialize for PinCodesProposal {
                 &self
                     .code_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -8984,7 +9031,7 @@ impl serde::Serialize for PinCodesProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PinCodesProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -8998,7 +9045,7 @@ impl<'de> serde::Deserialize<'de> for PinCodesProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9009,13 +9056,13 @@ impl<'de> serde::Deserialize<'de> for PinCodesProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9034,11 +9081,11 @@ impl<'de> serde::Deserialize<'de> for PinCodesProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = PinCodesProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.PinCodesProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PinCodesProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<PinCodesProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9063,12 +9110,10 @@ impl<'de> serde::Deserialize<'de> for PinCodesProposal {
                             if code_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("codeIds"));
                             }
-                            code_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            code_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -9089,7 +9134,7 @@ impl<'de> serde::Deserialize<'de> for PinCodesProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllContractStateRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9115,7 +9160,7 @@ impl serde::Serialize for QueryAllContractStateRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllContractStateRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9128,7 +9173,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9139,13 +9184,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9163,14 +9208,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllContractStateRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryAllContractStateRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllContractStateRequest, V::Error>
+            ) -> core::result::Result<QueryAllContractStateRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9208,7 +9253,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryAllContractStateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9234,7 +9279,7 @@ impl serde::Serialize for QueryAllContractStateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryAllContractStateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9247,7 +9292,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9258,13 +9303,13 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9282,14 +9327,14 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryAllContractStateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryAllContractStateResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryAllContractStateResponse, V::Error>
+            ) -> core::result::Result<QueryAllContractStateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9327,7 +9372,7 @@ impl<'de> serde::Deserialize<'de> for QueryAllContractStateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBuildAddressRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9369,7 +9414,7 @@ impl serde::Serialize for QueryBuildAddressRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBuildAddressRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9392,7 +9437,7 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9403,13 +9448,13 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9431,14 +9476,14 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBuildAddressRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryBuildAddressRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryBuildAddressRequest, V::Error>
+            ) -> core::result::Result<QueryBuildAddressRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9495,7 +9540,7 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryBuildAddressResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9515,7 +9560,7 @@ impl serde::Serialize for QueryBuildAddressResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryBuildAddressResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9527,7 +9572,7 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9538,13 +9583,13 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9561,14 +9606,14 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryBuildAddressResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryBuildAddressResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryBuildAddressResponse, V::Error>
+            ) -> core::result::Result<QueryBuildAddressResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9598,7 +9643,7 @@ impl<'de> serde::Deserialize<'de> for QueryBuildAddressResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCodeRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9611,7 +9656,10 @@ impl serde::Serialize for QueryCodeRequest {
             serializer.serialize_struct("cosmwasm.wasm.v1.QueryCodeRequest", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -9619,7 +9667,7 @@ impl serde::Serialize for QueryCodeRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCodeRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9631,7 +9679,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodeRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9642,13 +9690,13 @@ impl<'de> serde::Deserialize<'de> for QueryCodeRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9665,11 +9713,11 @@ impl<'de> serde::Deserialize<'de> for QueryCodeRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCodeRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryCodeRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryCodeRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryCodeRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9702,7 +9750,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodeRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCodeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9730,7 +9778,7 @@ impl serde::Serialize for QueryCodeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCodeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9743,7 +9791,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodeResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9754,13 +9802,13 @@ impl<'de> serde::Deserialize<'de> for QueryCodeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9778,11 +9826,11 @@ impl<'de> serde::Deserialize<'de> for QueryCodeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCodeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryCodeResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryCodeResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryCodeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9823,7 +9871,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCodesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9843,7 +9891,7 @@ impl serde::Serialize for QueryCodesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCodesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9855,7 +9903,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9866,13 +9914,13 @@ impl<'de> serde::Deserialize<'de> for QueryCodesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9889,11 +9937,11 @@ impl<'de> serde::Deserialize<'de> for QueryCodesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCodesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryCodesRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryCodesRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryCodesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -9923,7 +9971,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryCodesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -9949,7 +9997,7 @@ impl serde::Serialize for QueryCodesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryCodesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -9962,7 +10010,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -9973,13 +10021,13 @@ impl<'de> serde::Deserialize<'de> for QueryCodesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -9997,11 +10045,11 @@ impl<'de> serde::Deserialize<'de> for QueryCodesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryCodesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryCodesResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryCodesResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryCodesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10039,7 +10087,7 @@ impl<'de> serde::Deserialize<'de> for QueryCodesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractHistoryRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10065,7 +10113,7 @@ impl serde::Serialize for QueryContractHistoryRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractHistoryRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10078,7 +10126,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10089,13 +10137,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10113,14 +10161,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractHistoryRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractHistoryRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractHistoryRequest, V::Error>
+            ) -> core::result::Result<QueryContractHistoryRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10158,7 +10206,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractHistoryResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10184,7 +10232,7 @@ impl serde::Serialize for QueryContractHistoryResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractHistoryResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10197,7 +10245,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10208,13 +10256,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10232,14 +10280,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractHistoryResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractHistoryResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractHistoryResponse, V::Error>
+            ) -> core::result::Result<QueryContractHistoryResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10277,7 +10325,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractHistoryResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractInfoRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10297,7 +10345,7 @@ impl serde::Serialize for QueryContractInfoRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractInfoRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10309,7 +10357,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10320,13 +10368,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10343,14 +10391,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractInfoRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractInfoRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractInfoRequest, V::Error>
+            ) -> core::result::Result<QueryContractInfoRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10380,7 +10428,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractInfoResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10406,7 +10454,7 @@ impl serde::Serialize for QueryContractInfoResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractInfoResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10419,7 +10467,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10430,13 +10478,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10454,14 +10502,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractInfoResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractInfoResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractInfoResponse, V::Error>
+            ) -> core::result::Result<QueryContractInfoResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10499,7 +10547,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractInfoResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractsByCodeRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10515,7 +10563,10 @@ impl serde::Serialize for QueryContractsByCodeRequest {
             serializer.serialize_struct("cosmwasm.wasm.v1.QueryContractsByCodeRequest", len)?;
         if self.code_id != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("codeId", ToString::to_string(&self.code_id).as_str())?;
+            struct_ser.serialize_field(
+                "codeId",
+                alloc::string::ToString::to_string(&self.code_id).as_str(),
+            )?;
         }
         if let Some(v) = self.pagination.as_ref() {
             struct_ser.serialize_field("pagination", v)?;
@@ -10526,7 +10577,7 @@ impl serde::Serialize for QueryContractsByCodeRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractsByCodeRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10539,7 +10590,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10550,13 +10601,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10574,14 +10625,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractsByCodeRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractsByCodeRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractsByCodeRequest, V::Error>
+            ) -> core::result::Result<QueryContractsByCodeRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10622,7 +10673,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractsByCodeResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10648,7 +10699,7 @@ impl serde::Serialize for QueryContractsByCodeResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractsByCodeResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10661,7 +10712,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10672,13 +10723,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10696,14 +10747,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractsByCodeResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractsByCodeResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractsByCodeResponse, V::Error>
+            ) -> core::result::Result<QueryContractsByCodeResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10741,7 +10792,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCodeResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractsByCreatorRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10767,7 +10818,7 @@ impl serde::Serialize for QueryContractsByCreatorRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10780,7 +10831,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10791,13 +10842,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10817,14 +10868,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractsByCreatorRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractsByCreatorRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractsByCreatorRequest, V::Error>
+            ) -> core::result::Result<QueryContractsByCreatorRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10862,7 +10913,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryContractsByCreatorResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10888,7 +10939,7 @@ impl serde::Serialize for QueryContractsByCreatorResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -10901,7 +10952,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -10912,13 +10963,13 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -10938,14 +10989,14 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryContractsByCreatorResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryContractsByCreatorResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryContractsByCreatorResponse, V::Error>
+            ) -> core::result::Result<QueryContractsByCreatorResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -10983,7 +11034,7 @@ impl<'de> serde::Deserialize<'de> for QueryContractsByCreatorResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -10996,7 +11047,7 @@ impl serde::Serialize for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11006,7 +11057,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         enum GeneratedField {}
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11017,13 +11068,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11037,11 +11088,11 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryParamsRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<QueryParamsRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11061,7 +11112,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryParamsResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11081,7 +11132,7 @@ impl serde::Serialize for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11093,7 +11144,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11104,13 +11155,13 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11127,11 +11178,14 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryParamsResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryParamsResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<QueryParamsResponse, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<QueryParamsResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11159,7 +11213,7 @@ impl<'de> serde::Deserialize<'de> for QueryParamsResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryPinnedCodesRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11179,7 +11233,7 @@ impl serde::Serialize for QueryPinnedCodesRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryPinnedCodesRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11191,7 +11245,7 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11202,13 +11256,13 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11225,14 +11279,14 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryPinnedCodesRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryPinnedCodesRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryPinnedCodesRequest, V::Error>
+            ) -> core::result::Result<QueryPinnedCodesRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11262,7 +11316,7 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryPinnedCodesResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11282,8 +11336,8 @@ impl serde::Serialize for QueryPinnedCodesResponse {
                 &self
                     .code_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         if let Some(v) = self.pagination.as_ref() {
@@ -11295,7 +11349,7 @@ impl serde::Serialize for QueryPinnedCodesResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11308,7 +11362,7 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11319,13 +11373,13 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11343,14 +11397,14 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryPinnedCodesResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryPinnedCodesResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryPinnedCodesResponse, V::Error>
+            ) -> core::result::Result<QueryPinnedCodesResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11362,12 +11416,10 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
                             if code_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("codeIds"));
                             }
-                            code_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            code_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                         GeneratedField::Pagination => {
                             if pagination__.is_some() {
@@ -11393,7 +11445,7 @@ impl<'de> serde::Deserialize<'de> for QueryPinnedCodesResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryRawContractStateRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11423,7 +11475,7 @@ impl serde::Serialize for QueryRawContractStateRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryRawContractStateRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11436,7 +11488,7 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11447,13 +11499,13 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11471,14 +11523,14 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryRawContractStateRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryRawContractStateRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryRawContractStateRequest, V::Error>
+            ) -> core::result::Result<QueryRawContractStateRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11519,7 +11571,7 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QueryRawContractStateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11541,7 +11593,7 @@ impl serde::Serialize for QueryRawContractStateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QueryRawContractStateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11553,7 +11605,7 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11564,13 +11616,13 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11587,14 +11639,14 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QueryRawContractStateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QueryRawContractStateResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QueryRawContractStateResponse, V::Error>
+            ) -> core::result::Result<QueryRawContractStateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11627,7 +11679,7 @@ impl<'de> serde::Deserialize<'de> for QueryRawContractStateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySmartContractStateRequest {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11657,7 +11709,7 @@ impl serde::Serialize for QuerySmartContractStateRequest {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySmartContractStateRequest {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11670,7 +11722,7 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateRequest {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11681,13 +11733,13 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateRequest {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11705,14 +11757,14 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateRequest {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySmartContractStateRequest;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QuerySmartContractStateRequest")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySmartContractStateRequest, V::Error>
+            ) -> core::result::Result<QuerySmartContractStateRequest, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11753,7 +11805,7 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateRequest {
 #[cfg(feature = "serde")]
 impl serde::Serialize for QuerySmartContractStateResponse {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11775,7 +11827,7 @@ impl serde::Serialize for QuerySmartContractStateResponse {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for QuerySmartContractStateResponse {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11787,7 +11839,7 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateResponse {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11798,13 +11850,13 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateResponse {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11821,14 +11873,14 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateResponse {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = QuerySmartContractStateResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.QuerySmartContractStateResponse")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<QuerySmartContractStateResponse, V::Error>
+            ) -> core::result::Result<QuerySmartContractStateResponse, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11861,7 +11913,7 @@ impl<'de> serde::Deserialize<'de> for QuerySmartContractStateResponse {
 #[cfg(feature = "serde")]
 impl serde::Serialize for Sequence {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -11883,7 +11935,10 @@ impl serde::Serialize for Sequence {
         }
         if self.value != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("value", ToString::to_string(&self.value).as_str())?;
+            struct_ser.serialize_field(
+                "value",
+                alloc::string::ToString::to_string(&self.value).as_str(),
+            )?;
         }
         struct_ser.end()
     }
@@ -11891,7 +11946,7 @@ impl serde::Serialize for Sequence {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Sequence {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -11904,7 +11959,7 @@ impl<'de> serde::Deserialize<'de> for Sequence {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -11915,13 +11970,13 @@ impl<'de> serde::Deserialize<'de> for Sequence {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -11939,11 +11994,11 @@ impl<'de> serde::Deserialize<'de> for Sequence {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = Sequence;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.Sequence")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Sequence, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<Sequence, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -11983,7 +12038,7 @@ impl<'de> serde::Deserialize<'de> for Sequence {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreAndInstantiateContractProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -12085,7 +12140,7 @@ impl serde::Serialize for StoreAndInstantiateContractProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreAndInstantiateContractProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -12128,7 +12183,7 @@ impl<'de> serde::Deserialize<'de> for StoreAndInstantiateContractProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -12139,13 +12194,13 @@ impl<'de> serde::Deserialize<'de> for StoreAndInstantiateContractProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -12176,14 +12231,14 @@ impl<'de> serde::Deserialize<'de> for StoreAndInstantiateContractProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreAndInstantiateContractProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.StoreAndInstantiateContractProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<StoreAndInstantiateContractProposal, V::Error>
+            ) -> core::result::Result<StoreAndInstantiateContractProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -12320,7 +12375,7 @@ impl<'de> serde::Deserialize<'de> for StoreAndInstantiateContractProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreCodeAuthorization {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -12340,7 +12395,7 @@ impl serde::Serialize for StoreCodeAuthorization {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreCodeAuthorization {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -12352,7 +12407,7 @@ impl<'de> serde::Deserialize<'de> for StoreCodeAuthorization {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -12363,13 +12418,13 @@ impl<'de> serde::Deserialize<'de> for StoreCodeAuthorization {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -12386,14 +12441,14 @@ impl<'de> serde::Deserialize<'de> for StoreCodeAuthorization {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreCodeAuthorization;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.StoreCodeAuthorization")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<StoreCodeAuthorization, V::Error>
+            ) -> core::result::Result<StoreCodeAuthorization, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -12423,7 +12478,7 @@ impl<'de> serde::Deserialize<'de> for StoreCodeAuthorization {
 #[cfg(feature = "serde")]
 impl serde::Serialize for StoreCodeProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -12499,7 +12554,7 @@ impl serde::Serialize for StoreCodeProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for StoreCodeProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -12534,7 +12589,7 @@ impl<'de> serde::Deserialize<'de> for StoreCodeProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -12545,13 +12600,13 @@ impl<'de> serde::Deserialize<'de> for StoreCodeProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -12578,11 +12633,11 @@ impl<'de> serde::Deserialize<'de> for StoreCodeProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = StoreCodeProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.StoreCodeProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StoreCodeProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<StoreCodeProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -12684,7 +12739,7 @@ impl<'de> serde::Deserialize<'de> for StoreCodeProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for SudoContractProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -12724,7 +12779,7 @@ impl serde::Serialize for SudoContractProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SudoContractProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -12739,7 +12794,7 @@ impl<'de> serde::Deserialize<'de> for SudoContractProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -12750,13 +12805,13 @@ impl<'de> serde::Deserialize<'de> for SudoContractProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -12776,14 +12831,14 @@ impl<'de> serde::Deserialize<'de> for SudoContractProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = SudoContractProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.SudoContractProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<SudoContractProposal, V::Error>
+            ) -> core::result::Result<SudoContractProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -12840,7 +12895,7 @@ impl<'de> serde::Deserialize<'de> for SudoContractProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for UnpinCodesProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -12869,8 +12924,8 @@ impl serde::Serialize for UnpinCodesProposal {
                 &self
                     .code_ids
                     .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>(),
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>(),
             )?;
         }
         struct_ser.end()
@@ -12879,7 +12934,7 @@ impl serde::Serialize for UnpinCodesProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -12893,7 +12948,7 @@ impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -12904,13 +12959,13 @@ impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -12929,11 +12984,11 @@ impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = UnpinCodesProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.UnpinCodesProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<UnpinCodesProposal, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> core::result::Result<UnpinCodesProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -12958,12 +13013,10 @@ impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
                             if code_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("codeIds"));
                             }
-                            code_ids__ = Some(
-                                map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
-                                    .into_iter()
-                                    .map(|x| x.0)
-                                    .collect(),
-                            );
+                            code_ids__ =
+                                Some(map_.next_value::<alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                     }
                 }
@@ -12984,7 +13037,7 @@ impl<'de> serde::Deserialize<'de> for UnpinCodesProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for UpdateAdminProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -13022,7 +13075,7 @@ impl serde::Serialize for UpdateAdminProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for UpdateAdminProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -13037,7 +13090,7 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -13048,13 +13101,13 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -13074,11 +13127,14 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = UpdateAdminProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.UpdateAdminProposal")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<UpdateAdminProposal, V::Error>
+            fn visit_map<V>(
+                self,
+                mut map_: V,
+            ) -> core::result::Result<UpdateAdminProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {
@@ -13132,7 +13188,7 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminProposal {
 #[cfg(feature = "serde")]
 impl serde::Serialize for UpdateInstantiateConfigProposal {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -13164,7 +13220,7 @@ impl serde::Serialize for UpdateInstantiateConfigProposal {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for UpdateInstantiateConfigProposal {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -13183,7 +13239,7 @@ impl<'de> serde::Deserialize<'de> for UpdateInstantiateConfigProposal {
         }
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -13194,13 +13250,13 @@ impl<'de> serde::Deserialize<'de> for UpdateInstantiateConfigProposal {
 
                     fn expecting(
                         &self,
-                        formatter: &mut std::fmt::Formatter<'_>,
-                    ) -> std::fmt::Result {
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -13221,14 +13277,14 @@ impl<'de> serde::Deserialize<'de> for UpdateInstantiateConfigProposal {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = UpdateInstantiateConfigProposal;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmwasm.wasm.v1.UpdateInstantiateConfigProposal")
             }
 
             fn visit_map<V>(
                 self,
                 mut map_: V,
-            ) -> std::result::Result<UpdateInstantiateConfigProposal, V::Error>
+            ) -> core::result::Result<UpdateInstantiateConfigProposal, V::Error>
             where
                 V: serde::de::MapAccess<'de>,
             {

--- a/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.tonic.rs
+++ b/cosmos-sdk-proto/src/prost/wasmd/cosmwasm.wasm.v1.tonic.rs
@@ -88,12 +88,12 @@ pub mod query_client {
         pub async fn contract_info(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractInfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryContractInfoResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryContractInfoResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -106,12 +106,12 @@ pub mod query_client {
         pub async fn contract_history(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractHistoryRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryContractHistoryResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryContractHistoryResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -125,12 +125,12 @@ pub mod query_client {
         pub async fn contracts_by_code(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractsByCodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryContractsByCodeResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryContractsByCodeResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -144,12 +144,14 @@ pub mod query_client {
         pub async fn all_contract_state(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryAllContractStateRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryAllContractStateResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::QueryAllContractStateResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -165,12 +167,14 @@ pub mod query_client {
         pub async fn raw_contract_state(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryRawContractStateRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryRawContractStateResponse>, tonic::Status>
-        {
+        ) -> core::result::Result<
+            tonic::Response<super::QueryRawContractStateResponse>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -186,14 +190,14 @@ pub mod query_client {
         pub async fn smart_contract_state(
             &mut self,
             request: impl tonic::IntoRequest<super::QuerySmartContractStateRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QuerySmartContractStateResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -209,11 +213,12 @@ pub mod query_client {
         pub async fn code(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCodeRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCodeResponse>, tonic::Status> {
+        ) -> core::result::Result<tonic::Response<super::QueryCodeResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -226,12 +231,12 @@ pub mod query_client {
         pub async fn codes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryCodesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryCodesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryCodesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -244,12 +249,12 @@ pub mod query_client {
         pub async fn pinned_codes(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryPinnedCodesRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryPinnedCodesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryPinnedCodesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -262,12 +267,12 @@ pub mod query_client {
         pub async fn params(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryParamsRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -280,14 +285,14 @@ pub mod query_client {
         pub async fn contracts_by_creator(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryContractsByCreatorRequest>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::QueryContractsByCreatorResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -303,12 +308,12 @@ pub mod query_client {
         pub async fn build_address(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryBuildAddressRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryBuildAddressResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::QueryBuildAddressResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -406,12 +411,12 @@ pub mod msg_client {
         pub async fn store_code(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgStoreCode>,
-        ) -> std::result::Result<tonic::Response<super::MsgStoreCodeResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgStoreCodeResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -424,14 +429,14 @@ pub mod msg_client {
         pub async fn instantiate_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgInstantiateContract>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgInstantiateContractResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -447,14 +452,14 @@ pub mod msg_client {
         pub async fn instantiate_contract2(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgInstantiateContract2>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgInstantiateContract2Response>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -470,12 +475,12 @@ pub mod msg_client {
         pub async fn execute_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgExecuteContract>,
-        ) -> std::result::Result<tonic::Response<super::MsgExecuteContractResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgExecuteContractResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -489,12 +494,12 @@ pub mod msg_client {
         pub async fn migrate_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgMigrateContract>,
-        ) -> std::result::Result<tonic::Response<super::MsgMigrateContractResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgMigrateContractResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -508,12 +513,12 @@ pub mod msg_client {
         pub async fn update_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateAdmin>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateAdminResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateAdminResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -526,12 +531,12 @@ pub mod msg_client {
         pub async fn clear_admin(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgClearAdmin>,
-        ) -> std::result::Result<tonic::Response<super::MsgClearAdminResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgClearAdminResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -544,14 +549,14 @@ pub mod msg_client {
         pub async fn update_instantiate_config(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateInstantiateConfig>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateInstantiateConfigResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -568,12 +573,12 @@ pub mod msg_client {
         pub async fn update_params(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateParams>,
-        ) -> std::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUpdateParamsResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -586,12 +591,12 @@ pub mod msg_client {
         pub async fn sudo_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgSudoContract>,
-        ) -> std::result::Result<tonic::Response<super::MsgSudoContractResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgSudoContractResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -604,12 +609,12 @@ pub mod msg_client {
         pub async fn pin_codes(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgPinCodes>,
-        ) -> std::result::Result<tonic::Response<super::MsgPinCodesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgPinCodesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -622,12 +627,12 @@ pub mod msg_client {
         pub async fn unpin_codes(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUnpinCodes>,
-        ) -> std::result::Result<tonic::Response<super::MsgUnpinCodesResponse>, tonic::Status>
+        ) -> core::result::Result<tonic::Response<super::MsgUnpinCodesResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -640,14 +645,14 @@ pub mod msg_client {
         pub async fn store_and_instantiate_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgStoreAndInstantiateContract>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgStoreAndInstantiateContractResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -664,14 +669,14 @@ pub mod msg_client {
         pub async fn remove_code_upload_params_addresses(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgRemoveCodeUploadParamsAddresses>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgRemoveCodeUploadParamsAddressesResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -688,14 +693,14 @@ pub mod msg_client {
         pub async fn add_code_upload_params_addresses(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgAddCodeUploadParamsAddresses>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgAddCodeUploadParamsAddressesResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -712,14 +717,14 @@ pub mod msg_client {
         pub async fn store_and_migrate_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgStoreAndMigrateContract>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgStoreAndMigrateContractResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
@@ -736,14 +741,14 @@ pub mod msg_client {
         pub async fn update_contract_label(
             &mut self,
             request: impl tonic::IntoRequest<super::MsgUpdateContractLabel>,
-        ) -> std::result::Result<
+        ) -> core::result::Result<
             tonic::Response<super::MsgUpdateContractLabelResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
+                    alloc::format!("Service was not ready: {}", e.into()),
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -320,7 +320,7 @@ fn copy_and_patch(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<(
         ("alloc::alloc", "alloc"),
         ("alloc::vec::alloc", "alloc"),
         // workaround to keep rustfmt from having a freak out
-        ("__ = ", "__ =")
+        ("__ = ", "__ ="),
     ];
 
     // Skip proto files belonging to `EXCLUDED_PROTO_PACKAGES`

--- a/proto-build/src/main.rs
+++ b/proto-build/src/main.rs
@@ -309,6 +309,18 @@ fn copy_and_patch(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<(
             "#[cfg(feature = \"serde\")]\n\
             impl<'de> serde::Deserialize<'de> for",
         ),
+        // no_std compatibility
+        ("std::fmt", "core::fmt"),
+        ("std::option", "core::option"),
+        ("std::result", "core::result"),
+        ("ToString::", "alloc::string::ToString::"),
+        ("Vec", "alloc::vec::Vec"),
+        ("format!", "alloc::format!"),
+        // workarounds for duplication introduced by other regexes applied above
+        ("alloc::alloc", "alloc"),
+        ("alloc::vec::alloc", "alloc"),
+        // workaround to keep rustfmt from having a freak out
+        ("__ = ", "__ =")
     ];
 
     // Skip proto files belonging to `EXCLUDED_PROTO_PACKAGES`


### PR DESCRIPTION
Adds some transforms which enable the generated PBJSON-related code to be usable in `no_std` environments.

This is a workaround until such a time as it can be implemented natively in `neoeinstein-prost-serde`. See neoeinstein/protoc-gen-prost#102.

Closes #499