### PR TITLE
cosmos-sdk-proto v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "informalsystems-pbjson",
  "prost",

--- a/cosmos-sdk-proto/CHANGELOG.md
+++ b/cosmos-sdk-proto/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.27.0 (2025-03-27)
+### Changed
+- Bump `tonic` to v0.13; MSRV 1.75 ([#520])
+
+[#520]: https://github.com/cosmos/cosmos-rust/pull/520
+
 ## 0.26.1 (2024-11-08)
 ### Fixed
 - Make `serde` feature `no_std` compatible ([#513])

--- a/cosmos-sdk-proto/Cargo.toml
+++ b/cosmos-sdk-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-sdk-proto"
-version = "0.26.1"
+version = "0.27.0"
 authors = [
     "Justin Kilpatrick <justin@althea.net>",
     "Greg Szabo <greg@informal.systems>",

--- a/cosmos-sdk-proto/README.md
+++ b/cosmos-sdk-proto/README.md
@@ -20,7 +20,7 @@ Pull requests to expand coverage are welcome.
 
 ## Minimum Supported Rust Version
 
-This crate is supported on Rust **1.72** or newer.
+This crate is supported on Rust **1.75** or newer.
 
 [//]: # "badges"
 [crate-image]: https://img.shields.io/crates/v/cosmos-sdk-proto?logo=rust
@@ -31,7 +31,7 @@ This crate is supported on Rust **1.72** or newer.
 [build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmos-sdk-proto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 
 [//]: # "links"
 [Protobufs]: https://github.com/cosmos/cosmos-sdk/tree/master/proto/

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.26", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
+cosmos-sdk-proto = { version = "0.27", default-features = false, features = ["std"], path = "../cosmos-sdk-proto" }
 ecdsa = "0.16"
 eyre = "0.6"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }


### PR DESCRIPTION
### Changed
- Bump `tonic` to v0.13; MSRV 1.75 ([#520])

[#520]: https://github.com/cosmos/cosmos-rust/pull/520