### PR TITLE
cosmos-sdk-proto v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.25.0-pre.1"
+version = "0.25.0"
 dependencies = [
  "informalsystems-pbjson",
  "prost",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,15 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.25.0-pre.0 (prerelease)
+## 0.25.0 (2024-09-09)
 ### Changed
-- Re-export ICS23 proto definitions from the `ics23` crate ([#495])
 - Use tendermint proto from `tendermint_proto` instead of `tendermint_proto::v0_34` ([#495])
+
+### Fixed
+- `no_std` + `serde` support ([#500])
 
 ### Removed
 - IBC protos; use `ibc-proto` crate instead ([#495])
 
 [#495]: https://github.com/cosmos/cosmos-rust/pull/495
+[#500]: https://github.com/cosmos/cosmos-rust/pull/500
 
 ## 0.24.0 (2024-08-14)
 ### Added

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.25.0-pre.1"
+version = "0.25.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "=0.25.0-pre.1", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.25", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Use tendermint proto from `tendermint_proto` instead of `tendermint_proto::v0_34` ([#495])

### Fixed
- `no_std` + `serde` support ([#500])

### Removed
- IBC protos; use `ibc-proto` crate instead ([#495])

[#495]: https://github.com/cosmos/cosmos-rust/pull/495
[#500]: https://github.com/cosmos/cosmos-rust/pull/500