### PR TITLE
Bump `tendermint-rs` to `v0.40.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afea7809ffaaf1e5d9c3c9997cb3a834df7e94fbfab2fad2bc4577f1cde41"
+checksum = "37d513ce7f9e41c67ab2dd3d554ef65f36fbcc61745af1e1f93eafdeefa1ce37"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -1842,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8add7b85b0282e5901521f78fe441956ac1e2752452f4e1f2c0ce7e1f10d485"
+checksum = "4de4e66e78c6bfb768993e69c4fc5333dbc863f6d54ebd7a5d08d91556768087"
 dependencies = [
  "flex-error",
  "serde",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3abf34ecf33125621519e9952688e7a59a98232d51538037ba21fbe526a802"
+checksum = "c81ba1b023ec00763c3bc4f4376c67c0047f185cccf95c416c7a2f16272c4cbb"
 dependencies = [
  "bytes",
  "flex-error",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9693f42544bf3b41be3cbbfa418650c86e137fb8f5a57981659a84b677721ecf"
+checksum = "4d3ec9d6a266cb079a44272189b5a033227d058ab28659722557c1f7fed6b83c"
 dependencies = [
  "async-trait",
  "bytes",

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.72"
 
 [dependencies]
 prost = { version = "0.13", default-features = false }
-tendermint-proto = { version = "0.39.1" }
+tendermint-proto = { version = "0.40.0" }
 
 # Optional dependencies
 tonic = { version = "0.12", optional = true, default-features = false, features = ["codegen", "prost"] }

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -21,12 +21,12 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 signature = { version = "2", features = ["std"] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.39.1", features = ["secp256k1"] }
+tendermint = { version = "0.40.0", features = ["secp256k1"] }
 thiserror = "1"
 
 # optional dependencies
 bip32 = { version = "0.5", optional = true, default-features = false, features = ["alloc", "secp256k1"] }
-tendermint-rpc = { version = "0.39.1", optional = true, features = ["http-client"] }
+tendermint-rpc = { version = "0.40.0", optional = true, features = ["http-client"] }
 tokio = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Synchronize `tendermint-rs` version with ibc-proto-rs `v0.50.0` https://github.com/cosmos/ibc-proto-rs/blob/v0.50.0/CHANGELOG.md#v0500