### PR TITLE
fix(cosmrs): `BodyBuilder` non-critical extension add

### DIFF
--- a/cosmrs/src/tx/builder.rs
+++ b/cosmrs/src/tx/builder.rs
@@ -50,7 +50,7 @@ impl BodyBuilder {
 
     /// Add a non-critical extension option.
     pub fn non_critical_extension_option(&mut self, option: impl Into<Any>) -> &mut Self {
-        self.body.extension_options.push(option.into());
+        self.body.non_critical_extension_options.push(option.into());
         self
     }
 


### PR DESCRIPTION
Fixes adding a non-critical extension to the internal non-critical extension vector instead of to the extension vector.