### PR TITLE
feat(cosmrs): implement Hash for AccountId

### DIFF
--- a/cosmrs/src/base/account_id.rs
+++ b/cosmrs/src/base/account_id.rs
@@ -5,7 +5,7 @@ use std::{fmt, str::FromStr};
 use subtle_encoding::bech32;
 
 /// Account identifiers
-#[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct AccountId {
     /// Account ID encoded as Bech32
     bech32: String,


### PR DESCRIPTION
Implement `Hash` for `AccountId` so users of that struct don't need to use the [new type pattern](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) just to use in container types, e.g. `HashMap`