### PR TITLE
cosmrs v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.0 (2024-10-24)
+### Changed
+- Bump tendermint-rs to v0.40 ([#506])
+- Bump `cosmos-sdk-proto` to v0.26 ([#508])
+
+[#506]: https://github.com/cosmos/cosmos-rust/pull/506
+[#508]: https://github.com/cosmos/cosmos-rust/pull/508
+
 ## 0.20.0 (2024-09-09)
 ### Changed
 - Bump `cosmos-sdk-proto` to v0.25 ([#503])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Changed
- Bump tendermint-rs to v0.40 ([#506])
- Bump `cosmos-sdk-proto` to v0.26 ([#508])

[#506]: https://github.com/cosmos/cosmos-rust/pull/506
[#508]: https://github.com/cosmos/cosmos-rust/pull/508