### PR TITLE
cosmrs v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.20.0-pre"
+version = "0.20.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.20.0 (2024-09-09)
+### Changed
+- Bump `cosmos-sdk-proto` to v0.25 ([#503])
+
+[#503]: https://github.com/cosmos/cosmos-rust/pull/503
+
 ## 0.19.0 (2024-08-14)
 ### Changed
 - Bump tendermint-rs dependencies to v0.39 ([#482], [#483])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.20.0-pre"
+version = "0.20.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump `cosmos-sdk-proto` to v0.25 ([#503])

[#503]: https://github.com/cosmos/cosmos-rust/pull/503