### PR TITLE
cosmos-sdk-proto v0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "informalsystems-pbjson",
  "prost",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.26.0 (2024-10-24)
+## 0.26.1 (2024-11-08)
+### Fixed
+- Make `serde` feature `no_std` compatible ([#513])
+
+[#513]: https://github.com/cosmos/cosmos-rust/pull/513
+
+## 0.26.0 (2024-10-24) [YANKED]
 ### Changed
 - Bump `tendermint-proto` to v0.40 ([#506])
 

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.26.0"
+version = "0.26.1"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",


### PR DESCRIPTION
### Fixed
- Make `serde` feature `no_std` compatible ([#513])

[#513]: https://github.com/cosmos/cosmos-rust/pull/513
