### PR TITLE
cosmrs v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.1 (2025-02-06)
+### Fixed
+- `BodyBuilder` non-critical extension add ([#516])
+
+[#516]: https://github.com/cosmos/cosmos-rust/pull/516
+
 ## 0.21.0 (2024-10-24)
 ### Changed
 - Bump tendermint-rs to v0.40 ([#506])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"


### PR DESCRIPTION
### Fixed
- `BodyBuilder` non-critical extension add ([#516])

[#516]: https://github.com/cosmos/cosmos-rust/pull/516