### PR TITLE
cosmrs v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/cosmrs/CHANGELOG.md
+++ b/cosmrs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.22.0 (2025-03-27)
+### Changed
+- Use `Vec::with_capacity` for `MsgFundCommunityPool` ([#511])
+- Bump `cosmos-sdk-proto` to v0.27 ([#521])
+
+[#511]: https://github.com/cosmos/cosmos-rust/pull/511
+[#521]: https://github.com/cosmos/cosmos-rust/pull/521
+
 ## 0.21.1 (2025-02-06)
 ### Fixed
 - `BodyBuilder` non-critical extension add ([#516])

--- a/cosmrs/Cargo.toml
+++ b/cosmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmrs"
-version = "0.21.1"
+version = "0.22.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/cosmos/cosmos-rust/tree/main/cosmrs"

--- a/cosmrs/README.md
+++ b/cosmrs/README.md
@@ -30,7 +30,7 @@ and message passing.
 
 ## Minimum Supported Rust Version
 
-This crate is supported on Rust **1.72** or newer.
+This crate is supported on Rust **1.75** or newer.
 
 [//]: # "badges"
 [crate-image]: https://img.shields.io/crates/v/cosmrs?logo=rust
@@ -41,7 +41,7 @@ This crate is supported on Rust **1.72** or newer.
 [build-link]: https://github.com/cosmos/cosmos-rust/actions/workflows/cosmrs.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/cosmos/cosmos-rust/blob/master/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 
 [//]: # "links"
 [Cosmos]: https://cosmos.network/


### PR DESCRIPTION
### Changed
- Use `Vec::with_capacity` for `MsgFundCommunityPool` ([#511])
- Bump `cosmos-sdk-proto` to v0.27 ([#521])

[#511]: https://github.com/cosmos/cosmos-rust/pull/511
[#521]: https://github.com/cosmos/cosmos-rust/pull/521